### PR TITLE
feat: 背景色を可変にする (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ PNG output is implemented and produces a 1080×1920 vertical orb image:
 ```bash
 orber --input photo.jpg --output orb.png
 orber --input photo.jpg --output orb.png --blur 0.9 --orb-size 1.5 --saturation 1.4
+orber --input white_paper.jpg --output orb.png --background auto
+orber --input photo.jpg --output orb.png --background "#1a1a1a"
+orber --input photo.jpg --output orb.svg --background transparent
 ```
 
-Static PNG, vertical-format video (`mp4` via libx264, `webm` via libvpx-vp9), static SVG, and CSS background snippets are implemented. Only `webp` is accepted by the CLI but not yet rendered — it exits with `not yet implemented`. The output format is inferred from the extension. CLI flags cover orb size, blur, motion speed, shape (circle / aquarelle bleed), saturation, and clip duration. See all flags via `orber --help`.
+Static PNG, vertical-format video (`mp4` via libx264, `webm` via libvpx-vp9), static SVG, and CSS background snippets are implemented. Only `webp` is accepted by the CLI but not yet rendered — it exits with `not yet implemented`. The output format is inferred from the extension. CLI flags cover orb size, blur, motion speed, shape (circle / aquarelle bleed), saturation, clip duration, and background color (`black` / `white` / `auto` / `transparent` / `#RRGGBB[AA]`; default `auto` picks a dimmed average color of the input image). See all flags via `orber --help`.
 
 ## Build
 

--- a/src/animate.rs
+++ b/src/animate.rs
@@ -75,6 +75,8 @@ pub struct AnimateOptions {
     pub saturation: f32,
     pub motion: MotionPreset,
     pub seed: u64,
+    /// 背景 RGBA。alpha=0 で透過。
+    pub background: [u8; 4],
 }
 
 impl Default for AnimateOptions {
@@ -87,6 +89,7 @@ impl Default for AnimateOptions {
             saturation: 1.0,
             motion: MotionPreset::Slow,
             seed: 0,
+            background: [0, 0, 0, 255],
         }
     }
 }
@@ -217,6 +220,7 @@ pub fn render_frame(clusters: &[Cluster], opts: &AnimateOptions, t: f32) -> Rgba
         orb_size: opts.orb_size,
         blur: opts.blur,
         saturation: opts.saturation,
+        background: opts.background,
     };
     render_static(&modulated, &render_opts)
 }
@@ -250,6 +254,7 @@ mod tests {
             saturation: 1.0,
             motion,
             seed: 12345,
+            background: [0, 0, 0, 255],
         }
     }
 

--- a/src/background.rs
+++ b/src/background.rs
@@ -1,0 +1,243 @@
+//! 背景色解決モジュール。
+//!
+//! `--background` フラグの値（`black` / `white` / `auto` / `transparent` /
+//! `#RRGGBB` / `#RRGGBBAA`）を [`Background`] enum に正規化し、入力画像から
+//! 最終的な RGBA 8bit を決める [`resolve`] を提供する。
+//!
+//! # 設計メモ
+//!
+//! - `auto` は入力を 64x64 にダウンサンプルした平均色を取り、HSL の彩度を
+//!   半分・明度を 0.85 倍 + 下限 0.05 / 上限 0.7 に押し込めて純白／純黒を避ける。
+//!   写真の支配色を「やや暗めの背景」に寄せるのが狙い
+//! - `transparent` は alpha=0。動画は yuv420p 制約で alpha 不可なので、呼び出し
+//!   側で `transparent + 動画モード` を弾く責務を負う（このモジュールでは
+//!   そこまで踏み込まない）
+
+use image::RgbImage;
+
+/// 背景指定。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Background {
+    Black,
+    White,
+    Auto,
+    Hex([u8; 4]),
+    Transparent,
+}
+
+impl Background {
+    /// 透過が要求されているかどうか。動画経路の事前バリデーションに使う。
+    pub fn is_transparent(self) -> bool {
+        match self {
+            Self::Transparent => true,
+            Self::Hex([_, _, _, a]) => a == 0,
+            _ => false,
+        }
+    }
+}
+
+/// `--background` 値の文字列パースエラー。
+#[derive(Debug, PartialEq, Eq)]
+pub enum BackgroundParseError {
+    InvalidHex(String),
+    Unknown(String),
+}
+
+impl std::fmt::Display for BackgroundParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidHex(s) => {
+                write!(f, "invalid hex color {s:?} (expected #RRGGBB or #RRGGBBAA)")
+            }
+            Self::Unknown(s) => write!(
+                f,
+                "unknown --background value {s:?} (expected black|white|auto|transparent|#RRGGBB)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BackgroundParseError {}
+
+impl std::str::FromStr for Background {
+    type Err = BackgroundParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let lower = s.trim().to_ascii_lowercase();
+        match lower.as_str() {
+            "black" => Ok(Self::Black),
+            "white" => Ok(Self::White),
+            "auto" => Ok(Self::Auto),
+            "transparent" | "none" => Ok(Self::Transparent),
+            _ => parse_hex(&lower).ok_or_else(|| {
+                if lower.starts_with('#') {
+                    BackgroundParseError::InvalidHex(s.to_string())
+                } else {
+                    BackgroundParseError::Unknown(s.to_string())
+                }
+            }),
+        }
+    }
+}
+
+fn parse_hex(s: &str) -> Option<Background> {
+    let hex = s.strip_prefix('#')?;
+    let pair = |i: usize| u8::from_str_radix(hex.get(i..i + 2)?, 16).ok();
+    match hex.len() {
+        6 => Some(Background::Hex([pair(0)?, pair(2)?, pair(4)?, 255])),
+        8 => Some(Background::Hex([pair(0)?, pair(2)?, pair(4)?, pair(6)?])),
+        _ => None,
+    }
+}
+
+/// `Background` を入力画像と組み合わせて最終的な RGBA 8bit に解決する。
+///
+/// `auto` のみ入力画像に依存する。それ以外の variant は入力を参照しない
+/// （引数に渡されても無視される）。
+pub fn resolve(input: &RgbImage, bg: Background) -> [u8; 4] {
+    match bg {
+        Background::Black => [0, 0, 0, 255],
+        Background::White => [255, 255, 255, 255],
+        Background::Hex(rgba) => rgba,
+        Background::Transparent => [0, 0, 0, 0],
+        Background::Auto => auto_color(input),
+    }
+}
+
+fn auto_color(input: &RgbImage) -> [u8; 4] {
+    use image::imageops::{resize, FilterType};
+    use palette::{FromColor, Hsl, IntoColor, Srgb};
+
+    // 入力が極小で 64x64 に拡大される場合でも結果は安定する（平均色は変わらない）。
+    let small = if input.width() == 0 || input.height() == 0 {
+        return [0, 0, 0, 255];
+    } else {
+        resize(input, 64, 64, FilterType::Triangle)
+    };
+
+    let mut sr: u64 = 0;
+    let mut sg: u64 = 0;
+    let mut sb: u64 = 0;
+    let mut n: u64 = 0;
+    for px in small.pixels() {
+        sr += px[0] as u64;
+        sg += px[1] as u64;
+        sb += px[2] as u64;
+        n += 1;
+    }
+    let n = n.max(1) as f32;
+    let srgb = Srgb::new(
+        sr as f32 / n / 255.0,
+        sg as f32 / n / 255.0,
+        sb as f32 / n / 255.0,
+    );
+    let mut hsl: Hsl = Hsl::from_color(srgb);
+    hsl.saturation = (hsl.saturation * 0.5).clamp(0.0, 1.0);
+    hsl.lightness = (hsl.lightness * 0.85).clamp(0.05, 0.7);
+    let out: Srgb = hsl.into_color();
+    [
+        (out.red.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (out.green.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (out.blue.clamp(0.0, 1.0) * 255.0).round() as u8,
+        255,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::RgbImage;
+    use std::str::FromStr;
+
+    #[test]
+    fn parse_named() {
+        assert_eq!(Background::from_str("black").unwrap(), Background::Black);
+        assert_eq!(Background::from_str("WHITE").unwrap(), Background::White);
+        assert_eq!(Background::from_str("auto").unwrap(), Background::Auto);
+        assert_eq!(
+            Background::from_str("transparent").unwrap(),
+            Background::Transparent
+        );
+        assert_eq!(
+            Background::from_str("none").unwrap(),
+            Background::Transparent
+        );
+    }
+
+    #[test]
+    fn parse_hex_rgb() {
+        assert_eq!(
+            Background::from_str("#1a2b3c").unwrap(),
+            Background::Hex([0x1a, 0x2b, 0x3c, 0xff])
+        );
+        assert_eq!(
+            Background::from_str("#FF00FF").unwrap(),
+            Background::Hex([0xff, 0x00, 0xff, 0xff])
+        );
+    }
+
+    #[test]
+    fn parse_hex_rgba() {
+        assert_eq!(
+            Background::from_str("#11223344").unwrap(),
+            Background::Hex([0x11, 0x22, 0x33, 0x44])
+        );
+    }
+
+    #[test]
+    fn parse_invalid_hex() {
+        assert!(matches!(
+            Background::from_str("#zzzzzz"),
+            Err(BackgroundParseError::InvalidHex(_))
+        ));
+        assert!(matches!(
+            Background::from_str("#abc"),
+            Err(BackgroundParseError::InvalidHex(_))
+        ));
+    }
+
+    #[test]
+    fn parse_unknown() {
+        assert!(matches!(
+            Background::from_str("magenta"),
+            Err(BackgroundParseError::Unknown(_))
+        ));
+    }
+
+    #[test]
+    fn resolve_named_colors() {
+        let img = RgbImage::new(2, 2);
+        assert_eq!(resolve(&img, Background::Black), [0, 0, 0, 255]);
+        assert_eq!(resolve(&img, Background::White), [255, 255, 255, 255]);
+        assert_eq!(resolve(&img, Background::Transparent), [0, 0, 0, 0]);
+        assert_eq!(
+            resolve(&img, Background::Hex([10, 20, 30, 200])),
+            [10, 20, 30, 200]
+        );
+    }
+
+    #[test]
+    fn resolve_auto_red_image_yields_reddish_dim_color() {
+        // 全ピクセル赤の画像 → auto は赤系の暗めの色になる（彩度半減・明度抑制）。
+        let mut img = RgbImage::new(8, 8);
+        for px in img.pixels_mut() {
+            *px = image::Rgb([255, 0, 0]);
+        }
+        let [r, g, b, a] = resolve(&img, Background::Auto);
+        assert_eq!(a, 255);
+        assert!(
+            r > g && r > b,
+            "auto of red should remain red-dominant: {r} {g} {b}"
+        );
+        // 純赤 (255,0,0) より暗くなっている（明度 0.7 上限）。
+        assert!(r < 255, "auto should dim pure red, got {r}");
+    }
+
+    #[test]
+    fn is_transparent_logic() {
+        assert!(Background::Transparent.is_transparent());
+        assert!(Background::Hex([0, 0, 0, 0]).is_transparent());
+        assert!(!Background::Hex([0, 0, 0, 1]).is_transparent());
+        assert!(!Background::Black.is_transparent());
+        assert!(!Background::Auto.is_transparent());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 // (color clustering, orb rendering, animation, video output, etc.).
 
 pub mod animate;
+pub mod background;
 pub mod cluster;
 pub mod orb;
 pub mod output_mode;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, ValueEnum};
 use orber::animate::MotionPreset;
+use orber::background::{resolve as resolve_background, Background};
 use orber::cluster::extract_clusters;
 use orber::orb::{render_static, RenderOptions};
 use orber::output_mode::OutputMode;
@@ -78,6 +79,12 @@ struct Cli {
     /// Animated output duration in milliseconds (1000..=600000, i.e. 1s..=10min).
     #[arg(long, default_value_t = 5000)]
     duration_ms: u64,
+
+    /// Background color: black, white, auto, transparent, or #RRGGBB(AA).
+    /// `auto` picks a dimmed average color of the input image.
+    /// `transparent` is rejected for mp4/webm (yuv420p has no alpha).
+    #[arg(long, default_value = "auto")]
+    background: String,
 }
 
 fn main() -> ExitCode {
@@ -91,13 +98,27 @@ fn main() -> ExitCode {
         }
     };
 
+    let bg: Background = match cli.background.parse() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("orber: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
     if let Some(codec) = VideoCodec::from_output_mode(mode) {
-        return render_video_path(&cli, codec);
+        if bg.is_transparent() {
+            eprintln!(
+                "orber: --background transparent is not supported for {mode:?} (yuv420p has no alpha channel)"
+            );
+            return ExitCode::from(2);
+        }
+        return render_video_path(&cli, codec, bg);
     }
 
     match mode {
-        OutputMode::Png => render_png(&cli),
-        OutputMode::Svg | OutputMode::Css => render_style_path(&cli, mode),
+        OutputMode::Png => render_png(&cli, bg),
+        OutputMode::Svg | OutputMode::Css => render_style_path(&cli, mode, bg),
         _ => {
             eprintln!("orber: output mode {mode:?} is not yet implemented");
             ExitCode::from(1)
@@ -105,7 +126,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn render_style_path(cli: &Cli, mode: OutputMode) -> ExitCode {
+fn render_style_path(cli: &Cli, mode: OutputMode, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -129,6 +150,7 @@ fn render_style_path(cli: &Cli, mode: OutputMode) -> ExitCode {
         orb_size: cli.orb_size,
         blur: cli.blur,
         saturation: cli.saturation,
+        background: resolve_background(&img, bg),
     };
 
     // 4. mode で書き出しを分岐。
@@ -149,7 +171,7 @@ fn render_style_path(cli: &Cli, mode: OutputMode) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn render_video_path(cli: &Cli, codec: VideoCodec) -> ExitCode {
+fn render_video_path(cli: &Cli, codec: VideoCodec, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -175,6 +197,7 @@ fn render_video_path(cli: &Cli, codec: VideoCodec) -> ExitCode {
         saturation: cli.saturation,
         motion: cli.motion.into(),
         seed: cli.seed.unwrap_or(0),
+        background: resolve_background(&img, bg),
     };
 
     // 4. 動画書き出し。進捗とフレーム数の検証は render_video が担当する。
@@ -186,7 +209,7 @@ fn render_video_path(cli: &Cli, codec: VideoCodec) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn render_png(cli: &Cli) -> ExitCode {
+fn render_png(cli: &Cli, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -211,6 +234,7 @@ fn render_png(cli: &Cli) -> ExitCode {
         orb_size: cli.orb_size,
         blur: cli.blur,
         saturation: cli.saturation,
+        background: resolve_background(&img, bg),
         ..RenderOptions::default()
     };
 

--- a/src/orb.rs
+++ b/src/orb.rs
@@ -36,6 +36,8 @@ pub struct RenderOptions {
     pub blur: f32,
     /// 彩度倍率（1.0 = unchanged）
     pub saturation: f32,
+    /// 背景 RGBA。alpha=0 で透過。デフォルトは黒不透明。
+    pub background: [u8; 4],
 }
 
 impl Default for RenderOptions {
@@ -46,6 +48,7 @@ impl Default for RenderOptions {
             orb_size: 1.0,
             blur: 0.5,
             saturation: 1.0,
+            background: [0, 0, 0, 255],
         }
     }
 }
@@ -64,10 +67,15 @@ pub fn render_static(clusters: &[Cluster], opts: &RenderOptions) -> RgbaImage {
     let orb_size = opts.orb_size.max(0.0);
 
     // Pixmap::new は uninit を 0 埋めしてくれる（つまり全画面が透明）。
-    // 初期化を「黒 不透明」にしたいので明示的に塗る。
+    // 透過 (alpha=0) 指定なら fill をスキップしてその透明初期値を活かす。
+    // 不透明な背景指定なら明示的に塗る。tiny-skia は premultiplied alpha だが、
+    // Color::from_rgba8 は straight 色を内部で premul に直して塗る。
     let mut pixmap =
         Pixmap::new(width, height).expect("pixmap allocation should succeed for >0 dimensions");
-    pixmap.fill(Color::from_rgba8(0, 0, 0, 255));
+    let [br, bg, bb, ba] = opts.background;
+    if ba > 0 {
+        pixmap.fill(Color::from_rgba8(br, bg, bb, ba));
+    }
 
     let base_radius_unit = (width.min(height) as f32) * 0.25 * orb_size;
 
@@ -211,6 +219,7 @@ mod tests {
             blur: 0.5,
             saturation: 1.0,
             orb_size: 1.0,
+            ..Default::default()
         };
         let img = render_static(&[cluster([255, 0, 0], 0.5, 0.5, 1.0)], &opts);
         let center = img.get_pixel(50, 50);
@@ -288,6 +297,7 @@ mod tests {
             blur: 0.5,
             saturation: 0.0,
             orb_size: 1.0,
+            ..Default::default()
         };
         let img = render_static(&[cluster([220, 30, 40], 0.5, 0.5, 1.0)], &opts);
         let center = img.get_pixel(50, 50);
@@ -316,6 +326,7 @@ mod tests {
             saturation: 1.0,
             orb_size: 1.0,
             blur: 0.0,
+            ..Default::default()
         };
         let opts_sharp = RenderOptions {
             blur: 0.0,

--- a/src/style.rs
+++ b/src/style.rs
@@ -32,6 +32,8 @@ pub struct StyleOptions {
     pub blur: f32,
     /// 彩度倍率（1.0 = unchanged）
     pub saturation: f32,
+    /// 背景 RGBA。alpha=0 で透過 SVG / `background-color: transparent`。
+    pub background: [u8; 4],
 }
 
 impl Default for StyleOptions {
@@ -40,6 +42,7 @@ impl Default for StyleOptions {
             orb_size: 1.0,
             blur: 0.5,
             saturation: 1.0,
+            background: [0, 0, 0, 255],
         }
     }
 }
@@ -66,7 +69,19 @@ pub fn render_svg(clusters: &[Cluster], opts: &StyleOptions) -> String {
     s.push_str(&format!(
         "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 {STYLE_WIDTH} {STYLE_HEIGHT}\" width=\"{STYLE_WIDTH}\" height=\"{STYLE_HEIGHT}\">\n"
     ));
-    s.push_str("  <rect width=\"100%\" height=\"100%\" fill=\"black\"/>\n");
+    let [bg_r, bg_g, bg_b, bg_a] = opts.background;
+    if bg_a > 0 {
+        if bg_a == 255 {
+            s.push_str(&format!(
+                "  <rect width=\"100%\" height=\"100%\" fill=\"rgb({bg_r},{bg_g},{bg_b})\"/>\n"
+            ));
+        } else {
+            let opacity = bg_a as f32 / 255.0;
+            s.push_str(&format!(
+                "  <rect width=\"100%\" height=\"100%\" fill=\"rgb({bg_r},{bg_g},{bg_b})\" fill-opacity=\"{opacity:.3}\"/>\n"
+            ));
+        }
+    }
 
     // 描画対象 cluster だけ事前に絞り込んでから defs と circle の両方に使う。
     // weight=0 の cluster で空の gradient ID が defs に残らないようにする。
@@ -131,17 +146,28 @@ pub fn render_css(clusters: &[Cluster], opts: &StyleOptions) -> String {
     // blur=1 → mid=end の 20% （中心が点に近く、緩やかに減衰）
     let mid_factor = (1.0 - blur * 0.8).clamp(0.05, 0.95);
 
+    let [bg_r, bg_g, bg_b, bg_a] = opts.background;
+    let bg_css = if bg_a == 0 {
+        "transparent".to_string()
+    } else if bg_a == 255 {
+        format!("rgb({bg_r}, {bg_g}, {bg_b})")
+    } else {
+        let opacity = bg_a as f32 / 255.0;
+        format!("rgba({bg_r}, {bg_g}, {bg_b}, {opacity:.3})")
+    };
+
     let mut s = String::new();
     s.push_str("/* orber-generated background.\n");
     s.push_str("   Apply to <body> or any block element:\n");
     s.push_str("       body {\n");
     s.push_str("           margin: 0;\n");
     s.push_str("           min-height: 100vh;\n");
-    s.push_str("           background-color: black;\n");
+    s.push_str("           background-color: var(--orber-bg-color);\n");
     s.push_str("           background-image: var(--orber-bg);\n");
     s.push_str("       }\n");
-    s.push_str("   Generated as a CSS variable; reference with var(--orber-bg). */\n");
+    s.push_str("   Generated as CSS variables; reference with var(--orber-bg) and var(--orber-bg-color). */\n");
     s.push_str(":root {\n");
+    s.push_str(&format!("    --orber-bg-color: {bg_css};\n"));
 
     // 有効な gradient だけ集めてから書き出す（最後のカンマを抑制するため）。
     let mut gradients: Vec<String> = Vec::new();
@@ -219,7 +245,7 @@ mod tests {
         assert_eq!(svg.matches("<radialGradient").count(), 6);
         assert_eq!(svg.matches("<circle ").count(), 6);
         assert!(svg.contains("viewBox=\"0 0 1080 1920\""));
-        assert!(svg.contains("<rect width=\"100%\" height=\"100%\" fill=\"black\""));
+        assert!(svg.contains("<rect width=\"100%\" height=\"100%\" fill=\"rgb(0,0,0)\""));
         assert!(svg.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"));
         assert!(svg.ends_with("</svg>\n"));
     }
@@ -360,6 +386,7 @@ mod tests {
                     orb_size,
                     blur,
                     saturation: 1.0,
+                    ..Default::default()
                 };
                 let css = render_css(&extreme_clusters, &opts);
                 let stops = extract_css_stops(&css);

--- a/src/video.rs
+++ b/src/video.rs
@@ -78,6 +78,8 @@ pub struct VideoOptions {
     pub saturation: f32,
     pub motion: MotionPreset,
     pub seed: u64,
+    /// 背景 RGBA。動画は yuv420p 制約で alpha 不可なので呼び出し側で透過を弾くこと。
+    pub background: [u8; 4],
 }
 
 impl Default for VideoOptions {
@@ -89,6 +91,7 @@ impl Default for VideoOptions {
             saturation: a.saturation,
             motion: a.motion,
             seed: a.seed,
+            background: a.background,
         }
     }
 }
@@ -190,6 +193,7 @@ pub fn render_video(
         saturation: opts.saturation,
         motion: opts.motion,
         seed: opts.seed,
+        background: opts.background,
     };
 
     let temp_dir = tempfile::TempDir::new()?;


### PR DESCRIPTION
## Summary
- `--background black|white|auto|transparent|#RRGGBB(AA)` を新設。既定は `auto`（入力の平均色を彩度半減・明度 0.85倍にして純白/純黒を避ける）
- PNG / SVG / CSS で透過対応（動画は yuv420p 制約で `transparent` をエラー）
- `src/background.rs` に \`Background\` enum と \`resolve(input, bg)\`。各 \`*Options\` に \`background: [u8;4]\` を追加して renderer の塗り潰し色を差し替え

## Test plan
- [x] cargo test (56 unit + 2 cli + 1 doc)
- [x] CLI 実走: \`--background auto / black / transparent\` で PNG 出力差を確認
- [x] \`--background transparent\` + \`.mp4\` で exit=2 エラー

Closes #21