### PR TITLE
feat: aquarelle セル画夜景の質感セット (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ PNG output is implemented and produces a 1080×1920 vertical orb image:
 ```bash
 orber --input photo.jpg --output orb.png
 orber --input photo.jpg --output orb.png --blur 0.9 --orb-size 1.5 --saturation 1.4
+orber --input white_paper.jpg --output orb.png --background auto
+orber --input photo.jpg --output orb.png --background "#1a1a1a"
+orber --input photo.jpg --output orb.svg --background transparent
 ```
 
-Static PNG, vertical-format video (`mp4` via libx264, `webm` via libvpx-vp9), static SVG, and CSS background snippets are implemented. Only `webp` is accepted by the CLI but not yet rendered — it exits with `not yet implemented`. The output format is inferred from the extension. CLI flags cover orb size, blur, motion speed, shape (circle / aquarelle bleed), saturation, and clip duration. See all flags via `orber --help`.
+Static PNG, vertical-format video (`mp4` via libx264, `webm` via libvpx-vp9), static SVG, and CSS background snippets are implemented. Only `webp` is accepted by the CLI but not yet rendered — it exits with `not yet implemented`. The output format is inferred from the extension. CLI flags cover orb size, blur, motion speed, shape (circle / aquarelle bleed), saturation, clip duration, and background color (`black` / `white` / `auto` / `transparent` / `#RRGGBB[AA]`; default `auto` picks a dimmed average color of the input image). See all flags via `orber --help`.
 
 ## Build
 

--- a/src/animate.rs
+++ b/src/animate.rs
@@ -23,7 +23,7 @@
 //!   と完全同一の結果を返す。
 
 use crate::cluster::{Centroid, Cluster};
-use crate::orb::{render_static, RenderOptions};
+use crate::orb::{render_static, OrbShape, RenderOptions};
 use image::RgbaImage;
 use palette::{FromColor, Hsl, IntoColor, Srgb};
 use rand::{Rng, SeedableRng};
@@ -110,6 +110,8 @@ pub struct AnimateOptions {
     pub seed: u64,
     /// 背景 RGBA。alpha=0 で透過。
     pub background: [u8; 4],
+    /// orb の描画形式。
+    pub shape: OrbShape,
 }
 
 impl Default for AnimateOptions {
@@ -124,6 +126,7 @@ impl Default for AnimateOptions {
             motion_speed: MotionSpeed::Slow,
             seed: 0,
             background: [0, 0, 0, 255],
+            shape: OrbShape::Circle,
         }
     }
 }
@@ -304,6 +307,7 @@ pub fn render_frame(clusters: &[Cluster], opts: &AnimateOptions, t: f32) -> Rgba
         blur: opts.blur,
         saturation: opts.saturation,
         background: opts.background,
+        shape: opts.shape,
     };
     render_static(&modulated, &render_opts)
 }
@@ -340,6 +344,7 @@ mod tests {
             motion_speed: speed,
             seed: 12345,
             background: [0, 0, 0, 255],
+            shape: OrbShape::Circle,
         }
     }
 
@@ -354,6 +359,7 @@ mod tests {
             motion_speed: speed,
             seed: 12345,
             background: [0, 0, 0, 255],
+            shape: OrbShape::Circle,
         }
     }
 

--- a/src/animate.rs
+++ b/src/animate.rs
@@ -75,6 +75,8 @@ pub struct AnimateOptions {
     pub saturation: f32,
     pub motion: MotionPreset,
     pub seed: u64,
+    /// 背景 RGBA。alpha=0 で透過。
+    pub background: [u8; 4],
 }
 
 impl Default for AnimateOptions {
@@ -87,6 +89,7 @@ impl Default for AnimateOptions {
             saturation: 1.0,
             motion: MotionPreset::Slow,
             seed: 0,
+            background: [0, 0, 0, 255],
         }
     }
 }
@@ -217,6 +220,7 @@ pub fn render_frame(clusters: &[Cluster], opts: &AnimateOptions, t: f32) -> Rgba
         orb_size: opts.orb_size,
         blur: opts.blur,
         saturation: opts.saturation,
+        background: opts.background,
     };
     render_static(&modulated, &render_opts)
 }
@@ -250,6 +254,7 @@ mod tests {
             saturation: 1.0,
             motion,
             seed: 12345,
+            background: [0, 0, 0, 255],
         }
     }
 

--- a/src/animate.rs
+++ b/src/animate.rs
@@ -30,42 +30,74 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::f32::consts::TAU;
 
-/// アニメーションの動きの強さ。
+/// 軌道形（位置・サイズの動きパターン）。速度（[`MotionSpeed`]）と直交する次元。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MotionPreset {
+pub enum MotionShape {
     /// 動かない（render_static と同じ結果）
     Still,
-    /// ゆったり（既定）
+    /// リサジュー曲線（互いに干渉する 2D 軌道、既定）
+    Lissajous,
+    /// 縦方向のみ往復
+    Vertical,
+    /// 横方向のみ往復
+    Horizontal,
+    /// 斜め往復（dx と dy が同位相）
+    Diagonal,
+    /// 中心固定で半径が膨張収縮（呼吸）
+    Breathe,
+    /// 中心固定で大きさと明度が微小に瞬く（瞬き）
+    Twinkle,
+}
+
+/// 動きの速度・振幅レベル。形（[`MotionShape`]）と直交する次元。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MotionSpeed {
+    /// 夜景向け微動（位置振幅 ~2%、freq_scale=1）
+    Subtle,
+    /// 既定（位置振幅 ~6%、freq_scale=1）
     Slow,
-    /// 活発
+    /// 活発（位置振幅 ~12%、freq_scale=2）
+    Lively,
+}
+
+impl MotionSpeed {
+    /// (位置振幅, 色振幅, 周波数倍率) を返す。
+    ///
+    /// - 位置振幅は短辺 `min(width, height)` に対する比（0.06 → 6%）。
+    /// - 色振幅は HSL の S/L にかかる加算的な揺らぎ係数。
+    /// - 周波数倍率は「t=1 で何周回るか」を制御する**整数限定**。`(a, b)` リサジュー比
+    ///   や shape 内部の整数 frequency と掛け合わせても整数のままなのでループ性は保たれる。
+    pub(crate) fn coefficients(self) -> (f32, f32, u32) {
+        match self {
+            MotionSpeed::Subtle => (0.02, 0.03, 1),
+            MotionSpeed::Slow => (0.06, 0.05, 1),
+            MotionSpeed::Lively => (0.12, 0.10, 2),
+        }
+    }
+}
+
+/// 後方互換の動きプリセット。CLI の `--motion <still|slow|lively>` 経由でのみ使う。
+///
+/// 内部処理は [`MotionShape`] と [`MotionSpeed`] の組に展開される。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MotionPreset {
+    Still,
+    Slow,
     Lively,
 }
 
 impl MotionPreset {
-    /// motion preset から (位置振幅, 色振幅, 周波数倍率) を取り出す。
-    ///
-    /// - 位置振幅は短辺 `min(width, height)` に対する比（0.06 → 6%）。
-    /// - 色振幅は HSL の S/L にかかる加算的な揺らぎ係数。
-    /// - 周波数倍率は「t=1 で何周回るか」を制御する**整数限定**。リサジュー比
-    ///   (a, b) と掛け合わせても整数のままなのでループ性は保たれる。ここを
-    ///   非整数にすると `(a * t * scale).fract()` が t=1 で 0 にならず、
-    ///   t=0/t=1 のフレーム完全一致が崩れる。
-    // Still は amplitude=0 なので freq_scale の値は何でも結果が同じだが、
-    // 「動いていない」を表現するために 0 で揃える。
-    #[cfg_attr(test, allow(dead_code))]
-    pub(crate) fn coefficients(self) -> (f32, f32, u32) {
+    /// 旧 preset を新しい (shape, speed) の組に展開する。
+    pub fn split(self) -> (MotionShape, MotionSpeed) {
         match self {
-            MotionPreset::Still => (0.0, 0.0, 0),
-            MotionPreset::Slow => (0.06, 0.05, 1),
-            MotionPreset::Lively => (0.12, 0.10, 2),
+            MotionPreset::Still => (MotionShape::Still, MotionSpeed::Slow),
+            MotionPreset::Slow => (MotionShape::Lissajous, MotionSpeed::Slow),
+            MotionPreset::Lively => (MotionShape::Lissajous, MotionSpeed::Lively),
         }
     }
 }
 
 /// アニメーション 1 フレーム描画のオプション。
-///
-/// CLI 側の `Motion` enum との橋渡しは #5 (動画出力結線) で行う。
-/// それまで MotionPreset は内部 enum として独立。
 #[derive(Debug, Clone)]
 pub struct AnimateOptions {
     pub width: u32,
@@ -73,7 +105,8 @@ pub struct AnimateOptions {
     pub orb_size: f32,
     pub blur: f32,
     pub saturation: f32,
-    pub motion: MotionPreset,
+    pub motion_shape: MotionShape,
+    pub motion_speed: MotionSpeed,
     pub seed: u64,
     /// 背景 RGBA。alpha=0 で透過。
     pub background: [u8; 4],
@@ -87,7 +120,8 @@ impl Default for AnimateOptions {
             orb_size: 1.0,
             blur: 0.5,
             saturation: 1.0,
-            motion: MotionPreset::Slow,
+            motion_shape: MotionShape::Lissajous,
+            motion_speed: MotionSpeed::Slow,
             seed: 0,
             background: [0, 0, 0, 255],
         }
@@ -175,14 +209,19 @@ fn modulate_color(rgb: [u8; 3], s_factor: f32, l_factor: f32) -> [u8; 3] {
 // TODO: weight ベースの振幅補正（小さい orb は小さく動く）は将来 Issue で検討。
 // 現状は全 orb 同振幅で軌道を描く。
 pub fn render_frame(clusters: &[Cluster], opts: &AnimateOptions, t: f32) -> RgbaImage {
-    let (amp_pos, amp_color, freq_scale) = opts.motion.coefficients();
+    // Still は速度に依存しないので、speed の係数を読まずに 0 を直接使う。
+    // それ以外の shape は speed から振幅と freq_scale を取り出す。
+    let (amp_pos, amp_color, freq_scale) = if opts.motion_shape == MotionShape::Still {
+        (0.0, 0.0, 0)
+    } else {
+        opts.motion_speed.coefficients()
+    };
     let params = generate_orbit_params(opts.seed, clusters.len());
 
     // amp_pos は短辺 (min(w, h)) 基準の振幅比。normalized 座標 [0, 1] に直接
     // 加算すると、render_static 側で x は width 倍・y は height 倍されて
     // 縦横比に歪んだ楕円になってしまう。axis-scale 補正で normalized 座標系
-    // における円軌道を保つ（実際のピクセル変位は dx_pixel = amp_pos*min_side*sin、
-    // dy_pixel も同じ）。
+    // における円軌道を保つ。
     let min_side = opts.width.min(opts.height) as f32;
     let scale_x = min_side / opts.width as f32; // <= 1.0
     let scale_y = min_side / opts.height as f32; // <= 1.0
@@ -191,25 +230,69 @@ pub fn render_frame(clusters: &[Cluster], opts: &AnimateOptions, t: f32) -> Rgba
         .iter()
         .zip(params.iter())
         .map(|(c, p)| {
-            // 位置: リサジュー軌道（短辺基準で円軌道を維持）
-            let dx = amp_pos * scale_x * sin_loop(p.a, t, freq_scale, p.phi_x);
-            let dy = amp_pos * scale_y * sin_loop(p.b, t, freq_scale, p.phi_y);
-            // 範囲外に出た場合は単純に clamp する。reflect / wrap のほうが見た目は滑らかだが、
-            // prototype 段階では clamp で十分（軌道半径は数% 程度なので長時間停滞は起きにくい）。
+            // shape ごとに位置オフセットと weight 倍率を決める。
+            // weight 倍率は radius = base * sqrt(weight) を介して半径を
+            // (sqrt(weight_scale)) 倍する。Breathe / Twinkle で半径を直接揺らす。
+            let (dx, dy, radius_factor) = match opts.motion_shape {
+                MotionShape::Still => (0.0, 0.0, 1.0),
+                MotionShape::Lissajous => (
+                    amp_pos * scale_x * sin_loop(p.a, t, freq_scale, p.phi_x),
+                    amp_pos * scale_y * sin_loop(p.b, t, freq_scale, p.phi_y),
+                    1.0,
+                ),
+                MotionShape::Vertical => (
+                    0.0,
+                    amp_pos * scale_y * sin_loop(1, t, freq_scale, p.phi_y),
+                    1.0,
+                ),
+                MotionShape::Horizontal => (
+                    amp_pos * scale_x * sin_loop(1, t, freq_scale, p.phi_x),
+                    0.0,
+                    1.0,
+                ),
+                MotionShape::Diagonal => {
+                    let v = sin_loop(1, t, freq_scale, p.phi_x);
+                    (amp_pos * scale_x * v, amp_pos * scale_y * v, 1.0)
+                }
+                MotionShape::Breathe => {
+                    // 半径を ±(2 * amp_pos) の範囲で呼吸させる（位置基準の amp_pos を流用）。
+                    // amp_pos=0.06 なら半径は 0.88..1.12 倍で揺らぐ。
+                    let phase = sin_loop(1, t, freq_scale, p.phi_color);
+                    let r = (1.0 + 2.0 * amp_pos * phase).max(0.0);
+                    (0.0, 0.0, r)
+                }
+                MotionShape::Twinkle => {
+                    // 半径と明度を sin で同期して揺らす。amp_pos=0.06 なら半径は 0.7..1.3 倍。
+                    // 「瞬き」感を出すため Breathe より振幅を大きめに、freq_scale も 2 倍する。
+                    let phase = sin_loop(2, t, freq_scale, p.phi_color);
+                    let r = (1.0 + 5.0 * amp_pos * phase).max(0.0);
+                    (0.0, 0.0, r)
+                }
+            };
+
+            // 範囲外に出た場合は clamp。軌道半径は数% 程度なので長時間停滞は起きにくい。
             let new_x = (c.centroid.x + dx).clamp(0.0, 1.0);
             let new_y = (c.centroid.y + dy).clamp(0.0, 1.0);
 
             // 色揺らぎ: HSL の S と L を 1 ± amp_color の範囲で振る。
-            // L は派手すぎないよう半振幅に。
+            // Twinkle は明度の振れ幅を倍にして「瞬き」感を強める。
             let color_phase = sin_loop(1, t, freq_scale, p.phi_color);
+            let l_amp = match opts.motion_shape {
+                MotionShape::Twinkle => amp_color,
+                _ => amp_color * 0.5,
+            };
             let s_factor = 1.0 + amp_color * color_phase;
-            let l_factor = 1.0 + (amp_color * 0.5) * color_phase;
+            let l_factor = 1.0 + l_amp * color_phase;
             let new_color = modulate_color(c.color, s_factor, l_factor);
+
+            // radius = base * sqrt(weight) なので、半径を radius_factor 倍するには
+            // weight を radius_factor^2 倍すれば良い。
+            let weight_scale = radius_factor * radius_factor;
 
             Cluster {
                 color: new_color,
                 centroid: Centroid { x: new_x, y: new_y },
-                weight: c.weight,
+                weight: (c.weight * weight_scale).max(0.0),
             }
         })
         .collect();
@@ -246,13 +329,29 @@ mod tests {
     }
 
     fn small_opts(motion: MotionPreset) -> AnimateOptions {
+        let (shape, speed) = motion.split();
         AnimateOptions {
             width: 64,
             height: 64,
             orb_size: 1.0,
             blur: 0.5,
             saturation: 1.0,
-            motion,
+            motion_shape: shape,
+            motion_speed: speed,
+            seed: 12345,
+            background: [0, 0, 0, 255],
+        }
+    }
+
+    fn opts_with(shape: MotionShape, speed: MotionSpeed) -> AnimateOptions {
+        AnimateOptions {
+            width: 64,
+            height: 64,
+            orb_size: 1.0,
+            blur: 0.5,
+            saturation: 1.0,
+            motion_shape: shape,
+            motion_speed: speed,
             seed: 12345,
             background: [0, 0, 0, 255],
         }
@@ -384,21 +483,101 @@ mod tests {
 
     #[test]
     fn freq_scale_combinations_have_integer_period() {
-        // すべての (a, b) × freq_scale で t=1 のとき位相が完全に閉じることを
-        // 数値レベルで検証。整数 a/b と整数 scale の積は常に整数なので
-        // fract() は 0.0 になるはず。
+        // すべての (a, b) × speed で t=1 のとき位相が完全に閉じる。
         for &(a, b) in FREQ_RATIOS {
-            for preset in [
-                MotionPreset::Still,
-                MotionPreset::Slow,
-                MotionPreset::Lively,
-            ] {
-                let (_, _, scale) = preset.coefficients();
+            for speed in [MotionSpeed::Subtle, MotionSpeed::Slow, MotionSpeed::Lively] {
+                let (_, _, scale) = speed.coefficients();
                 let prod_a = (a as f32 * 1.0 * scale as f32).fract();
                 let prod_b = (b as f32 * 1.0 * scale as f32).fract();
                 assert_eq!(prod_a, 0.0, "a={a} scale={scale}");
                 assert_eq!(prod_b, 0.0, "b={b} scale={scale}");
             }
         }
+    }
+
+    #[test]
+    fn all_shape_speed_combinations_loop_closed() {
+        // 全 shape × 全 speed で t=0 と t=1 が完全一致することを検証する。
+        // Twinkle は freq_scale を内部で 2 倍するが、整数演算のままなので閉じる。
+        let clusters = sample_clusters();
+        for shape in [
+            MotionShape::Still,
+            MotionShape::Lissajous,
+            MotionShape::Vertical,
+            MotionShape::Horizontal,
+            MotionShape::Diagonal,
+            MotionShape::Breathe,
+            MotionShape::Twinkle,
+        ] {
+            for speed in [MotionSpeed::Subtle, MotionSpeed::Slow, MotionSpeed::Lively] {
+                let opts = opts_with(shape, speed);
+                let a = render_frame(&clusters, &opts, 0.0);
+                let b = render_frame(&clusters, &opts, 1.0);
+                assert!(
+                    pixels_equal(&a, &b),
+                    "loop closure broken for shape={shape:?} speed={speed:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn vertical_does_not_move_horizontally() {
+        // Vertical では cluster の x 座標が変わらないので、横スキャンで非ゼロピクセルの
+        // 列範囲が t=0 と t=0.25 で同じになる。簡易チェックとして、最も明るいピクセルの
+        // x 座標が一致することを確認する。
+        let clusters = vec![cluster([255, 0, 0], 0.5, 0.3, 0.5)];
+        let opts = opts_with(MotionShape::Vertical, MotionSpeed::Lively);
+        let a = render_frame(&clusters, &opts, 0.0);
+        let b = render_frame(&clusters, &opts, 0.25);
+        let bright_x = |img: &RgbaImage| -> u32 {
+            let mut best = 0u32;
+            let mut best_v = 0u32;
+            for x in 0..img.width() {
+                let mut col_sum = 0u32;
+                for y in 0..img.height() {
+                    col_sum += img.get_pixel(x, y)[0] as u32;
+                }
+                if col_sum > best_v {
+                    best_v = col_sum;
+                    best = x;
+                }
+            }
+            best
+        };
+        assert_eq!(
+            bright_x(&a),
+            bright_x(&b),
+            "Vertical shape must not shift horizontally"
+        );
+    }
+
+    #[test]
+    fn breathe_keeps_center_changes_radius() {
+        // Breathe は位置不動・半径変動。t=0 と t=0.5 で違う絵になる（radius が違う）。
+        let clusters = sample_clusters();
+        let opts = opts_with(MotionShape::Breathe, MotionSpeed::Slow);
+        let a = render_frame(&clusters, &opts, 0.0);
+        let b = render_frame(&clusters, &opts, 0.5);
+        assert!(
+            !pixels_equal(&a, &b),
+            "Breathe must produce different frame at t=0 vs t=0.5 (radius modulation)"
+        );
+    }
+
+    #[test]
+    fn motion_preset_split_back_compat() {
+        assert_eq!(
+            MotionPreset::Still.split(),
+            (MotionShape::Still, MotionSpeed::Slow)
+        );
+        assert_eq!(
+            MotionPreset::Slow.split(),
+            (MotionShape::Lissajous, MotionSpeed::Slow)
+        );
+        assert_eq!(
+            MotionPreset::Lively.split(),
+            (MotionShape::Lissajous, MotionSpeed::Lively)
+        );
     }
 }

--- a/src/aquarelle/mod.rs
+++ b/src/aquarelle/mod.rs
@@ -1,0 +1,360 @@
+//! セル画夜景の質感セット（aquarelle）。
+//!
+//! 円形ぼかしの単純な orb を、80-90 年代アニメのセル画夜景風に踏み込ませるための
+//! 4 要素（bleed / bloom / offset / halo）を集約する。将来 `aquarelle` を独立 crate
+//! に切り出すための土台で、orber 本体への依存を持たない型と関数だけを公開する。
+//!
+//! # 4 要素
+//!
+//! 1. **bleed** — 円形ぼかしに歪みを足したフィルム感。同色の小さなオフセット
+//!    gradient を周辺に重ねて滲み感を作る
+//! 2. **bloom** — 中心が完全飽和（白に近い）になり光源っぽく見える。半径の内側
+//!    `bloom * R_inner` までを白寄りでクリップ
+//! 3. **offset** — gradient 中心が円の幾何中心から少しズレる。完全な同心円より
+//!    片寄った光のほうが光源として自然。seed で決定的にオフセット方向を選ぶ
+//! 4. **halo** — 周辺へ滲むときに彩度を **上げて** 滲ませる（フィルムのハレーション風）
+//!
+//! # 設計メモ
+//!
+//! - tiny-skia の `Pixmap` を借りて描く。Pixmap は orber 本体でも使われているが、
+//!   aquarelle はそれを「ただのピクセルバッファの抽象」として扱い、`Cluster` 等
+//!   orber 固有の型は持ち込まない（独立 crate 化に備える）
+//! - 入力は `center: (f32, f32)`, `radius: f32`, `color: [u8; 3]`, `seed: u64` の
+//!   primitive のみ
+//! - HSL 経路で彩度ブーストする際は palette を使う（orber 本体と同じ依存。crate
+//!   分割時にも palette は持っていける）
+
+use palette::{FromColor, Hsl, IntoColor, Srgb};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::f32::consts::TAU;
+use tiny_skia::{
+    Color, FillRule, GradientStop, Paint, PathBuilder, Pixmap, Point, RadialGradient, SpreadMode,
+    Transform,
+};
+
+/// aquarelle 4 要素の強度。各 0.0..=1.0。
+#[derive(Debug, Clone, Copy)]
+pub struct AquarelleParams {
+    /// 周辺の小さなオフセット gradient による滲み。0=なし、1=最大。
+    pub bleed: f32,
+    /// 中心の白飛びコア。0=単色、1=半径内側 30% を白寄りに置換。
+    pub bloom: f32,
+    /// gradient 中心の同心ズレ。0=同心、1=半径の 25% までズラす。
+    pub offset: f32,
+    /// 周辺彩度ブースト。0=なし、1=元色の彩度を 1.6 倍まで上げる。
+    pub halo: f32,
+}
+
+impl Default for AquarelleParams {
+    /// 中庸の見栄え（全要素 0.5 で穏やかなセル画感）。
+    fn default() -> Self {
+        Self {
+            bleed: 0.5,
+            bloom: 0.5,
+            offset: 0.5,
+            halo: 0.5,
+        }
+    }
+}
+
+impl AquarelleParams {
+    /// 各値を [0, 1] に丸めた、安全に処理できる版を返す。
+    fn clamped(self) -> Self {
+        Self {
+            bleed: self.bleed.clamp(0.0, 1.0),
+            bloom: self.bloom.clamp(0.0, 1.0),
+            offset: self.offset.clamp(0.0, 1.0),
+            halo: self.halo.clamp(0.0, 1.0),
+        }
+    }
+}
+
+/// 1 つの aquarelle orb を `pixmap` に描き込む。
+///
+/// `seed` は決定的なオフセット方向 / bleed 配置に使われる。同じ `seed` ・
+/// `center` ・ `radius` ・ `color` ・ `params` で同じ結果が返る。
+///
+/// 描画は SourceOver で重ねる。背景の塗り潰しは呼び出し側の責任。
+pub fn render_aquarelle_orb(
+    pixmap: &mut Pixmap,
+    center: (f32, f32),
+    radius: f32,
+    color: [u8; 3],
+    seed: u64,
+    params: AquarelleParams,
+) {
+    if radius <= 0.0 {
+        return;
+    }
+    let p = params.clamped();
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+
+    // 1. 中心オフセット: 半径の最大 25% まで、決定論的にズラす。
+    let offset_dist = radius * 0.25 * p.offset;
+    let theta: f32 = rng.gen_range(0.0..TAU);
+    let cx = center.0 + offset_dist * theta.cos();
+    let cy = center.1 + offset_dist * theta.sin();
+
+    // 2. メインの radial gradient。halo パラメータで周辺彩度を上げる。
+    let halo_color = boost_saturation(color, 1.0 + 0.6 * p.halo);
+    draw_radial(
+        pixmap,
+        cx,
+        cy,
+        radius,
+        color_with_alpha(color, 255),
+        color_with_alpha(halo_color, 128),
+        color_with_alpha(halo_color, 0),
+        0.55,
+    );
+
+    // 3. bleed: 周辺に小さな同色 gradient を 0..3 個ばら撒く。
+    let bleed_count = (3.0 * p.bleed).round() as u32;
+    for _ in 0..bleed_count {
+        let bleed_theta: f32 = rng.gen_range(0.0..TAU);
+        let bleed_dist = radius * rng.gen_range(0.4..0.9);
+        let bx = center.0 + bleed_dist * bleed_theta.cos();
+        let by = center.1 + bleed_dist * bleed_theta.sin();
+        let bleed_radius = radius * rng.gen_range(0.2..0.4) * (0.5 + 0.5 * p.bleed);
+        let bleed_color = boost_saturation(color, 1.0 + 0.4 * p.halo);
+        draw_radial(
+            pixmap,
+            bx,
+            by,
+            bleed_radius,
+            color_with_alpha(bleed_color, 100),
+            color_with_alpha(bleed_color, 50),
+            color_with_alpha(bleed_color, 0),
+            0.5,
+        );
+    }
+
+    // 4. bloom: 中心の白飛びコア。半径内側 0..30% を白に近づける。
+    if p.bloom > 0.0 {
+        let core_radius = radius * 0.3 * p.bloom;
+        if core_radius > 0.0 {
+            let mix_amount = 0.7;
+            let bloom_color = mix_with_white(color, mix_amount);
+            draw_radial(
+                pixmap,
+                cx,
+                cy,
+                core_radius,
+                color_with_alpha(bloom_color, 255),
+                color_with_alpha(bloom_color, 128),
+                color_with_alpha(bloom_color, 0),
+                0.55,
+            );
+        }
+    }
+}
+
+#[inline]
+fn color_with_alpha(rgb: [u8; 3], a: u8) -> [u8; 4] {
+    [rgb[0], rgb[1], rgb[2], a]
+}
+
+fn draw_radial(
+    pixmap: &mut Pixmap,
+    cx: f32,
+    cy: f32,
+    radius: f32,
+    inner_rgba: [u8; 4],
+    mid_rgba: [u8; 4],
+    edge_rgba: [u8; 4],
+    mid_stop: f32,
+) {
+    let center_color =
+        Color::from_rgba8(inner_rgba[0], inner_rgba[1], inner_rgba[2], inner_rgba[3]);
+    let mid_color = Color::from_rgba8(mid_rgba[0], mid_rgba[1], mid_rgba[2], mid_rgba[3]);
+    let edge_color = Color::from_rgba8(edge_rgba[0], edge_rgba[1], edge_rgba[2], edge_rgba[3]);
+    let stops = vec![
+        GradientStop::new(0.0, center_color),
+        GradientStop::new(mid_stop.clamp(0.05, 0.95), mid_color),
+        GradientStop::new(1.0, edge_color),
+    ];
+    let Some(shader) = RadialGradient::new(
+        Point::from_xy(cx, cy),
+        Point::from_xy(cx, cy),
+        radius,
+        stops,
+        SpreadMode::Pad,
+        Transform::identity(),
+    ) else {
+        return;
+    };
+    let paint = Paint {
+        shader,
+        anti_alias: true,
+        ..Default::default()
+    };
+    let mut pb = PathBuilder::new();
+    pb.push_circle(cx, cy, radius * 1.5);
+    if let Some(path) = pb.finish() {
+        pixmap.fill_path(
+            &path,
+            &paint,
+            FillRule::Winding,
+            Transform::identity(),
+            None,
+        );
+    }
+}
+
+fn boost_saturation(rgb: [u8; 3], factor: f32) -> [u8; 3] {
+    if (factor - 1.0).abs() < f32::EPSILON {
+        return rgb;
+    }
+    let srgb = Srgb::new(
+        rgb[0] as f32 / 255.0,
+        rgb[1] as f32 / 255.0,
+        rgb[2] as f32 / 255.0,
+    );
+    let mut hsl: Hsl = Hsl::from_color(srgb);
+    hsl.saturation = (hsl.saturation * factor).clamp(0.0, 1.0);
+    let out: Srgb = hsl.into_color();
+    [
+        (out.red.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (out.green.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (out.blue.clamp(0.0, 1.0) * 255.0).round() as u8,
+    ]
+}
+
+fn mix_with_white(rgb: [u8; 3], amount: f32) -> [u8; 3] {
+    let a = amount.clamp(0.0, 1.0);
+    [
+        (rgb[0] as f32 * (1.0 - a) + 255.0 * a).round() as u8,
+        (rgb[1] as f32 * (1.0 - a) + 255.0 * a).round() as u8,
+        (rgb[2] as f32 * (1.0 - a) + 255.0 * a).round() as u8,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tiny_skia::Pixmap;
+
+    fn fresh_pixmap(w: u32, h: u32) -> Pixmap {
+        let mut p = Pixmap::new(w, h).expect("pixmap");
+        p.fill(Color::from_rgba8(0, 0, 0, 255));
+        p
+    }
+
+    fn count_non_black(pix: &Pixmap) -> u64 {
+        pix.data()
+            .chunks_exact(4)
+            .filter(|px| px[0] > 0 || px[1] > 0 || px[2] > 0)
+            .count() as u64
+    }
+
+    #[test]
+    fn aquarelle_renders_visible_orb() {
+        let mut pix = fresh_pixmap(64, 64);
+        render_aquarelle_orb(
+            &mut pix,
+            (32.0, 32.0),
+            16.0,
+            [200, 100, 50],
+            42,
+            AquarelleParams::default(),
+        );
+        assert!(
+            count_non_black(&pix) > 0,
+            "aquarelle orb should produce visible pixels"
+        );
+    }
+
+    #[test]
+    fn aquarelle_zero_radius_is_noop() {
+        let mut pix = fresh_pixmap(32, 32);
+        render_aquarelle_orb(
+            &mut pix,
+            (16.0, 16.0),
+            0.0,
+            [200, 100, 50],
+            1,
+            AquarelleParams::default(),
+        );
+        assert_eq!(count_non_black(&pix), 0);
+    }
+
+    #[test]
+    fn bloom_brightens_center() {
+        // bloom=1.0 にすると中心ピクセルが元色 (200, 100, 50) より白寄り(全成分大)になる。
+        let mut a = fresh_pixmap(64, 64);
+        let mut b = fresh_pixmap(64, 64);
+        let zero_bloom = AquarelleParams {
+            bleed: 0.0,
+            bloom: 0.0,
+            offset: 0.0,
+            halo: 0.0,
+        };
+        let full_bloom = AquarelleParams {
+            bleed: 0.0,
+            bloom: 1.0,
+            offset: 0.0,
+            halo: 0.0,
+        };
+        render_aquarelle_orb(&mut a, (32.0, 32.0), 24.0, [200, 100, 50], 1, zero_bloom);
+        render_aquarelle_orb(&mut b, (32.0, 32.0), 24.0, [200, 100, 50], 1, full_bloom);
+        let pa = a.pixel(32, 32).expect("center pixel exists");
+        let pb = b.pixel(32, 32).expect("center pixel exists");
+        // bloom=1 では中心の青成分が bloom=0 より高い（白に近づく）。
+        assert!(
+            pb.blue() > pa.blue(),
+            "bloom should raise blue at center: zero={} full={}",
+            pa.blue(),
+            pb.blue()
+        );
+    }
+
+    #[test]
+    fn params_individually_change_output() {
+        // 各要素を個別に上げると、bloom=0 のベースから差分が出ることを確認する。
+        let base = AquarelleParams {
+            bleed: 0.0,
+            bloom: 0.0,
+            offset: 0.0,
+            halo: 0.0,
+        };
+        let mut p_base = fresh_pixmap(64, 64);
+        render_aquarelle_orb(&mut p_base, (32.0, 32.0), 20.0, [200, 100, 50], 7, base);
+        let base_data: Vec<u8> = p_base.data().to_vec();
+
+        for (name, modified) in [
+            ("bleed", AquarelleParams { bleed: 1.0, ..base }),
+            ("bloom", AquarelleParams { bloom: 1.0, ..base }),
+            (
+                "offset",
+                AquarelleParams {
+                    offset: 1.0,
+                    ..base
+                },
+            ),
+            ("halo", AquarelleParams { halo: 1.0, ..base }),
+        ] {
+            let mut p = fresh_pixmap(64, 64);
+            render_aquarelle_orb(&mut p, (32.0, 32.0), 20.0, [200, 100, 50], 7, modified);
+            assert_ne!(
+                p.data(),
+                &base_data[..],
+                "{name}=1.0 should change rendered orb"
+            );
+        }
+    }
+
+    #[test]
+    fn deterministic_with_seed() {
+        let mut a = fresh_pixmap(64, 64);
+        let mut b = fresh_pixmap(64, 64);
+        let params = AquarelleParams::default();
+        render_aquarelle_orb(&mut a, (32.0, 32.0), 20.0, [200, 100, 50], 12345, params);
+        render_aquarelle_orb(&mut b, (32.0, 32.0), 20.0, [200, 100, 50], 12345, params);
+        assert_eq!(
+            a.data(),
+            b.data(),
+            "same seed + inputs must produce identical output"
+        );
+    }
+}

--- a/src/background.rs
+++ b/src/background.rs
@@ -1,0 +1,243 @@
+//! 背景色解決モジュール。
+//!
+//! `--background` フラグの値（`black` / `white` / `auto` / `transparent` /
+//! `#RRGGBB` / `#RRGGBBAA`）を [`Background`] enum に正規化し、入力画像から
+//! 最終的な RGBA 8bit を決める [`resolve`] を提供する。
+//!
+//! # 設計メモ
+//!
+//! - `auto` は入力を 64x64 にダウンサンプルした平均色を取り、HSL の彩度を
+//!   半分・明度を 0.85 倍 + 下限 0.05 / 上限 0.7 に押し込めて純白／純黒を避ける。
+//!   写真の支配色を「やや暗めの背景」に寄せるのが狙い
+//! - `transparent` は alpha=0。動画は yuv420p 制約で alpha 不可なので、呼び出し
+//!   側で `transparent + 動画モード` を弾く責務を負う（このモジュールでは
+//!   そこまで踏み込まない）
+
+use image::RgbImage;
+
+/// 背景指定。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Background {
+    Black,
+    White,
+    Auto,
+    Hex([u8; 4]),
+    Transparent,
+}
+
+impl Background {
+    /// 透過が要求されているかどうか。動画経路の事前バリデーションに使う。
+    pub fn is_transparent(self) -> bool {
+        match self {
+            Self::Transparent => true,
+            Self::Hex([_, _, _, a]) => a == 0,
+            _ => false,
+        }
+    }
+}
+
+/// `--background` 値の文字列パースエラー。
+#[derive(Debug, PartialEq, Eq)]
+pub enum BackgroundParseError {
+    InvalidHex(String),
+    Unknown(String),
+}
+
+impl std::fmt::Display for BackgroundParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidHex(s) => {
+                write!(f, "invalid hex color {s:?} (expected #RRGGBB or #RRGGBBAA)")
+            }
+            Self::Unknown(s) => write!(
+                f,
+                "unknown --background value {s:?} (expected black|white|auto|transparent|#RRGGBB)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BackgroundParseError {}
+
+impl std::str::FromStr for Background {
+    type Err = BackgroundParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let lower = s.trim().to_ascii_lowercase();
+        match lower.as_str() {
+            "black" => Ok(Self::Black),
+            "white" => Ok(Self::White),
+            "auto" => Ok(Self::Auto),
+            "transparent" | "none" => Ok(Self::Transparent),
+            _ => parse_hex(&lower).ok_or_else(|| {
+                if lower.starts_with('#') {
+                    BackgroundParseError::InvalidHex(s.to_string())
+                } else {
+                    BackgroundParseError::Unknown(s.to_string())
+                }
+            }),
+        }
+    }
+}
+
+fn parse_hex(s: &str) -> Option<Background> {
+    let hex = s.strip_prefix('#')?;
+    let pair = |i: usize| u8::from_str_radix(hex.get(i..i + 2)?, 16).ok();
+    match hex.len() {
+        6 => Some(Background::Hex([pair(0)?, pair(2)?, pair(4)?, 255])),
+        8 => Some(Background::Hex([pair(0)?, pair(2)?, pair(4)?, pair(6)?])),
+        _ => None,
+    }
+}
+
+/// `Background` を入力画像と組み合わせて最終的な RGBA 8bit に解決する。
+///
+/// `auto` のみ入力画像に依存する。それ以外の variant は入力を参照しない
+/// （引数に渡されても無視される）。
+pub fn resolve(input: &RgbImage, bg: Background) -> [u8; 4] {
+    match bg {
+        Background::Black => [0, 0, 0, 255],
+        Background::White => [255, 255, 255, 255],
+        Background::Hex(rgba) => rgba,
+        Background::Transparent => [0, 0, 0, 0],
+        Background::Auto => auto_color(input),
+    }
+}
+
+fn auto_color(input: &RgbImage) -> [u8; 4] {
+    use image::imageops::{resize, FilterType};
+    use palette::{FromColor, Hsl, IntoColor, Srgb};
+
+    // 入力が極小で 64x64 に拡大される場合でも結果は安定する（平均色は変わらない）。
+    let small = if input.width() == 0 || input.height() == 0 {
+        return [0, 0, 0, 255];
+    } else {
+        resize(input, 64, 64, FilterType::Triangle)
+    };
+
+    let mut sr: u64 = 0;
+    let mut sg: u64 = 0;
+    let mut sb: u64 = 0;
+    let mut n: u64 = 0;
+    for px in small.pixels() {
+        sr += px[0] as u64;
+        sg += px[1] as u64;
+        sb += px[2] as u64;
+        n += 1;
+    }
+    let n = n.max(1) as f32;
+    let srgb = Srgb::new(
+        sr as f32 / n / 255.0,
+        sg as f32 / n / 255.0,
+        sb as f32 / n / 255.0,
+    );
+    let mut hsl: Hsl = Hsl::from_color(srgb);
+    hsl.saturation = (hsl.saturation * 0.5).clamp(0.0, 1.0);
+    hsl.lightness = (hsl.lightness * 0.85).clamp(0.05, 0.7);
+    let out: Srgb = hsl.into_color();
+    [
+        (out.red.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (out.green.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (out.blue.clamp(0.0, 1.0) * 255.0).round() as u8,
+        255,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::RgbImage;
+    use std::str::FromStr;
+
+    #[test]
+    fn parse_named() {
+        assert_eq!(Background::from_str("black").unwrap(), Background::Black);
+        assert_eq!(Background::from_str("WHITE").unwrap(), Background::White);
+        assert_eq!(Background::from_str("auto").unwrap(), Background::Auto);
+        assert_eq!(
+            Background::from_str("transparent").unwrap(),
+            Background::Transparent
+        );
+        assert_eq!(
+            Background::from_str("none").unwrap(),
+            Background::Transparent
+        );
+    }
+
+    #[test]
+    fn parse_hex_rgb() {
+        assert_eq!(
+            Background::from_str("#1a2b3c").unwrap(),
+            Background::Hex([0x1a, 0x2b, 0x3c, 0xff])
+        );
+        assert_eq!(
+            Background::from_str("#FF00FF").unwrap(),
+            Background::Hex([0xff, 0x00, 0xff, 0xff])
+        );
+    }
+
+    #[test]
+    fn parse_hex_rgba() {
+        assert_eq!(
+            Background::from_str("#11223344").unwrap(),
+            Background::Hex([0x11, 0x22, 0x33, 0x44])
+        );
+    }
+
+    #[test]
+    fn parse_invalid_hex() {
+        assert!(matches!(
+            Background::from_str("#zzzzzz"),
+            Err(BackgroundParseError::InvalidHex(_))
+        ));
+        assert!(matches!(
+            Background::from_str("#abc"),
+            Err(BackgroundParseError::InvalidHex(_))
+        ));
+    }
+
+    #[test]
+    fn parse_unknown() {
+        assert!(matches!(
+            Background::from_str("magenta"),
+            Err(BackgroundParseError::Unknown(_))
+        ));
+    }
+
+    #[test]
+    fn resolve_named_colors() {
+        let img = RgbImage::new(2, 2);
+        assert_eq!(resolve(&img, Background::Black), [0, 0, 0, 255]);
+        assert_eq!(resolve(&img, Background::White), [255, 255, 255, 255]);
+        assert_eq!(resolve(&img, Background::Transparent), [0, 0, 0, 0]);
+        assert_eq!(
+            resolve(&img, Background::Hex([10, 20, 30, 200])),
+            [10, 20, 30, 200]
+        );
+    }
+
+    #[test]
+    fn resolve_auto_red_image_yields_reddish_dim_color() {
+        // 全ピクセル赤の画像 → auto は赤系の暗めの色になる（彩度半減・明度抑制）。
+        let mut img = RgbImage::new(8, 8);
+        for px in img.pixels_mut() {
+            *px = image::Rgb([255, 0, 0]);
+        }
+        let [r, g, b, a] = resolve(&img, Background::Auto);
+        assert_eq!(a, 255);
+        assert!(
+            r > g && r > b,
+            "auto of red should remain red-dominant: {r} {g} {b}"
+        );
+        // 純赤 (255,0,0) より暗くなっている（明度 0.7 上限）。
+        assert!(r < 255, "auto should dim pure red, got {r}");
+    }
+
+    #[test]
+    fn is_transparent_logic() {
+        assert!(Background::Transparent.is_transparent());
+        assert!(Background::Hex([0, 0, 0, 0]).is_transparent());
+        assert!(!Background::Hex([0, 0, 0, 1]).is_transparent());
+        assert!(!Background::Black.is_transparent());
+        assert!(!Background::Auto.is_transparent());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@ pub mod cluster;
 pub mod orb;
 pub mod output_mode;
 pub mod style;
+pub mod variations;
 pub mod video;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 // (color clustering, orb rendering, animation, video output, etc.).
 
 pub mod animate;
+pub mod background;
 pub mod cluster;
 pub mod orb;
 pub mod output_mode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 // (color clustering, orb rendering, animation, video output, etc.).
 
 pub mod animate;
+pub mod aquarelle;
 pub mod background;
 pub mod cluster;
 pub mod orb;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 use clap::{Parser, ValueEnum};
 use orber::animate::{MotionPreset, MotionShape, MotionSpeed};
 use orber::background::{resolve as resolve_background, Background};
-use orber::cluster::extract_clusters;
+use orber::cluster::{extract_clusters, Cluster};
 use orber::orb::{render_static, RenderOptions};
 use orber::output_mode::OutputMode;
 use orber::style::{render_css, render_svg, StyleOptions};
+use orber::variations::{select_specs, VariationKind, VariationMode, VariationSpec};
 use orber::video::{render_video, VideoCodec, VideoOptions};
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -64,6 +65,24 @@ enum CliMotionSpeed {
     Lively,
 }
 
+/// `--variations-mode` の選択肢。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CliVariationMode {
+    Still,
+    Video,
+    Mixed,
+}
+
+impl From<CliVariationMode> for VariationMode {
+    fn from(m: CliVariationMode) -> Self {
+        match m {
+            CliVariationMode::Still => VariationMode::Still,
+            CliVariationMode::Video => VariationMode::Video,
+            CliVariationMode::Mixed => VariationMode::Mixed,
+        }
+    }
+}
+
 impl From<CliMotionSpeed> for MotionSpeed {
     fn from(s: CliMotionSpeed) -> Self {
         match s {
@@ -93,8 +112,23 @@ struct Cli {
     input: PathBuf,
 
     /// Output file. Format inferred from extension: png, webp, mp4, webm, svg, css.
+    /// Required for the single-output mode (omitted when --variations is set).
     #[arg(short, long)]
-    output: PathBuf,
+    output: Option<PathBuf>,
+
+    /// Generate N variations of the input under --output-dir instead of a single file.
+    /// Requires --output-dir. Variations are picked from a curated preset table
+    /// (still ×3, drift ×4, breathe ×1, lissajous ×2 = up to 10).
+    #[arg(long)]
+    variations: Option<usize>,
+
+    /// Output directory for --variations mode. Created if it does not exist.
+    #[arg(long)]
+    output_dir: Option<PathBuf>,
+
+    /// Filter for --variations: only stills, only videos, or mixed (default).
+    #[arg(long, value_enum, default_value_t = CliVariationMode::Mixed)]
+    variations_mode: CliVariationMode,
 
     /// Random seed for reproducible output.
     #[arg(long)]
@@ -145,16 +179,28 @@ struct Cli {
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    let mode = match OutputMode::from_path(&cli.output) {
-        Ok(m) => m,
+    let bg: Background = match cli.background.parse() {
+        Ok(b) => b,
         Err(e) => {
             eprintln!("orber: {e}");
             return ExitCode::from(2);
         }
     };
 
-    let bg: Background = match cli.background.parse() {
-        Ok(b) => b,
+    if let Some(n) = cli.variations {
+        return render_variations(&cli, n, bg);
+    }
+
+    let output = match &cli.output {
+        Some(p) => p.clone(),
+        None => {
+            eprintln!("orber: either --output FILE or --variations N --output-dir DIR is required");
+            return ExitCode::from(2);
+        }
+    };
+
+    let mode = match OutputMode::from_path(&output) {
+        Ok(m) => m,
         Err(e) => {
             eprintln!("orber: {e}");
             return ExitCode::from(2);
@@ -168,12 +214,12 @@ fn main() -> ExitCode {
             );
             return ExitCode::from(2);
         }
-        return render_video_path(&cli, codec, bg);
+        return render_video_path(&cli, &output, codec, bg);
     }
 
     match mode {
-        OutputMode::Png => render_png(&cli, bg),
-        OutputMode::Svg | OutputMode::Css => render_style_path(&cli, mode, bg),
+        OutputMode::Png => render_png(&cli, &output, bg),
+        OutputMode::Svg | OutputMode::Css => render_style_path(&cli, &output, mode, bg),
         _ => {
             eprintln!("orber: output mode {mode:?} is not yet implemented");
             ExitCode::from(1)
@@ -196,7 +242,7 @@ fn resolve_motion(cli: &Cli) -> (MotionShape, MotionSpeed) {
     (shape, speed)
 }
 
-fn render_style_path(cli: &Cli, mode: OutputMode, bg: Background) -> ExitCode {
+fn render_style_path(cli: &Cli, output: &PathBuf, mode: OutputMode, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -230,18 +276,15 @@ fn render_style_path(cli: &Cli, mode: OutputMode, bg: Background) -> ExitCode {
         _ => unreachable!("render_style_path called with non-style mode {mode:?}"),
     };
 
-    if let Err(e) = std::fs::write(&cli.output, content) {
-        eprintln!(
-            "orber: failed to write output {}: {e}",
-            cli.output.display()
-        );
+    if let Err(e) = std::fs::write(output, content) {
+        eprintln!("orber: failed to write output {}: {e}", output.display());
         return ExitCode::from(2);
     }
-    eprintln!("orber: wrote {}", cli.output.display());
+    eprintln!("orber: wrote {}", output.display());
     ExitCode::SUCCESS
 }
 
-fn render_video_path(cli: &Cli, codec: VideoCodec, bg: Background) -> ExitCode {
+fn render_video_path(cli: &Cli, output: &PathBuf, codec: VideoCodec, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -273,15 +316,15 @@ fn render_video_path(cli: &Cli, codec: VideoCodec, bg: Background) -> ExitCode {
     };
 
     // 4. 動画書き出し。進捗とフレーム数の検証は render_video が担当する。
-    if let Err(e) = render_video(&clusters, &opts, &cli.output, cli.duration_ms, codec) {
+    if let Err(e) = render_video(&clusters, &opts, output, cli.duration_ms, codec) {
         eprintln!("orber: video render failed: {e}");
         return ExitCode::from(2);
     }
-    eprintln!("orber: wrote {}", cli.output.display());
+    eprintln!("orber: wrote {}", output.display());
     ExitCode::SUCCESS
 }
 
-fn render_png(cli: &Cli, bg: Background) -> ExitCode {
+fn render_png(cli: &Cli, output: &PathBuf, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -314,15 +357,120 @@ fn render_png(cli: &Cli, bg: Background) -> ExitCode {
     let out = render_static(&clusters, &opts);
 
     // 5. 保存。
-    if let Err(e) = out.save(&cli.output) {
+    if let Err(e) = out.save(output) {
+        eprintln!("orber: failed to write output {}: {e}", output.display());
+        return ExitCode::from(2);
+    }
+    eprintln!("orber: wrote {}", output.display());
+    ExitCode::SUCCESS
+}
+
+/// `--variations` 経路。`output_dir` を作って各 spec で逐次書き出す。
+fn render_variations(cli: &Cli, n: usize, bg: Background) -> ExitCode {
+    let dir = match &cli.output_dir {
+        Some(d) => d.clone(),
+        None => {
+            eprintln!("orber: --variations requires --output-dir DIR");
+            return ExitCode::from(2);
+        }
+    };
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("orber: failed to create output dir {}: {e}", dir.display());
+        return ExitCode::from(2);
+    }
+
+    // 入力 + クラスタは全 spec で共有。
+    let img = match image::open(&cli.input) {
+        Ok(img) => img.to_rgb8(),
+        Err(e) => {
+            eprintln!("orber: failed to read input {}: {e}", cli.input.display());
+            return ExitCode::from(2);
+        }
+    };
+    let clusters = match extract_clusters(&img, 6) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("orber: cluster extraction failed: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let resolved_bg = resolve_background(&img, bg);
+
+    let specs = select_specs(n, cli.variations_mode.into());
+    if specs.is_empty() {
         eprintln!(
-            "orber: failed to write output {}: {e}",
-            cli.output.display()
+            "orber: no variations matched (requested n={n}, mode={:?})",
+            cli.variations_mode
         );
         return ExitCode::from(2);
     }
-    eprintln!("orber: wrote {}", cli.output.display());
+
+    let total = specs.len();
+    if total < n {
+        eprintln!(
+            "orber: only {total} variation(s) available for mode {:?} (requested {n})",
+            cli.variations_mode
+        );
+    }
+
+    for (i, spec) in specs.iter().enumerate() {
+        let idx = i + 1;
+        let filename = format!("{idx:02}_{}.{}", spec.label, spec.kind.ext());
+        let out_path = dir.join(&filename);
+        eprintln!("orber: variation {idx}/{total} ({filename})");
+        // 動画 + 透過は不可（yuv420p）。bg が transparent なら black に置換して進める。
+        let spec_bg = if spec.kind == VariationKind::Mp4 && resolved_bg[3] == 0 {
+            [0, 0, 0, 255]
+        } else {
+            resolved_bg
+        };
+        let result = render_one_variation(&clusters, spec, &out_path, spec_bg);
+        if let Err(msg) = result {
+            eprintln!("orber: variation {idx} ({filename}) failed: {msg}");
+            return ExitCode::from(2);
+        }
+    }
     ExitCode::SUCCESS
+}
+
+fn render_one_variation(
+    clusters: &[Cluster],
+    spec: &VariationSpec,
+    out_path: &std::path::Path,
+    bg_rgba: [u8; 4],
+) -> Result<(), String> {
+    match spec.kind {
+        VariationKind::Png => {
+            let opts = RenderOptions {
+                orb_size: spec.orb_size,
+                blur: spec.blur,
+                saturation: spec.saturation,
+                background: bg_rgba,
+                ..RenderOptions::default()
+            };
+            let img = render_static(clusters, &opts);
+            img.save(out_path).map_err(|e| e.to_string())
+        }
+        VariationKind::Mp4 => {
+            let opts = VideoOptions {
+                orb_size: spec.orb_size,
+                blur: spec.blur,
+                saturation: spec.saturation,
+                motion_shape: spec.shape,
+                motion_speed: spec.speed,
+                seed: spec.seed,
+                background: bg_rgba,
+            };
+            render_video(
+                clusters,
+                &opts,
+                out_path,
+                spec.duration_ms,
+                VideoCodec::H264,
+            )
+            .map_err(|e| e.to_string())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use clap::{Parser, ValueEnum};
 use orber::animate::{MotionPreset, MotionShape, MotionSpeed};
+use orber::aquarelle::AquarelleParams;
 use orber::background::{resolve as resolve_background, Background};
 use orber::cluster::{extract_clusters, Cluster};
-use orber::orb::{render_static, RenderOptions};
+use orber::orb::{render_static, OrbShape, RenderOptions};
 use orber::output_mode::OutputMode;
 use orber::style::{render_css, render_svg, StyleOptions};
 use orber::variations::{select_specs, VariationKind, VariationMode, VariationSpec};
@@ -98,8 +99,17 @@ impl From<CliMotionSpeed> for MotionSpeed {
 enum Shape {
     /// Plain circular orb (default).
     Circle,
-    /// Watercolor-style irregular bleed.
+    /// Cel-painted nightscape texture set: bleed + bloom + offset + halo.
     Aquarelle,
+}
+
+impl Shape {
+    fn to_orb_shape(self, params: AquarelleParams) -> OrbShape {
+        match self {
+            Shape::Circle => OrbShape::Circle,
+            Shape::Aquarelle => OrbShape::Aquarelle(params),
+        }
+    }
 }
 
 #[derive(Debug, Parser)]
@@ -174,6 +184,37 @@ struct Cli {
     /// `transparent` is rejected for mp4/webm (yuv420p has no alpha).
     #[arg(long, default_value = "auto")]
     background: String,
+
+    /// Aquarelle: bleed strength (0.0..=1.0). Only used with --shape aquarelle.
+    #[arg(long, default_value_t = 0.5)]
+    aquarelle_bleed: f32,
+
+    /// Aquarelle: blown-out core strength (0.0..=1.0). Only used with --shape aquarelle.
+    #[arg(long, default_value_t = 0.5)]
+    aquarelle_bloom: f32,
+
+    /// Aquarelle: gradient center offset (0.0..=1.0). Only used with --shape aquarelle.
+    #[arg(long, default_value_t = 0.5)]
+    aquarelle_offset: f32,
+
+    /// Aquarelle: peripheral saturation (halo) (0.0..=1.0). Only used with --shape aquarelle.
+    #[arg(long, default_value_t = 0.5)]
+    aquarelle_halo: f32,
+}
+
+impl Cli {
+    fn aquarelle_params(&self) -> AquarelleParams {
+        AquarelleParams {
+            bleed: self.aquarelle_bleed,
+            bloom: self.aquarelle_bloom,
+            offset: self.aquarelle_offset,
+            halo: self.aquarelle_halo,
+        }
+    }
+
+    fn orb_shape(&self) -> OrbShape {
+        self.shape.to_orb_shape(self.aquarelle_params())
+    }
 }
 
 fn main() -> ExitCode {
@@ -313,6 +354,7 @@ fn render_video_path(cli: &Cli, output: &PathBuf, codec: VideoCodec, bg: Backgro
         motion_speed: speed,
         seed: cli.seed.unwrap_or(0),
         background: resolve_background(&img, bg),
+        shape: cli.orb_shape(),
     };
 
     // 4. 動画書き出し。進捗とフレーム数の検証は render_video が担当する。
@@ -350,6 +392,7 @@ fn render_png(cli: &Cli, output: &PathBuf, bg: Background) -> ExitCode {
         blur: cli.blur,
         saturation: cli.saturation,
         background: resolve_background(&img, bg),
+        shape: cli.orb_shape(),
         ..RenderOptions::default()
     };
 
@@ -413,6 +456,7 @@ fn render_variations(cli: &Cli, n: usize, bg: Background) -> ExitCode {
         );
     }
 
+    let orb_shape = cli.orb_shape();
     for (i, spec) in specs.iter().enumerate() {
         let idx = i + 1;
         let filename = format!("{idx:02}_{}.{}", spec.label, spec.kind.ext());
@@ -424,7 +468,7 @@ fn render_variations(cli: &Cli, n: usize, bg: Background) -> ExitCode {
         } else {
             resolved_bg
         };
-        let result = render_one_variation(&clusters, spec, &out_path, spec_bg);
+        let result = render_one_variation(&clusters, spec, &out_path, spec_bg, orb_shape);
         if let Err(msg) = result {
             eprintln!("orber: variation {idx} ({filename}) failed: {msg}");
             return ExitCode::from(2);
@@ -438,6 +482,7 @@ fn render_one_variation(
     spec: &VariationSpec,
     out_path: &std::path::Path,
     bg_rgba: [u8; 4],
+    orb_shape: OrbShape,
 ) -> Result<(), String> {
     match spec.kind {
         VariationKind::Png => {
@@ -446,6 +491,7 @@ fn render_one_variation(
                 blur: spec.blur,
                 saturation: spec.saturation,
                 background: bg_rgba,
+                shape: orb_shape,
                 ..RenderOptions::default()
             };
             let img = render_static(clusters, &opts);
@@ -460,6 +506,7 @@ fn render_one_variation(
                 motion_speed: spec.speed,
                 seed: spec.seed,
                 background: bg_rgba,
+                shape: orb_shape,
             };
             render_video(
                 clusters,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, ValueEnum};
-use orber::animate::MotionPreset;
+use orber::animate::{MotionPreset, MotionShape, MotionSpeed};
 use orber::background::{resolve as resolve_background, Background};
 use orber::cluster::extract_clusters;
 use orber::orb::{render_static, RenderOptions};
@@ -9,14 +9,14 @@ use orber::video::{render_video, VideoCodec, VideoOptions};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-/// Drift speed of orbs in animated outputs.
+/// Back-compat motion preset (`--motion`). Equivalent to a fixed (shape, speed) pair.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum Motion {
-    /// No movement.
+    /// No movement (shape=still).
     Still,
-    /// Slow, leisurely drift (default).
+    /// Slow Lissajous drift (default).
     Slow,
-    /// Lively, faster drift.
+    /// Lively Lissajous drift.
     Lively,
 }
 
@@ -26,6 +26,50 @@ impl From<Motion> for MotionPreset {
             Motion::Still => MotionPreset::Still,
             Motion::Slow => MotionPreset::Slow,
             Motion::Lively => MotionPreset::Lively,
+        }
+    }
+}
+
+/// Orbit shape (`--motion-shape`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CliMotionShape {
+    Still,
+    Lissajous,
+    Vertical,
+    Horizontal,
+    Diagonal,
+    Breathe,
+    Twinkle,
+}
+
+impl From<CliMotionShape> for MotionShape {
+    fn from(s: CliMotionShape) -> Self {
+        match s {
+            CliMotionShape::Still => MotionShape::Still,
+            CliMotionShape::Lissajous => MotionShape::Lissajous,
+            CliMotionShape::Vertical => MotionShape::Vertical,
+            CliMotionShape::Horizontal => MotionShape::Horizontal,
+            CliMotionShape::Diagonal => MotionShape::Diagonal,
+            CliMotionShape::Breathe => MotionShape::Breathe,
+            CliMotionShape::Twinkle => MotionShape::Twinkle,
+        }
+    }
+}
+
+/// Motion speed (`--motion-speed`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CliMotionSpeed {
+    Subtle,
+    Slow,
+    Lively,
+}
+
+impl From<CliMotionSpeed> for MotionSpeed {
+    fn from(s: CliMotionSpeed) -> Self {
+        match s {
+            CliMotionSpeed::Subtle => MotionSpeed::Subtle,
+            CliMotionSpeed::Slow => MotionSpeed::Slow,
+            CliMotionSpeed::Lively => MotionSpeed::Lively,
         }
     }
 }
@@ -64,9 +108,20 @@ struct Cli {
     #[arg(long, default_value_t = 0.5)]
     blur: f32,
 
-    /// Drift speed for animated outputs.
+    /// Back-compat drift preset for animated outputs. Equivalent to a fixed
+    /// (motion-shape, motion-speed) pair: still→(still,slow), slow→(lissajous,slow),
+    /// lively→(lissajous,lively). Overridden if --motion-shape or --motion-speed
+    /// is also passed.
     #[arg(long, value_enum, default_value_t = Motion::Slow)]
     motion: Motion,
+
+    /// Orbit shape independent of speed. Overrides the shape implied by --motion.
+    #[arg(long, value_enum)]
+    motion_shape: Option<CliMotionShape>,
+
+    /// Motion speed/amplitude independent of shape. Overrides the speed implied by --motion.
+    #[arg(long, value_enum)]
+    motion_speed: Option<CliMotionSpeed>,
 
     /// Orb rendering shape.
     #[arg(long, value_enum, default_value_t = Shape::Circle)]
@@ -124,6 +179,21 @@ fn main() -> ExitCode {
             ExitCode::from(1)
         }
     }
+}
+
+/// `--motion` の preset と `--motion-shape` / `--motion-speed` の上書きを統合する。
+///
+/// 個別フラグが指定されていればそちらを優先、なければ `--motion` 由来の組を使う。
+fn resolve_motion(cli: &Cli) -> (MotionShape, MotionSpeed) {
+    let preset: MotionPreset = cli.motion.into();
+    let (mut shape, mut speed) = preset.split();
+    if let Some(s) = cli.motion_shape {
+        shape = s.into();
+    }
+    if let Some(sp) = cli.motion_speed {
+        speed = sp.into();
+    }
+    (shape, speed)
 }
 
 fn render_style_path(cli: &Cli, mode: OutputMode, bg: Background) -> ExitCode {
@@ -191,11 +261,13 @@ fn render_video_path(cli: &Cli, codec: VideoCodec, bg: Background) -> ExitCode {
     };
 
     // 3. ビデオオプション構築。解像度は固定。
+    let (shape, speed) = resolve_motion(cli);
     let opts = VideoOptions {
         orb_size: cli.orb_size,
         blur: cli.blur,
         saturation: cli.saturation,
-        motion: cli.motion.into(),
+        motion_shape: shape,
+        motion_speed: speed,
         seed: cli.seed.unwrap_or(0),
         background: resolve_background(&img, bg),
     };
@@ -281,8 +353,9 @@ mod tests {
         // ここで motion/orb_size/blur/saturation の SoT 一致を担保する。
         let cli = Cli::parse_from(["orber", "--input", "x", "--output", "x.mp4"]);
         let a = AnimateOptions::default();
-        let motion: MotionPreset = cli.motion.into();
-        assert_eq!(motion, a.motion, "motion default mismatch");
+        let (shape, speed) = resolve_motion(&cli);
+        assert_eq!(shape, a.motion_shape, "motion_shape default mismatch");
+        assert_eq!(speed, a.motion_speed, "motion_speed default mismatch");
         assert_eq!(cli.orb_size, a.orb_size, "orb_size default mismatch");
         assert_eq!(cli.blur, a.blur, "blur default mismatch");
         assert_eq!(cli.saturation, a.saturation, "saturation default mismatch");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, ValueEnum};
 use orber::animate::MotionPreset;
+use orber::background::{resolve as resolve_background, Background};
 use orber::cluster::extract_clusters;
 use orber::orb::{render_static, RenderOptions};
 use orber::output_mode::OutputMode;
@@ -78,6 +79,12 @@ struct Cli {
     /// Animated output duration in milliseconds (1000..=600000, i.e. 1s..=10min).
     #[arg(long, default_value_t = 5000)]
     duration_ms: u64,
+
+    /// Background color: black, white, auto, transparent, or #RRGGBB(AA).
+    /// `auto` picks a dimmed average color of the input image.
+    /// `transparent` is rejected for mp4/webm (yuv420p has no alpha).
+    #[arg(long, default_value = "auto")]
+    background: String,
 }
 
 fn main() -> ExitCode {
@@ -91,13 +98,27 @@ fn main() -> ExitCode {
         }
     };
 
+    let bg: Background = match cli.background.parse() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("orber: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
     if let Some(codec) = VideoCodec::from_output_mode(mode) {
-        return render_video_path(&cli, codec);
+        if bg.is_transparent() {
+            eprintln!(
+                "orber: --background transparent is not supported for {mode:?} (yuv420p has no alpha channel)"
+            );
+            return ExitCode::from(2);
+        }
+        return render_video_path(&cli, codec, bg);
     }
 
     match mode {
-        OutputMode::Png => render_png(&cli),
-        OutputMode::Svg | OutputMode::Css => render_style_path(&cli, mode),
+        OutputMode::Png => render_png(&cli, bg),
+        OutputMode::Svg | OutputMode::Css => render_style_path(&cli, mode, bg),
         _ => {
             eprintln!("orber: output mode {mode:?} is not yet implemented");
             ExitCode::from(1)
@@ -105,7 +126,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn render_style_path(cli: &Cli, mode: OutputMode) -> ExitCode {
+fn render_style_path(cli: &Cli, mode: OutputMode, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -129,6 +150,7 @@ fn render_style_path(cli: &Cli, mode: OutputMode) -> ExitCode {
         orb_size: cli.orb_size,
         blur: cli.blur,
         saturation: cli.saturation,
+        background: resolve_background(&img, bg),
     };
 
     // 4. mode で書き出しを分岐。
@@ -149,7 +171,7 @@ fn render_style_path(cli: &Cli, mode: OutputMode) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn render_video_path(cli: &Cli, codec: VideoCodec) -> ExitCode {
+fn render_video_path(cli: &Cli, codec: VideoCodec, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -175,6 +197,7 @@ fn render_video_path(cli: &Cli, codec: VideoCodec) -> ExitCode {
         saturation: cli.saturation,
         motion: cli.motion.into(),
         seed: cli.seed.unwrap_or(0),
+        background: resolve_background(&img, bg),
     };
 
     // 4. 動画書き出し。進捗とフレーム数の検証は render_video が担当する。
@@ -186,7 +209,7 @@ fn render_video_path(cli: &Cli, codec: VideoCodec) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn render_png(cli: &Cli) -> ExitCode {
+fn render_png(cli: &Cli, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -211,6 +234,7 @@ fn render_png(cli: &Cli) -> ExitCode {
         orb_size: cli.orb_size,
         blur: cli.blur,
         saturation: cli.saturation,
+        background: resolve_background(&img, bg),
         ..RenderOptions::default()
     };
 

--- a/src/orb.rs
+++ b/src/orb.rs
@@ -15,6 +15,7 @@
 //!   blur=1 → 中心の不透明領域が点に近く、緩やかに減衰
 //! - 彩度調整は palette の HSL 経由
 
+use crate::aquarelle::{render_aquarelle_orb, AquarelleParams};
 use crate::cluster::Cluster;
 use image::RgbaImage;
 use palette::{FromColor, Hsl, IntoColor, Srgb};
@@ -22,6 +23,29 @@ use tiny_skia::{
     Color, FillRule, GradientStop, Paint, PathBuilder, Pixmap, Point, RadialGradient, SpreadMode,
     Transform,
 };
+
+/// orb 描画形式。`Circle` は単一の radial gradient、`Aquarelle` はセル画夜景の
+/// 質感セット（[`crate::aquarelle`]）を有効にする。
+#[derive(Debug, Clone, Copy)]
+pub enum OrbShape {
+    Circle,
+    Aquarelle(AquarelleParams),
+}
+
+impl Default for OrbShape {
+    fn default() -> Self {
+        Self::Circle
+    }
+}
+
+impl PartialEq for OrbShape {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (OrbShape::Circle, OrbShape::Circle) | (OrbShape::Aquarelle(_), OrbShape::Aquarelle(_))
+        )
+    }
+}
 
 /// 静的 orb 描画のオプション。
 #[derive(Debug, Clone)]
@@ -38,6 +62,8 @@ pub struct RenderOptions {
     pub saturation: f32,
     /// 背景 RGBA。alpha=0 で透過。デフォルトは黒不透明。
     pub background: [u8; 4],
+    /// orb の描画形式。Circle なら現状互換、Aquarelle ならセル画夜景の質感セット。
+    pub shape: OrbShape,
 }
 
 impl Default for RenderOptions {
@@ -49,6 +75,7 @@ impl Default for RenderOptions {
             blur: 0.5,
             saturation: 1.0,
             background: [0, 0, 0, 255],
+            shape: OrbShape::Circle,
         }
     }
 }
@@ -79,7 +106,7 @@ pub fn render_static(clusters: &[Cluster], opts: &RenderOptions) -> RgbaImage {
 
     let base_radius_unit = (width.min(height) as f32) * 0.25 * orb_size;
 
-    for cluster in clusters {
+    for (i, cluster) in clusters.iter().enumerate() {
         // 半径 0 の orb は何も描画しないのでスキップ（0 半径の RadialGradient は tiny-skia で None になる）。
         let radius = base_radius_unit * cluster.weight.max(0.0).sqrt();
         if radius <= 0.0 {
@@ -90,6 +117,13 @@ pub fn render_static(clusters: &[Cluster], opts: &RenderOptions) -> RgbaImage {
         let cy = cluster.centroid.y.clamp(0.0, 1.0) * height as f32;
 
         let [r, g, b] = adjust_saturation(cluster.color, saturation);
+
+        // Aquarelle は別モジュールへ委譲。同じ Pixmap に SourceOver で書き込む。
+        if let OrbShape::Aquarelle(params) = opts.shape {
+            // i (cluster index) を seed の差分にして orb 同士で異なるオフセットを得る。
+            render_aquarelle_orb(&mut pixmap, (cx, cy), radius, [r, g, b], i as u64, params);
+            continue;
+        }
         let center_color = Color::from_rgba8(r, g, b, 255);
         // 中間 stop の半透明色は中心と同じ RGB で alpha だけ落とす。
         let mid_color = Color::from_rgba8(r, g, b, 128);

--- a/src/orb.rs
+++ b/src/orb.rs
@@ -36,6 +36,8 @@ pub struct RenderOptions {
     pub blur: f32,
     /// 彩度倍率（1.0 = unchanged）
     pub saturation: f32,
+    /// 背景 RGBA。alpha=0 で透過。デフォルトは黒不透明。
+    pub background: [u8; 4],
 }
 
 impl Default for RenderOptions {
@@ -46,6 +48,7 @@ impl Default for RenderOptions {
             orb_size: 1.0,
             blur: 0.5,
             saturation: 1.0,
+            background: [0, 0, 0, 255],
         }
     }
 }
@@ -64,10 +67,15 @@ pub fn render_static(clusters: &[Cluster], opts: &RenderOptions) -> RgbaImage {
     let orb_size = opts.orb_size.max(0.0);
 
     // Pixmap::new は uninit を 0 埋めしてくれる（つまり全画面が透明）。
-    // 初期化を「黒 不透明」にしたいので明示的に塗る。
+    // 透過 (alpha=0) 指定なら fill をスキップしてその透明初期値を活かす。
+    // 不透明な背景指定なら明示的に塗る。tiny-skia は premultiplied alpha だが、
+    // Color::from_rgba8 は straight 色を内部で premul に直して塗る。
     let mut pixmap =
         Pixmap::new(width, height).expect("pixmap allocation should succeed for >0 dimensions");
-    pixmap.fill(Color::from_rgba8(0, 0, 0, 255));
+    let [br, bg, bb, ba] = opts.background;
+    if ba > 0 {
+        pixmap.fill(Color::from_rgba8(br, bg, bb, ba));
+    }
 
     let base_radius_unit = (width.min(height) as f32) * 0.25 * orb_size;
 
@@ -211,6 +219,7 @@ mod tests {
             blur: 0.5,
             saturation: 1.0,
             orb_size: 1.0,
+            ..Default::default()
         };
         let img = render_static(&[cluster([255, 0, 0], 0.5, 0.5, 1.0)], &opts);
         let center = img.get_pixel(50, 50);
@@ -288,6 +297,7 @@ mod tests {
             blur: 0.5,
             saturation: 0.0,
             orb_size: 1.0,
+            ..Default::default()
         };
         let img = render_static(&[cluster([220, 30, 40], 0.5, 0.5, 1.0)], &opts);
         let center = img.get_pixel(50, 50);
@@ -316,6 +326,7 @@ mod tests {
             saturation: 1.0,
             orb_size: 1.0,
             blur: 0.0,
+            ..Default::default()
         };
         let opts_sharp = RenderOptions {
             blur: 0.0,

--- a/src/style.rs
+++ b/src/style.rs
@@ -32,6 +32,8 @@ pub struct StyleOptions {
     pub blur: f32,
     /// 彩度倍率（1.0 = unchanged）
     pub saturation: f32,
+    /// 背景 RGBA。alpha=0 で透過 SVG / `background-color: transparent`。
+    pub background: [u8; 4],
 }
 
 impl Default for StyleOptions {
@@ -40,6 +42,7 @@ impl Default for StyleOptions {
             orb_size: 1.0,
             blur: 0.5,
             saturation: 1.0,
+            background: [0, 0, 0, 255],
         }
     }
 }
@@ -66,7 +69,19 @@ pub fn render_svg(clusters: &[Cluster], opts: &StyleOptions) -> String {
     s.push_str(&format!(
         "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 {STYLE_WIDTH} {STYLE_HEIGHT}\" width=\"{STYLE_WIDTH}\" height=\"{STYLE_HEIGHT}\">\n"
     ));
-    s.push_str("  <rect width=\"100%\" height=\"100%\" fill=\"black\"/>\n");
+    let [bg_r, bg_g, bg_b, bg_a] = opts.background;
+    if bg_a > 0 {
+        if bg_a == 255 {
+            s.push_str(&format!(
+                "  <rect width=\"100%\" height=\"100%\" fill=\"rgb({bg_r},{bg_g},{bg_b})\"/>\n"
+            ));
+        } else {
+            let opacity = bg_a as f32 / 255.0;
+            s.push_str(&format!(
+                "  <rect width=\"100%\" height=\"100%\" fill=\"rgb({bg_r},{bg_g},{bg_b})\" fill-opacity=\"{opacity:.3}\"/>\n"
+            ));
+        }
+    }
 
     // 描画対象 cluster だけ事前に絞り込んでから defs と circle の両方に使う。
     // weight=0 の cluster で空の gradient ID が defs に残らないようにする。
@@ -131,17 +146,28 @@ pub fn render_css(clusters: &[Cluster], opts: &StyleOptions) -> String {
     // blur=1 → mid=end の 20% （中心が点に近く、緩やかに減衰）
     let mid_factor = (1.0 - blur * 0.8).clamp(0.05, 0.95);
 
+    let [bg_r, bg_g, bg_b, bg_a] = opts.background;
+    let bg_css = if bg_a == 0 {
+        "transparent".to_string()
+    } else if bg_a == 255 {
+        format!("rgb({bg_r}, {bg_g}, {bg_b})")
+    } else {
+        let opacity = bg_a as f32 / 255.0;
+        format!("rgba({bg_r}, {bg_g}, {bg_b}, {opacity:.3})")
+    };
+
     let mut s = String::new();
     s.push_str("/* orber-generated background.\n");
     s.push_str("   Apply to <body> or any block element:\n");
     s.push_str("       body {\n");
     s.push_str("           margin: 0;\n");
     s.push_str("           min-height: 100vh;\n");
-    s.push_str("           background-color: black;\n");
+    s.push_str("           background-color: var(--orber-bg-color);\n");
     s.push_str("           background-image: var(--orber-bg);\n");
     s.push_str("       }\n");
-    s.push_str("   Generated as a CSS variable; reference with var(--orber-bg). */\n");
+    s.push_str("   Generated as CSS variables; reference with var(--orber-bg) and var(--orber-bg-color). */\n");
     s.push_str(":root {\n");
+    s.push_str(&format!("    --orber-bg-color: {bg_css};\n"));
 
     // 有効な gradient だけ集めてから書き出す（最後のカンマを抑制するため）。
     let mut gradients: Vec<String> = Vec::new();
@@ -219,7 +245,7 @@ mod tests {
         assert_eq!(svg.matches("<radialGradient").count(), 6);
         assert_eq!(svg.matches("<circle ").count(), 6);
         assert!(svg.contains("viewBox=\"0 0 1080 1920\""));
-        assert!(svg.contains("<rect width=\"100%\" height=\"100%\" fill=\"black\""));
+        assert!(svg.contains("<rect width=\"100%\" height=\"100%\" fill=\"rgb(0,0,0)\""));
         assert!(svg.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"));
         assert!(svg.ends_with("</svg>\n"));
     }
@@ -360,6 +386,7 @@ mod tests {
                     orb_size,
                     blur,
                     saturation: 1.0,
+                    ..Default::default()
                 };
                 let css = render_css(&extreme_clusters, &opts);
                 let stops = extract_css_stops(&css);

--- a/src/variations.rs
+++ b/src/variations.rs
@@ -1,0 +1,258 @@
+//! バリエーション一括生成のプリセット。
+//!
+//! `--variations N --output-dir DIR` 経由で 1 つの入力から複数案を一気に書き出す
+//! ための「良い感じの 10 案セット」をハードコードする。完全ランダムだとハズレ案が
+//! 混ざるので、まずは編集者が手で選んだセットから始める方針。
+//!
+//! # 設計メモ
+//!
+//! - `VariationSpec` は静止 (Png) / 動画 (Mp4) いずれかに展開する。動画の shape /
+//!   speed / duration_ms は spec 側に持たせ、PNG では shape / speed / duration_ms は
+//!   参照されない（無視）
+//! - フィルタリング時 (`--variations-mode still|video|mixed`) は VariationKind で
+//!   絞り込む。`mixed` がデフォルト
+//! - 出力ファイル名は `{idx:02}_{label}.{ext}` 形式。label は ASCII / underscore
+//!   のみで構成し、シェル安全に保つ
+
+use crate::animate::{MotionShape, MotionSpeed};
+
+/// バリエーションが書き出す出力種別。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariationKind {
+    Png,
+    Mp4,
+}
+
+impl VariationKind {
+    /// 出力ファイルの拡張子（drop-in）。
+    pub fn ext(self) -> &'static str {
+        match self {
+            Self::Png => "png",
+            Self::Mp4 => "mp4",
+        }
+    }
+}
+
+/// `--variations-mode` の選択肢。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariationMode {
+    Still,
+    Video,
+    Mixed,
+}
+
+impl VariationMode {
+    /// この mode で許される `VariationKind` か。
+    pub fn accepts(self, kind: VariationKind) -> bool {
+        match self {
+            Self::Mixed => true,
+            Self::Still => kind == VariationKind::Png,
+            Self::Video => kind == VariationKind::Mp4,
+        }
+    }
+}
+
+/// 1 つのバリエーション案。
+#[derive(Debug, Clone, Copy)]
+pub struct VariationSpec {
+    pub label: &'static str,
+    pub kind: VariationKind,
+    /// 動画用の軌道形（Png では参照されない）。
+    pub shape: MotionShape,
+    /// 動画用の速度（Png では参照されない）。
+    pub speed: MotionSpeed,
+    pub orb_size: f32,
+    pub blur: f32,
+    pub saturation: f32,
+    pub seed: u64,
+    /// 動画用の長さ（ms）。Png では参照されない。
+    pub duration_ms: u64,
+}
+
+/// デフォルト 10 案セット。
+///
+/// 編集者の手選別: 静止 ×3 / 微動 ×4 / 呼吸 ×1 / リサジュー ×2 = 10。
+/// 動画は 4 秒で短尺寄り。手元で N 案見て採用したいものを選ぶ UX を想定。
+pub const DEFAULT_VARIATIONS: &[VariationSpec] = &[
+    VariationSpec {
+        label: "still_warm",
+        kind: VariationKind::Png,
+        shape: MotionShape::Still,
+        speed: MotionSpeed::Slow,
+        orb_size: 1.0,
+        blur: 0.5,
+        saturation: 1.2,
+        seed: 1,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "still_cool",
+        kind: VariationKind::Png,
+        shape: MotionShape::Still,
+        speed: MotionSpeed::Slow,
+        orb_size: 1.2,
+        blur: 0.7,
+        saturation: 0.8,
+        seed: 2,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "still_punch",
+        kind: VariationKind::Png,
+        shape: MotionShape::Still,
+        speed: MotionSpeed::Slow,
+        orb_size: 0.8,
+        blur: 0.3,
+        saturation: 1.5,
+        seed: 3,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "drift_vertical_subtle",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Vertical,
+        speed: MotionSpeed::Subtle,
+        orb_size: 1.2,
+        blur: 0.6,
+        saturation: 1.0,
+        seed: 4,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "drift_horizontal_subtle",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Horizontal,
+        speed: MotionSpeed::Subtle,
+        orb_size: 1.0,
+        blur: 0.5,
+        saturation: 1.0,
+        seed: 5,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "drift_diagonal_subtle",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Diagonal,
+        speed: MotionSpeed::Subtle,
+        orb_size: 1.1,
+        blur: 0.5,
+        saturation: 1.1,
+        seed: 6,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "twinkle_subtle",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Twinkle,
+        speed: MotionSpeed::Subtle,
+        orb_size: 1.0,
+        blur: 0.5,
+        saturation: 1.0,
+        seed: 7,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "breathe_slow",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Breathe,
+        speed: MotionSpeed::Slow,
+        orb_size: 1.0,
+        blur: 0.5,
+        saturation: 1.0,
+        seed: 8,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "lissajous_slow",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Lissajous,
+        speed: MotionSpeed::Slow,
+        orb_size: 1.0,
+        blur: 0.5,
+        saturation: 1.1,
+        seed: 9,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "lissajous_lively",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Lissajous,
+        speed: MotionSpeed::Lively,
+        orb_size: 0.9,
+        blur: 0.4,
+        saturation: 1.2,
+        seed: 10,
+        duration_ms: 4000,
+    },
+];
+
+/// 上限 N と mode で `DEFAULT_VARIATIONS` から実際に書き出す spec を選び出す。
+///
+/// `mode` で受け付ける kind だけを残し、上から `n` 件取る。要求された n が
+/// 残り件数より多い場合はあるだけ返す（要求数を満たせなかったかは呼び出し側で判定）。
+pub fn select_specs(n: usize, mode: VariationMode) -> Vec<VariationSpec> {
+    DEFAULT_VARIATIONS
+        .iter()
+        .copied()
+        .filter(|s| mode.accepts(s.kind))
+        .take(n)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_set_has_ten_specs() {
+        assert_eq!(DEFAULT_VARIATIONS.len(), 10);
+    }
+
+    #[test]
+    fn default_set_balance() {
+        // 静止と動画の混合になっていること（mixed UX が成立する）。
+        let png = DEFAULT_VARIATIONS
+            .iter()
+            .filter(|s| s.kind == VariationKind::Png)
+            .count();
+        let mp4 = DEFAULT_VARIATIONS
+            .iter()
+            .filter(|s| s.kind == VariationKind::Mp4)
+            .count();
+        assert!(png >= 1, "expected at least 1 still variation");
+        assert!(mp4 >= 1, "expected at least 1 video variation");
+    }
+
+    #[test]
+    fn labels_unique_and_ascii_safe() {
+        let mut seen = std::collections::HashSet::new();
+        for s in DEFAULT_VARIATIONS {
+            assert!(seen.insert(s.label), "duplicate label: {}", s.label);
+            for ch in s.label.chars() {
+                assert!(
+                    ch.is_ascii_alphanumeric() || ch == '_',
+                    "non shell-safe char in label {:?}: {ch:?}",
+                    s.label
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn select_specs_respects_mode() {
+        let still = select_specs(10, VariationMode::Still);
+        assert!(still.iter().all(|s| s.kind == VariationKind::Png));
+        let video = select_specs(10, VariationMode::Video);
+        assert!(video.iter().all(|s| s.kind == VariationKind::Mp4));
+        let mixed = select_specs(10, VariationMode::Mixed);
+        assert_eq!(mixed.len(), 10);
+    }
+
+    #[test]
+    fn select_specs_respects_n() {
+        let three = select_specs(3, VariationMode::Mixed);
+        assert_eq!(three.len(), 3);
+        let zero = select_specs(0, VariationMode::Mixed);
+        assert_eq!(zero.len(), 0);
+    }
+}

--- a/src/video.rs
+++ b/src/video.rs
@@ -78,6 +78,8 @@ pub struct VideoOptions {
     pub saturation: f32,
     pub motion: MotionPreset,
     pub seed: u64,
+    /// 背景 RGBA。動画は yuv420p 制約で alpha 不可なので呼び出し側で透過を弾くこと。
+    pub background: [u8; 4],
 }
 
 impl Default for VideoOptions {
@@ -89,6 +91,7 @@ impl Default for VideoOptions {
             saturation: a.saturation,
             motion: a.motion,
             seed: a.seed,
+            background: a.background,
         }
     }
 }
@@ -190,6 +193,7 @@ pub fn render_video(
         saturation: opts.saturation,
         motion: opts.motion,
         seed: opts.seed,
+        background: opts.background,
     };
 
     let temp_dir = tempfile::TempDir::new()?;

--- a/src/video.rs
+++ b/src/video.rs
@@ -16,6 +16,7 @@
 
 use crate::animate::{render_frame, AnimateOptions, MotionShape, MotionSpeed};
 use crate::cluster::Cluster;
+use crate::orb::OrbShape;
 use crate::output_mode::OutputMode;
 use std::io;
 use std::path::Path;
@@ -81,6 +82,8 @@ pub struct VideoOptions {
     pub seed: u64,
     /// 背景 RGBA。動画は yuv420p 制約で alpha 不可なので呼び出し側で透過を弾くこと。
     pub background: [u8; 4],
+    /// orb の描画形式。
+    pub shape: OrbShape,
 }
 
 impl Default for VideoOptions {
@@ -94,6 +97,7 @@ impl Default for VideoOptions {
             motion_speed: a.motion_speed,
             seed: a.seed,
             background: a.background,
+            shape: a.shape,
         }
     }
 }
@@ -197,6 +201,7 @@ pub fn render_video(
         motion_speed: opts.motion_speed,
         seed: opts.seed,
         background: opts.background,
+        shape: opts.shape,
     };
 
     let temp_dir = tempfile::TempDir::new()?;

--- a/src/video.rs
+++ b/src/video.rs
@@ -14,7 +14,7 @@
 //! - ffmpeg が PATH に無い場合は [`VideoError::FfmpegNotFound`] を返す。
 //!   ユーザー側でインストール案内を出す前提。
 
-use crate::animate::{render_frame, AnimateOptions, MotionPreset};
+use crate::animate::{render_frame, AnimateOptions, MotionShape, MotionSpeed};
 use crate::cluster::Cluster;
 use crate::output_mode::OutputMode;
 use std::io;
@@ -76,7 +76,8 @@ pub struct VideoOptions {
     pub orb_size: f32,
     pub blur: f32,
     pub saturation: f32,
-    pub motion: MotionPreset,
+    pub motion_shape: MotionShape,
+    pub motion_speed: MotionSpeed,
     pub seed: u64,
     /// 背景 RGBA。動画は yuv420p 制約で alpha 不可なので呼び出し側で透過を弾くこと。
     pub background: [u8; 4],
@@ -89,7 +90,8 @@ impl Default for VideoOptions {
             orb_size: a.orb_size,
             blur: a.blur,
             saturation: a.saturation,
-            motion: a.motion,
+            motion_shape: a.motion_shape,
+            motion_speed: a.motion_speed,
             seed: a.seed,
             background: a.background,
         }
@@ -191,7 +193,8 @@ pub fn render_video(
         orb_size: opts.orb_size,
         blur: opts.blur,
         saturation: opts.saturation,
-        motion: opts.motion,
+        motion_shape: opts.motion_shape,
+        motion_speed: opts.motion_speed,
         seed: opts.seed,
         background: opts.background,
     };
@@ -357,7 +360,8 @@ mod tests {
         assert_eq!(v.orb_size, a.orb_size);
         assert_eq!(v.blur, a.blur);
         assert_eq!(v.saturation, a.saturation);
-        assert_eq!(v.motion, a.motion);
+        assert_eq!(v.motion_shape, a.motion_shape);
+        assert_eq!(v.motion_speed, a.motion_speed);
         assert_eq!(v.seed, a.seed);
     }
 }


### PR DESCRIPTION
Stacked on top of #26 (PR for #23).

## Summary
- \`src/aquarelle/mod.rs\` 新設。独立 crate 化を見据えて orber 本体への依存を持たない API（primitive のみ）
- \`AquarelleParams { bleed, bloom, offset, halo }\` の 4 要素を独立に持つ
- \`OrbShape::Aquarelle(params)\` を \`RenderOptions\` / \`AnimateOptions\` / \`VideoOptions\` に通して全経路で有効化
- CLI に \`--shape aquarelle\` と \`--aquarelle-{bleed,bloom,offset,halo}\` を追加

## Test plan
- [x] cargo test (70 unit + 2 cli + 1 doc 全 pass)
- [x] aquarelle 単体: bloom=1 で中心の青成分が増える / 各要素を上げるとピクセル差分が出ることを検証
- [x] CLI 実走: \`--shape circle\` vs \`--shape aquarelle\` で出力差分 16M (max 111/255)

Closes #8