### PR TITLE
feat: バリエーション一括生成 CLI (#23)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@ pub mod cluster;
 pub mod orb;
 pub mod output_mode;
 pub mod style;
+pub mod variations;
 pub mod video;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 use clap::{Parser, ValueEnum};
 use orber::animate::{MotionPreset, MotionShape, MotionSpeed};
 use orber::background::{resolve as resolve_background, Background};
-use orber::cluster::extract_clusters;
+use orber::cluster::{extract_clusters, Cluster};
 use orber::orb::{render_static, RenderOptions};
 use orber::output_mode::OutputMode;
 use orber::style::{render_css, render_svg, StyleOptions};
+use orber::variations::{select_specs, VariationKind, VariationMode, VariationSpec};
 use orber::video::{render_video, VideoCodec, VideoOptions};
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -64,6 +65,24 @@ enum CliMotionSpeed {
     Lively,
 }
 
+/// `--variations-mode` の選択肢。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CliVariationMode {
+    Still,
+    Video,
+    Mixed,
+}
+
+impl From<CliVariationMode> for VariationMode {
+    fn from(m: CliVariationMode) -> Self {
+        match m {
+            CliVariationMode::Still => VariationMode::Still,
+            CliVariationMode::Video => VariationMode::Video,
+            CliVariationMode::Mixed => VariationMode::Mixed,
+        }
+    }
+}
+
 impl From<CliMotionSpeed> for MotionSpeed {
     fn from(s: CliMotionSpeed) -> Self {
         match s {
@@ -93,8 +112,23 @@ struct Cli {
     input: PathBuf,
 
     /// Output file. Format inferred from extension: png, webp, mp4, webm, svg, css.
+    /// Required for the single-output mode (omitted when --variations is set).
     #[arg(short, long)]
-    output: PathBuf,
+    output: Option<PathBuf>,
+
+    /// Generate N variations of the input under --output-dir instead of a single file.
+    /// Requires --output-dir. Variations are picked from a curated preset table
+    /// (still ×3, drift ×4, breathe ×1, lissajous ×2 = up to 10).
+    #[arg(long)]
+    variations: Option<usize>,
+
+    /// Output directory for --variations mode. Created if it does not exist.
+    #[arg(long)]
+    output_dir: Option<PathBuf>,
+
+    /// Filter for --variations: only stills, only videos, or mixed (default).
+    #[arg(long, value_enum, default_value_t = CliVariationMode::Mixed)]
+    variations_mode: CliVariationMode,
 
     /// Random seed for reproducible output.
     #[arg(long)]
@@ -145,16 +179,28 @@ struct Cli {
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    let mode = match OutputMode::from_path(&cli.output) {
-        Ok(m) => m,
+    let bg: Background = match cli.background.parse() {
+        Ok(b) => b,
         Err(e) => {
             eprintln!("orber: {e}");
             return ExitCode::from(2);
         }
     };
 
-    let bg: Background = match cli.background.parse() {
-        Ok(b) => b,
+    if let Some(n) = cli.variations {
+        return render_variations(&cli, n, bg);
+    }
+
+    let output = match &cli.output {
+        Some(p) => p.clone(),
+        None => {
+            eprintln!("orber: either --output FILE or --variations N --output-dir DIR is required");
+            return ExitCode::from(2);
+        }
+    };
+
+    let mode = match OutputMode::from_path(&output) {
+        Ok(m) => m,
         Err(e) => {
             eprintln!("orber: {e}");
             return ExitCode::from(2);
@@ -168,12 +214,12 @@ fn main() -> ExitCode {
             );
             return ExitCode::from(2);
         }
-        return render_video_path(&cli, codec, bg);
+        return render_video_path(&cli, &output, codec, bg);
     }
 
     match mode {
-        OutputMode::Png => render_png(&cli, bg),
-        OutputMode::Svg | OutputMode::Css => render_style_path(&cli, mode, bg),
+        OutputMode::Png => render_png(&cli, &output, bg),
+        OutputMode::Svg | OutputMode::Css => render_style_path(&cli, &output, mode, bg),
         _ => {
             eprintln!("orber: output mode {mode:?} is not yet implemented");
             ExitCode::from(1)
@@ -196,7 +242,7 @@ fn resolve_motion(cli: &Cli) -> (MotionShape, MotionSpeed) {
     (shape, speed)
 }
 
-fn render_style_path(cli: &Cli, mode: OutputMode, bg: Background) -> ExitCode {
+fn render_style_path(cli: &Cli, output: &PathBuf, mode: OutputMode, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -230,18 +276,15 @@ fn render_style_path(cli: &Cli, mode: OutputMode, bg: Background) -> ExitCode {
         _ => unreachable!("render_style_path called with non-style mode {mode:?}"),
     };
 
-    if let Err(e) = std::fs::write(&cli.output, content) {
-        eprintln!(
-            "orber: failed to write output {}: {e}",
-            cli.output.display()
-        );
+    if let Err(e) = std::fs::write(output, content) {
+        eprintln!("orber: failed to write output {}: {e}", output.display());
         return ExitCode::from(2);
     }
-    eprintln!("orber: wrote {}", cli.output.display());
+    eprintln!("orber: wrote {}", output.display());
     ExitCode::SUCCESS
 }
 
-fn render_video_path(cli: &Cli, codec: VideoCodec, bg: Background) -> ExitCode {
+fn render_video_path(cli: &Cli, output: &PathBuf, codec: VideoCodec, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -273,15 +316,15 @@ fn render_video_path(cli: &Cli, codec: VideoCodec, bg: Background) -> ExitCode {
     };
 
     // 4. 動画書き出し。進捗とフレーム数の検証は render_video が担当する。
-    if let Err(e) = render_video(&clusters, &opts, &cli.output, cli.duration_ms, codec) {
+    if let Err(e) = render_video(&clusters, &opts, output, cli.duration_ms, codec) {
         eprintln!("orber: video render failed: {e}");
         return ExitCode::from(2);
     }
-    eprintln!("orber: wrote {}", cli.output.display());
+    eprintln!("orber: wrote {}", output.display());
     ExitCode::SUCCESS
 }
 
-fn render_png(cli: &Cli, bg: Background) -> ExitCode {
+fn render_png(cli: &Cli, output: &PathBuf, bg: Background) -> ExitCode {
     // 1. 入力画像を読み込み RGB8 に正規化。
     let img = match image::open(&cli.input) {
         Ok(img) => img.to_rgb8(),
@@ -314,15 +357,120 @@ fn render_png(cli: &Cli, bg: Background) -> ExitCode {
     let out = render_static(&clusters, &opts);
 
     // 5. 保存。
-    if let Err(e) = out.save(&cli.output) {
+    if let Err(e) = out.save(output) {
+        eprintln!("orber: failed to write output {}: {e}", output.display());
+        return ExitCode::from(2);
+    }
+    eprintln!("orber: wrote {}", output.display());
+    ExitCode::SUCCESS
+}
+
+/// `--variations` 経路。`output_dir` を作って各 spec で逐次書き出す。
+fn render_variations(cli: &Cli, n: usize, bg: Background) -> ExitCode {
+    let dir = match &cli.output_dir {
+        Some(d) => d.clone(),
+        None => {
+            eprintln!("orber: --variations requires --output-dir DIR");
+            return ExitCode::from(2);
+        }
+    };
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("orber: failed to create output dir {}: {e}", dir.display());
+        return ExitCode::from(2);
+    }
+
+    // 入力 + クラスタは全 spec で共有。
+    let img = match image::open(&cli.input) {
+        Ok(img) => img.to_rgb8(),
+        Err(e) => {
+            eprintln!("orber: failed to read input {}: {e}", cli.input.display());
+            return ExitCode::from(2);
+        }
+    };
+    let clusters = match extract_clusters(&img, 6) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("orber: cluster extraction failed: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let resolved_bg = resolve_background(&img, bg);
+
+    let specs = select_specs(n, cli.variations_mode.into());
+    if specs.is_empty() {
         eprintln!(
-            "orber: failed to write output {}: {e}",
-            cli.output.display()
+            "orber: no variations matched (requested n={n}, mode={:?})",
+            cli.variations_mode
         );
         return ExitCode::from(2);
     }
-    eprintln!("orber: wrote {}", cli.output.display());
+
+    let total = specs.len();
+    if total < n {
+        eprintln!(
+            "orber: only {total} variation(s) available for mode {:?} (requested {n})",
+            cli.variations_mode
+        );
+    }
+
+    for (i, spec) in specs.iter().enumerate() {
+        let idx = i + 1;
+        let filename = format!("{idx:02}_{}.{}", spec.label, spec.kind.ext());
+        let out_path = dir.join(&filename);
+        eprintln!("orber: variation {idx}/{total} ({filename})");
+        // 動画 + 透過は不可（yuv420p）。bg が transparent なら black に置換して進める。
+        let spec_bg = if spec.kind == VariationKind::Mp4 && resolved_bg[3] == 0 {
+            [0, 0, 0, 255]
+        } else {
+            resolved_bg
+        };
+        let result = render_one_variation(&clusters, spec, &out_path, spec_bg);
+        if let Err(msg) = result {
+            eprintln!("orber: variation {idx} ({filename}) failed: {msg}");
+            return ExitCode::from(2);
+        }
+    }
     ExitCode::SUCCESS
+}
+
+fn render_one_variation(
+    clusters: &[Cluster],
+    spec: &VariationSpec,
+    out_path: &std::path::Path,
+    bg_rgba: [u8; 4],
+) -> Result<(), String> {
+    match spec.kind {
+        VariationKind::Png => {
+            let opts = RenderOptions {
+                orb_size: spec.orb_size,
+                blur: spec.blur,
+                saturation: spec.saturation,
+                background: bg_rgba,
+                ..RenderOptions::default()
+            };
+            let img = render_static(clusters, &opts);
+            img.save(out_path).map_err(|e| e.to_string())
+        }
+        VariationKind::Mp4 => {
+            let opts = VideoOptions {
+                orb_size: spec.orb_size,
+                blur: spec.blur,
+                saturation: spec.saturation,
+                motion_shape: spec.shape,
+                motion_speed: spec.speed,
+                seed: spec.seed,
+                background: bg_rgba,
+            };
+            render_video(
+                clusters,
+                &opts,
+                out_path,
+                spec.duration_ms,
+                VideoCodec::H264,
+            )
+            .map_err(|e| e.to_string())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/variations.rs
+++ b/src/variations.rs
@@ -1,0 +1,258 @@
+//! バリエーション一括生成のプリセット。
+//!
+//! `--variations N --output-dir DIR` 経由で 1 つの入力から複数案を一気に書き出す
+//! ための「良い感じの 10 案セット」をハードコードする。完全ランダムだとハズレ案が
+//! 混ざるので、まずは編集者が手で選んだセットから始める方針。
+//!
+//! # 設計メモ
+//!
+//! - `VariationSpec` は静止 (Png) / 動画 (Mp4) いずれかに展開する。動画の shape /
+//!   speed / duration_ms は spec 側に持たせ、PNG では shape / speed / duration_ms は
+//!   参照されない（無視）
+//! - フィルタリング時 (`--variations-mode still|video|mixed`) は VariationKind で
+//!   絞り込む。`mixed` がデフォルト
+//! - 出力ファイル名は `{idx:02}_{label}.{ext}` 形式。label は ASCII / underscore
+//!   のみで構成し、シェル安全に保つ
+
+use crate::animate::{MotionShape, MotionSpeed};
+
+/// バリエーションが書き出す出力種別。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariationKind {
+    Png,
+    Mp4,
+}
+
+impl VariationKind {
+    /// 出力ファイルの拡張子（drop-in）。
+    pub fn ext(self) -> &'static str {
+        match self {
+            Self::Png => "png",
+            Self::Mp4 => "mp4",
+        }
+    }
+}
+
+/// `--variations-mode` の選択肢。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariationMode {
+    Still,
+    Video,
+    Mixed,
+}
+
+impl VariationMode {
+    /// この mode で許される `VariationKind` か。
+    pub fn accepts(self, kind: VariationKind) -> bool {
+        match self {
+            Self::Mixed => true,
+            Self::Still => kind == VariationKind::Png,
+            Self::Video => kind == VariationKind::Mp4,
+        }
+    }
+}
+
+/// 1 つのバリエーション案。
+#[derive(Debug, Clone, Copy)]
+pub struct VariationSpec {
+    pub label: &'static str,
+    pub kind: VariationKind,
+    /// 動画用の軌道形（Png では参照されない）。
+    pub shape: MotionShape,
+    /// 動画用の速度（Png では参照されない）。
+    pub speed: MotionSpeed,
+    pub orb_size: f32,
+    pub blur: f32,
+    pub saturation: f32,
+    pub seed: u64,
+    /// 動画用の長さ（ms）。Png では参照されない。
+    pub duration_ms: u64,
+}
+
+/// デフォルト 10 案セット。
+///
+/// 編集者の手選別: 静止 ×3 / 微動 ×4 / 呼吸 ×1 / リサジュー ×2 = 10。
+/// 動画は 4 秒で短尺寄り。手元で N 案見て採用したいものを選ぶ UX を想定。
+pub const DEFAULT_VARIATIONS: &[VariationSpec] = &[
+    VariationSpec {
+        label: "still_warm",
+        kind: VariationKind::Png,
+        shape: MotionShape::Still,
+        speed: MotionSpeed::Slow,
+        orb_size: 1.0,
+        blur: 0.5,
+        saturation: 1.2,
+        seed: 1,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "still_cool",
+        kind: VariationKind::Png,
+        shape: MotionShape::Still,
+        speed: MotionSpeed::Slow,
+        orb_size: 1.2,
+        blur: 0.7,
+        saturation: 0.8,
+        seed: 2,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "still_punch",
+        kind: VariationKind::Png,
+        shape: MotionShape::Still,
+        speed: MotionSpeed::Slow,
+        orb_size: 0.8,
+        blur: 0.3,
+        saturation: 1.5,
+        seed: 3,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "drift_vertical_subtle",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Vertical,
+        speed: MotionSpeed::Subtle,
+        orb_size: 1.2,
+        blur: 0.6,
+        saturation: 1.0,
+        seed: 4,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "drift_horizontal_subtle",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Horizontal,
+        speed: MotionSpeed::Subtle,
+        orb_size: 1.0,
+        blur: 0.5,
+        saturation: 1.0,
+        seed: 5,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "drift_diagonal_subtle",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Diagonal,
+        speed: MotionSpeed::Subtle,
+        orb_size: 1.1,
+        blur: 0.5,
+        saturation: 1.1,
+        seed: 6,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "twinkle_subtle",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Twinkle,
+        speed: MotionSpeed::Subtle,
+        orb_size: 1.0,
+        blur: 0.5,
+        saturation: 1.0,
+        seed: 7,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "breathe_slow",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Breathe,
+        speed: MotionSpeed::Slow,
+        orb_size: 1.0,
+        blur: 0.5,
+        saturation: 1.0,
+        seed: 8,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "lissajous_slow",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Lissajous,
+        speed: MotionSpeed::Slow,
+        orb_size: 1.0,
+        blur: 0.5,
+        saturation: 1.1,
+        seed: 9,
+        duration_ms: 4000,
+    },
+    VariationSpec {
+        label: "lissajous_lively",
+        kind: VariationKind::Mp4,
+        shape: MotionShape::Lissajous,
+        speed: MotionSpeed::Lively,
+        orb_size: 0.9,
+        blur: 0.4,
+        saturation: 1.2,
+        seed: 10,
+        duration_ms: 4000,
+    },
+];
+
+/// 上限 N と mode で `DEFAULT_VARIATIONS` から実際に書き出す spec を選び出す。
+///
+/// `mode` で受け付ける kind だけを残し、上から `n` 件取る。要求された n が
+/// 残り件数より多い場合はあるだけ返す（要求数を満たせなかったかは呼び出し側で判定）。
+pub fn select_specs(n: usize, mode: VariationMode) -> Vec<VariationSpec> {
+    DEFAULT_VARIATIONS
+        .iter()
+        .copied()
+        .filter(|s| mode.accepts(s.kind))
+        .take(n)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_set_has_ten_specs() {
+        assert_eq!(DEFAULT_VARIATIONS.len(), 10);
+    }
+
+    #[test]
+    fn default_set_balance() {
+        // 静止と動画の混合になっていること（mixed UX が成立する）。
+        let png = DEFAULT_VARIATIONS
+            .iter()
+            .filter(|s| s.kind == VariationKind::Png)
+            .count();
+        let mp4 = DEFAULT_VARIATIONS
+            .iter()
+            .filter(|s| s.kind == VariationKind::Mp4)
+            .count();
+        assert!(png >= 1, "expected at least 1 still variation");
+        assert!(mp4 >= 1, "expected at least 1 video variation");
+    }
+
+    #[test]
+    fn labels_unique_and_ascii_safe() {
+        let mut seen = std::collections::HashSet::new();
+        for s in DEFAULT_VARIATIONS {
+            assert!(seen.insert(s.label), "duplicate label: {}", s.label);
+            for ch in s.label.chars() {
+                assert!(
+                    ch.is_ascii_alphanumeric() || ch == '_',
+                    "non shell-safe char in label {:?}: {ch:?}",
+                    s.label
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn select_specs_respects_mode() {
+        let still = select_specs(10, VariationMode::Still);
+        assert!(still.iter().all(|s| s.kind == VariationKind::Png));
+        let video = select_specs(10, VariationMode::Video);
+        assert!(video.iter().all(|s| s.kind == VariationKind::Mp4));
+        let mixed = select_specs(10, VariationMode::Mixed);
+        assert_eq!(mixed.len(), 10);
+    }
+
+    #[test]
+    fn select_specs_respects_n() {
+        let three = select_specs(3, VariationMode::Mixed);
+        assert_eq!(three.len(), 3);
+        let zero = select_specs(0, VariationMode::Mixed);
+        assert_eq!(zero.len(), 0);
+    }
+}


### PR DESCRIPTION
Re-opened against main after #28 merged.

## Summary
- `--variations N --output-dir DIR` で 1 入力から複数案を一気に書き出す
- `src/variations.rs` に `VariationSpec` 配列 (`DEFAULT_VARIATIONS`) を定義し、編集者が手で選んだ 10 案 (静止 ×3 / 微動 ×4 / 呼吸 ×1 / リサジュー ×2)
- `--variations-mode still|video|mixed` (既定 mixed) で絞り込み

Closes #23