### PR TITLE
refactor: OutputMode のエラー型を thiserror 化 (#14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "y4m",
 ]
@@ -789,6 +789,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "tempfile",
+ "thiserror 1.0.69",
  "tiny-skia",
 ]
 
@@ -1058,7 +1059,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -1200,11 +1201,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ palette = "0.7"
 rand = "0.8"
 rand_chacha = "0.3"
 tempfile = "3"
+thiserror = "1"
 tiny-skia = "0.11"
 
 [dev-dependencies]

--- a/src/output_mode.rs
+++ b/src/output_mode.rs
@@ -6,7 +6,8 @@
 //! user gets immediate feedback instead of running a full render and
 //! producing a file the rest of the toolchain cannot consume.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
 
 /// Output rendering mode inferred from the output file extension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -25,12 +26,29 @@ pub enum OutputMode {
     Css,
 }
 
+const SUPPORTED_EXTS: &str = "png, webp, mp4, webm, svg, css";
+
+/// Errors returned by [`OutputMode::from_path`].
+///
+/// Carrying the offending value (path / extension) instead of a free-form
+/// `String` lets call sites pattern-match on the failure mode rather than
+/// scraping error messages.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum OutputModeError {
+    /// Path has no usable extension at all (e.g. `"noext"`, `".png"` hidden
+    /// files where `Path::extension()` returns `None`).
+    #[error("output path {} has no extension; expected one of {SUPPORTED_EXTS}", path.display())]
+    MissingExtension { path: PathBuf },
+    /// Extension is present but does not match a supported output format.
+    #[error("unsupported output extension {ext}; expected one of {SUPPORTED_EXTS}")]
+    UnsupportedExtension { ext: String },
+}
+
 impl OutputMode {
     /// Infer the [`OutputMode`] from a file path's extension.
     ///
-    /// Matching is case-insensitive. Returns an `Err` describing the
-    /// problem if the extension is missing or not one of the supported
-    /// formats.
+    /// Matching is case-insensitive. Returns [`OutputModeError`] if the
+    /// extension is missing or not one of the supported formats.
     ///
     /// ```
     /// use orber::output_mode::OutputMode;
@@ -40,16 +58,13 @@ impl OutputMode {
     /// assert!(OutputMode::from_path(Path::new(".png")).is_err()); // hidden file: extension is None
     /// assert!(OutputMode::from_path(Path::new("noext")).is_err());
     /// ```
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, String> {
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, OutputModeError> {
         let path = path.as_ref();
         let ext = path
             .extension()
             .and_then(|e| e.to_str())
-            .ok_or_else(|| {
-                format!(
-                    "output path {} has no extension; expected one of png, webp, mp4, webm, svg, css",
-                    path.display()
-                )
+            .ok_or_else(|| OutputModeError::MissingExtension {
+                path: path.to_path_buf(),
             })?
             .to_ascii_lowercase();
 
@@ -60,9 +75,9 @@ impl OutputMode {
             "webm" => Ok(OutputMode::Webm),
             "svg" => Ok(OutputMode::Svg),
             "css" => Ok(OutputMode::Css),
-            other => Err(format!(
-                "unsupported output extension {other}; expected one of png, webp, mp4, webm, svg, css"
-            )),
+            other => Err(OutputModeError::UnsupportedExtension {
+                ext: other.to_string(),
+            }),
         }
     }
 }
@@ -109,16 +124,21 @@ mod tests {
     #[test]
     fn unsupported_extension() {
         let err = OutputMode::from_path("a.gif").unwrap_err();
-        assert!(
-            err.contains("gif"),
-            "error should mention the bad ext: {err}"
-        );
+        match err {
+            OutputModeError::UnsupportedExtension { ext } => assert_eq!(ext, "gif"),
+            other => panic!("expected UnsupportedExtension, got {other:?}"),
+        }
     }
 
     #[test]
     fn missing_extension() {
         let err = OutputMode::from_path("noext").unwrap_err();
-        assert!(err.contains("no extension"), "got: {err}");
+        match err {
+            OutputModeError::MissingExtension { path } => {
+                assert_eq!(path.to_str().unwrap(), "noext");
+            }
+            other => panic!("expected MissingExtension, got {other:?}"),
+        }
     }
 
     #[test]
@@ -132,21 +152,40 @@ mod tests {
     #[test]
     fn nested_path_no_extension() {
         let err = OutputMode::from_path("dir/sub/clip").unwrap_err();
-        assert!(err.contains("no extension"), "got: {err}");
+        assert!(matches!(err, OutputModeError::MissingExtension { .. }));
     }
 
     #[test]
     fn trailing_dot() {
         // "foo." yields Some("") from Path::extension(), so it falls through
-        // to the unsupported branch (not the missing-extension branch).
+        // to the UnsupportedExtension branch (not MissingExtension).
         let err = OutputMode::from_path("foo.").unwrap_err();
-        assert!(err.contains("unsupported"), "got: {err}");
+        match err {
+            OutputModeError::UnsupportedExtension { ext } => assert_eq!(ext, ""),
+            other => panic!("expected UnsupportedExtension, got {other:?}"),
+        }
     }
 
     #[test]
     fn multi_dot_unsupported_extension() {
         // Only the final ".bak" counts as the extension.
         let err = OutputMode::from_path("foo.PNG.bak").unwrap_err();
-        assert!(err.contains("bak"), "error should mention bak: {err}");
+        match err {
+            OutputModeError::UnsupportedExtension { ext } => assert_eq!(ext, "bak"),
+            other => panic!("expected UnsupportedExtension, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn display_messages_remain_user_facing() {
+        // ユーザー向けメッセージが拡張子と「expected one of ...」を含むことを保証する
+        // （main.rs での表示と互換）。
+        let missing = OutputMode::from_path("noext").unwrap_err().to_string();
+        assert!(missing.contains("no extension"), "got: {missing}");
+        assert!(missing.contains("png"), "should list supported: {missing}");
+
+        let bad = OutputMode::from_path("a.gif").unwrap_err().to_string();
+        assert!(bad.contains("gif"), "got: {bad}");
+        assert!(bad.contains("png"), "should list supported: {bad}");
     }
 }


### PR DESCRIPTION
## Summary
- `OutputMode::from_path` の戻り値を `Result<Self, String>` から `Result<Self, OutputModeError>` に変更
- `MissingExtension { path }` / `UnsupportedExtension { ext }` の 2 variant
- `Display` は thiserror で実装。表示メッセージは現状互換（"no extension" / "unsupported" / supported list）

## Test plan
- [x] cargo test (71 unit + 2 cli + 1 doc 全 pass)

Closes #14