### PR TITLE
feat: orber#54 ドロップエリアにサムネイル表示 + 差し替え可視化

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -63,9 +63,30 @@ No bold anywhere. Headers are deliberately light.
 - Background: transparent
 - Border: `1px dashed hairline`, radius `0.75rem`
 - Padding: `2.5rem` (40px) vertical, `2rem` (32px) horizontal
-- Drag-over state: border swaps to `fg-muted`, no fill change
-- Text: placeholder uses `fg-subtle`, picked filename uses `fg`
-- Cursor: `pointer`
+- Hover state (empty): border swaps to `fg-muted`
+- Drag-over state: border swaps to `fg`, fill `glass-bg`
+- Text: placeholder uses `fg-muted`, picked filename uses `fg`
+- Cursor: `pointer` (always — even when filled with a thumbnail; the area
+  remains an active drop target / file picker trigger)
+- Focus: when the inner `<input type=file>` is focused, the surrounding
+  `<label>` gets `focus-within:border-focusRing`
+
+#### Filled state (thumbnail)
+
+After a file is picked, the drop area shows the source image as a thumbnail
+**without losing its drop-target framing**. The dashed border, padding, and
+cursor are kept exactly as in the empty state — only the inner content swaps.
+
+- Thumbnail: `<img>`, centered, `object-contain`, `max-h-40` (160px) so the
+  drop frame keeps a consistent height regardless of source aspect
+- Replace overlay: a fade-in layer above the thumbnail
+  - Hover (group): `opacity 0 → 1`, fill `bg/40` (40% black scrim), centered
+    `Replace` / `差し替え` label in `font-display`, `text-sm`, `tracking-wide`,
+    color `fg`
+  - Drag-over: overlay fully opaque with fill `fg/5` (faint white wash) and
+    no label — the active drop affordance is the white border and the wash
+- The overlay is `pointer-events: none` so the underlying `<label>` keeps
+  receiving drag / click events
 
 ### Button (Glass)
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ randomly per drop, so the same image yields a different layout each time. The fi
 **half** of the batch (5 tiles) are static PNGs; the **last 5 tiles** are H.264 mp4
 loops generated client-side via WebCodecs and inlined as `<video muted autoplay
 playsinline loop>`, so they animate continuously in the grid without any user
-interaction. Pick favorites with the ✓ toggle and download single (PNG / MP4) or
-multi (mixed-extension ZIP).
+interaction. Pick favorites with the corner-marker toggle and download single
+(PNG / MP4) or multi (mixed-extension ZIP). After drop, the source image stays
+in the drop zone as a thumbnail; hover (or drag a new file over it) to swap it
+out without touching any other control.
 
 The GUI runs entirely client-side. The `orber-wasm` crate handles rendering
 (measured ≈ 220 KB gzipped at v0.3.0); H.264 encoding is done in the browser via

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -38,6 +38,8 @@ export default function Studio() {
   const [aspect, setAspect] = createSignal<Aspect>('portrait');
   const [decoded, setDecoded] = createSignal<DecodedImage | null>(null);
   const [pickedName, setPickedName] = createSignal<string>('');
+  // ドロップエリアに表示するサムネイル用の object URL。差し替えで revoke する。
+  const [pickedThumbUrl, setPickedThumbUrl] = createSignal<string>('');
   const [phase, setPhase] = createSignal<Phase>('idle');
   const [progress, setProgress] = createSignal<number>(0);
   const [errorMsg, setErrorMsg] = createSignal<string>('');
@@ -76,6 +78,7 @@ export default function Studio() {
       URL.revokeObjectURL(t.blobUrl);
       if (t.videoBlobUrl) URL.revokeObjectURL(t.videoBlobUrl);
     }
+    if (pickedThumbUrl()) URL.revokeObjectURL(pickedThumbUrl());
   });
 
   const clearTiles = () => {
@@ -223,6 +226,10 @@ export default function Studio() {
   const acceptFile = async (file: File) => {
     setErrorMsg('');
     setPickedName(file.name);
+    // サムネイル URL を差し替え。前回分は revoke してメモリリークを防ぐ。
+    const prevThumbUrl = pickedThumbUrl();
+    setPickedThumbUrl(URL.createObjectURL(file));
+    if (prevThumbUrl) URL.revokeObjectURL(prevThumbUrl);
     setPhase('decoding');
     try {
       const dec = await decodeImageToRgb(file);
@@ -339,7 +346,7 @@ export default function Studio() {
         onDragOver={onDragOver}
         onDragLeave={onDragLeave}
         class={
-          'block cursor-pointer rounded-xl border border-dashed py-10 px-8 text-center transition-colors duration-200 ease-out ' +
+          'group relative block cursor-pointer rounded-xl border border-dashed py-10 px-8 text-center transition-colors duration-200 ease-out focus-within:border-focusRing ' +
           (dragOver()
             ? 'border-fg bg-glassBg'
             : 'border-hairline hover:border-fgMuted')
@@ -357,8 +364,29 @@ export default function Studio() {
             target.value = '';
           }}
         />
-        {pickedName() ? (
-          <span class="text-fg">{pickedName()}</span>
+        {pickedThumbUrl() ? (
+          <div class="relative">
+            <img
+              src={pickedThumbUrl()}
+              alt={pickedName()}
+              class="mx-auto max-h-40 object-contain"
+            />
+            {/* 差し替え overlay — hover (group) で暗幕 + ラベル fade-in。
+                dragOver 時は薄い白オーバーレイで強調 (DESIGN.md §4 DropArea Filled). */}
+            <div
+              class={
+                'pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity duration-200 ease-out ' +
+                (dragOver()
+                  ? 'opacity-100 bg-fg/5'
+                  : 'opacity-0 bg-bg/40 group-hover:opacity-100')
+              }
+              aria-hidden="true"
+            >
+              <span class="font-display text-sm tracking-wide text-fg">
+                {t('replaceImageHint')}
+              </span>
+            </div>
+          </div>
         ) : (
           <span class="text-fgMuted">{t('dropZonePlaceholder')}</span>
         )}

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -239,6 +239,11 @@ export default function Studio() {
       console.error('decode failed', e);
       setErrorMsg(String(e));
       setPhase('error');
+      // 失敗した画像を「成功扱い」のサムネとしてドロップエリアに残さない。
+      const failedThumbUrl = pickedThumbUrl();
+      if (failedThumbUrl) URL.revokeObjectURL(failedThumbUrl);
+      setPickedThumbUrl('');
+      setPickedName('');
     }
   };
 
@@ -341,7 +346,11 @@ export default function Studio() {
   return (
     <section class="space-y-4" data-lang={lang()}>
       <label
-        aria-label={t('dropZoneLabel')}
+        aria-label={
+          pickedThumbUrl()
+            ? `${t('dropZoneLabel')} — ${t('replaceImageHint')}`
+            : t('dropZoneLabel')
+        }
         onDrop={onDrop}
         onDragOver={onDragOver}
         onDragLeave={onDragLeave}
@@ -352,11 +361,14 @@ export default function Studio() {
             : 'border-hairline hover:border-fgMuted')
         }
       >
+        {/* sr-only で input を視覚的に隠しつつフォーカス可能に保つ。
+            display:none (旧 class="hidden") にすると Tab で focus できず
+            focus-within も発火しないため使わない。 */}
         <input
           ref={fileInput}
           type="file"
           accept="image/*"
-          class="hidden"
+          class="sr-only"
           onChange={(e) => {
             const target = e.currentTarget;
             acceptFiles(target.files);
@@ -368,17 +380,18 @@ export default function Studio() {
           <div class="relative">
             <img
               src={pickedThumbUrl()}
-              alt={pickedName()}
+              alt={t('pickedThumbAlt', { name: pickedName() })}
               class="mx-auto max-h-40 object-contain"
             />
-            {/* 差し替え overlay — hover (group) で暗幕 + ラベル fade-in。
-                dragOver 時は薄い白オーバーレイで強調 (DESIGN.md §4 DropArea Filled). */}
+            {/* 差し替え overlay — hover / focus (group) で暗幕 + ラベル fade-in。
+                dragOver 時は薄い白オーバーレイで強調 (DESIGN.md §4 Filled state)。
+                opacity 値 (bg/40, fg/5) は §4 Filled state に明記済み。 */}
             <div
               class={
                 'pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity duration-200 ease-out ' +
                 (dragOver()
                   ? 'opacity-100 bg-fg/5'
-                  : 'opacity-0 bg-bg/40 group-hover:opacity-100')
+                  : 'opacity-0 bg-bg/40 group-hover:opacity-100 group-focus-within:opacity-100')
               }
               aria-hidden="true"
             >

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -23,6 +23,7 @@ export const STRINGS = {
     ja: '画像を 1 つドロップ / クリックして選択',
     en: 'Drop an image or click to choose',
   },
+  replaceImageHint: { ja: '差し替え', en: 'Replace' },
   aspectPortrait: { ja: '縦長', en: 'Portrait' },
   aspectPortraitTitle: { ja: '縦長 540×960', en: 'Portrait 540×960' },
   aspectLandscape: { ja: '横長', en: 'Landscape' },

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -24,6 +24,10 @@ export const STRINGS = {
     en: 'Drop an image or click to choose',
   },
   replaceImageHint: { ja: '差し替え', en: 'Replace' },
+  pickedThumbAlt: {
+    ja: '選択した画像: {name}',
+    en: 'Picked image: {name}',
+  },
   aspectPortrait: { ja: '縦長', en: 'Portrait' },
   aspectPortraitTitle: { ja: '縦長 540×960', en: 'Portrait 540×960' },
   aspectLandscape: { ja: '横長', en: 'Landscape' },


### PR DESCRIPTION
## 関連 Issue
closes #54

## ベース
**\`62-design-renewal-i18n\` ブランチに積み上げ** (DESIGN.md / i18n / glass トークンに依存)。
#62 がマージされた後、自動的にベースを main に切り替わる想定。

## 変更内容

### Studio.tsx
- \`pickedThumbUrl\` signal を追加。\`acceptFile\` 内で \`URL.createObjectURL(file)\` を保持し、差し替え時は前回分を revoke。\`onCleanup\` でも revoke
- ドロップエリアの \`<label>\` を \`group relative\` 化。画像読込後はプレースホルダ文の代わりに \`<img class=\"mx-auto max-h-40 object-contain\">\` をサムネイル表示
- 「差し替え overlay」を内部に追加:
  - hover: \`opacity 0 → 1\`、40% 黒スクリム + 中央 \`Replace\` / \`差し替え\` ラベル (font-display tracking-wide)
  - dragOver: 完全不透明、\`bg-fg/5\` の白うっすら + 枠線 \`border-fg\` (既存)
  - \`pointer-events: none\` で下層のドロップ/クリックを邪魔しない
- \`focus-within:border-focusRing\` で input フォーカス時に \`<label>\` 全体を光らせる

### strings.ts
- \`replaceImageHint\`: ja \`差し替え\` / en \`Replace\` を追加

### DESIGN.md
- §4 DropArea に「Filled state (thumbnail)」サブセクションと Replace overlay スペックを追記
- 既存の Drag-over state の border 色を \`fg-muted\` → \`fg\` に修正 (実装と整合)

## Test plan
- [ ] 画像を読込むとドロップエリアにサムネイルが表示される (object-contain で歪まない)
- [ ] 別の画像をドロップすると差し替わる (前 URL がリークしない)
- [ ] サムネイル上にカーソルを重ねると \`差し替え\` ラベルが fade-in
- [ ] サムネイル上に画像をドラッグするとオーバーレイが白うっすらに変わり、枠線が \`fg\` に
- [ ] サムネイル表示中もクリックでファイル選択ダイアログが開く
- [ ] focus-visible リングがドロップエリアに当たる