### PR TITLE
feat: orber#54 ドロップエリアにサムネイル表示 + 差し替え可視化

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -63,9 +63,30 @@ No bold anywhere. Headers are deliberately light.
 - Background: transparent
 - Border: `1px dashed hairline`, radius `0.75rem`
 - Padding: `2.5rem` (40px) vertical, `2rem` (32px) horizontal
-- Drag-over state: border swaps to `fg-muted`, no fill change
-- Text: placeholder uses `fg-subtle`, picked filename uses `fg`
-- Cursor: `pointer`
+- Hover state (empty): border swaps to `fg-muted`
+- Drag-over state: border swaps to `fg`, fill `glass-bg`
+- Text: placeholder uses `fg-muted`, picked filename uses `fg`
+- Cursor: `pointer` (always — even when filled with a thumbnail; the area
+  remains an active drop target / file picker trigger)
+- Focus: when the inner `<input type=file>` is focused, the surrounding
+  `<label>` gets `focus-within:border-focusRing`
+
+#### Filled state (thumbnail)
+
+After a file is picked, the drop area shows the source image as a thumbnail
+**without losing its drop-target framing**. The dashed border, padding, and
+cursor are kept exactly as in the empty state — only the inner content swaps.
+
+- Thumbnail: `<img>`, centered, `object-contain`, `max-h-40` (160px) so the
+  drop frame keeps a consistent height regardless of source aspect
+- Replace overlay: a fade-in layer above the thumbnail
+  - Hover (group): `opacity 0 → 1`, fill `bg/40` (40% black scrim), centered
+    `Replace` / `差し替え` label in `font-display`, `text-sm`, `tracking-wide`,
+    color `fg`
+  - Drag-over: overlay fully opaque with fill `fg/5` (faint white wash) and
+    no label — the active drop affordance is the white border and the wash
+- The overlay is `pointer-events: none` so the underlying `<label>` keeps
+  receiving drag / click events
 
 ### Button (Glass)
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ randomly per drop, so the same image yields a different layout each time. The fi
 **half** of the batch (5 tiles) are static PNGs; the **last 5 tiles** are H.264 mp4
 loops generated client-side via WebCodecs and inlined as `<video muted autoplay
 playsinline loop>`, so they animate continuously in the grid without any user
-interaction. Pick favorites with the ✓ toggle and download single (PNG / MP4) or
-multi (mixed-extension ZIP).
+interaction. Pick favorites with the corner-marker toggle and download single
+(PNG / MP4) or multi (mixed-extension ZIP). After drop, the source image stays
+in the drop zone as a thumbnail; hover (or drag a new file over it) to swap it
+out without touching any other control.
 
 The GUI runs entirely client-side. The `orber-wasm` crate handles rendering
 (measured ≈ 220 KB gzipped at v0.3.0); H.264 encoding is done in the browser via

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -38,6 +38,8 @@ export default function Studio() {
   const [aspect, setAspect] = createSignal<Aspect>('portrait');
   const [decoded, setDecoded] = createSignal<DecodedImage | null>(null);
   const [pickedName, setPickedName] = createSignal<string>('');
+  // ドロップエリアに表示するサムネイル用の object URL。差し替えで revoke する。
+  const [pickedThumbUrl, setPickedThumbUrl] = createSignal<string>('');
   const [phase, setPhase] = createSignal<Phase>('idle');
   const [progress, setProgress] = createSignal<number>(0);
   const [errorMsg, setErrorMsg] = createSignal<string>('');
@@ -76,6 +78,7 @@ export default function Studio() {
       URL.revokeObjectURL(t.blobUrl);
       if (t.videoBlobUrl) URL.revokeObjectURL(t.videoBlobUrl);
     }
+    if (pickedThumbUrl()) URL.revokeObjectURL(pickedThumbUrl());
   });
 
   const clearTiles = () => {
@@ -223,6 +226,10 @@ export default function Studio() {
   const acceptFile = async (file: File) => {
     setErrorMsg('');
     setPickedName(file.name);
+    // サムネイル URL を差し替え。前回分は revoke してメモリリークを防ぐ。
+    const prevThumbUrl = pickedThumbUrl();
+    setPickedThumbUrl(URL.createObjectURL(file));
+    if (prevThumbUrl) URL.revokeObjectURL(prevThumbUrl);
     setPhase('decoding');
     try {
       const dec = await decodeImageToRgb(file);
@@ -339,7 +346,7 @@ export default function Studio() {
         onDragOver={onDragOver}
         onDragLeave={onDragLeave}
         class={
-          'block cursor-pointer rounded-xl border border-dashed py-10 px-8 text-center transition-colors duration-200 ease-out ' +
+          'group relative block cursor-pointer rounded-xl border border-dashed py-10 px-8 text-center transition-colors duration-200 ease-out focus-within:border-focusRing ' +
           (dragOver()
             ? 'border-fg bg-glassBg'
             : 'border-hairline hover:border-fgMuted')
@@ -357,8 +364,29 @@ export default function Studio() {
             target.value = '';
           }}
         />
-        {pickedName() ? (
-          <span class="text-fg">{pickedName()}</span>
+        {pickedThumbUrl() ? (
+          <div class="relative">
+            <img
+              src={pickedThumbUrl()}
+              alt={pickedName()}
+              class="mx-auto max-h-40 object-contain"
+            />
+            {/* 差し替え overlay — hover (group) で暗幕 + ラベル fade-in。
+                dragOver 時は薄い白オーバーレイで強調 (DESIGN.md §4 DropArea Filled). */}
+            <div
+              class={
+                'pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity duration-200 ease-out ' +
+                (dragOver()
+                  ? 'opacity-100 bg-fg/5'
+                  : 'opacity-0 bg-bg/40 group-hover:opacity-100')
+              }
+              aria-hidden="true"
+            >
+              <span class="font-display text-sm tracking-wide text-fg">
+                {t('replaceImageHint')}
+              </span>
+            </div>
+          </div>
         ) : (
           <span class="text-fgMuted">{t('dropZonePlaceholder')}</span>
         )}

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -239,6 +239,11 @@ export default function Studio() {
       console.error('decode failed', e);
       setErrorMsg(String(e));
       setPhase('error');
+      // 失敗した画像を「成功扱い」のサムネとしてドロップエリアに残さない。
+      const failedThumbUrl = pickedThumbUrl();
+      if (failedThumbUrl) URL.revokeObjectURL(failedThumbUrl);
+      setPickedThumbUrl('');
+      setPickedName('');
     }
   };
 
@@ -341,7 +346,11 @@ export default function Studio() {
   return (
     <section class="space-y-4" data-lang={lang()}>
       <label
-        aria-label={t('dropZoneLabel')}
+        aria-label={
+          pickedThumbUrl()
+            ? `${t('dropZoneLabel')} — ${t('replaceImageHint')}`
+            : t('dropZoneLabel')
+        }
         onDrop={onDrop}
         onDragOver={onDragOver}
         onDragLeave={onDragLeave}
@@ -352,11 +361,14 @@ export default function Studio() {
             : 'border-hairline hover:border-fgMuted')
         }
       >
+        {/* sr-only で input を視覚的に隠しつつフォーカス可能に保つ。
+            display:none (旧 class="hidden") にすると Tab で focus できず
+            focus-within も発火しないため使わない。 */}
         <input
           ref={fileInput}
           type="file"
           accept="image/*"
-          class="hidden"
+          class="sr-only"
           onChange={(e) => {
             const target = e.currentTarget;
             acceptFiles(target.files);
@@ -368,17 +380,18 @@ export default function Studio() {
           <div class="relative">
             <img
               src={pickedThumbUrl()}
-              alt={pickedName()}
+              alt={t('pickedThumbAlt', { name: pickedName() })}
               class="mx-auto max-h-40 object-contain"
             />
-            {/* 差し替え overlay — hover (group) で暗幕 + ラベル fade-in。
-                dragOver 時は薄い白オーバーレイで強調 (DESIGN.md §4 DropArea Filled). */}
+            {/* 差し替え overlay — hover / focus (group) で暗幕 + ラベル fade-in。
+                dragOver 時は薄い白オーバーレイで強調 (DESIGN.md §4 Filled state)。
+                opacity 値 (bg/40, fg/5) は §4 Filled state に明記済み。 */}
             <div
               class={
                 'pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity duration-200 ease-out ' +
                 (dragOver()
                   ? 'opacity-100 bg-fg/5'
-                  : 'opacity-0 bg-bg/40 group-hover:opacity-100')
+                  : 'opacity-0 bg-bg/40 group-hover:opacity-100 group-focus-within:opacity-100')
               }
               aria-hidden="true"
             >

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -23,6 +23,7 @@ export const STRINGS = {
     ja: '画像を 1 つドロップ / クリックして選択',
     en: 'Drop an image or click to choose',
   },
+  replaceImageHint: { ja: '差し替え', en: 'Replace' },
   aspectPortrait: { ja: '縦長', en: 'Portrait' },
   aspectPortraitTitle: { ja: '縦長 540×960', en: 'Portrait 540×960' },
   aspectLandscape: { ja: '横長', en: 'Landscape' },

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -24,6 +24,10 @@ export const STRINGS = {
     en: 'Drop an image or click to choose',
   },
   replaceImageHint: { ja: '差し替え', en: 'Replace' },
+  pickedThumbAlt: {
+    ja: '選択した画像: {name}',
+    en: 'Picked image: {name}',
+  },
   aspectPortrait: { ja: '縦長', en: 'Portrait' },
   aspectPortraitTitle: { ja: '縦長 540×960', en: 'Portrait 540×960' },
   aspectLandscape: { ja: '横長', en: 'Landscape' },


### PR DESCRIPTION
## 関連 Issue
closes #54

## 経緯
当初 #62 (PR #63) ブランチに積み上げて作成 (旧 PR #64) → #63 merge 時に base ブランチが削除され自動クローズされたため、main に rebase して再 PR。

## 変更内容

### Studio.tsx
- \`pickedThumbUrl\` signal を追加。\`acceptFile\` で \`URL.createObjectURL(file)\` を保持し、差し替え時 / decode 失敗時 / onCleanup で revoke
- ドロップエリアの \`<label>\` を \`group relative\` 化、画像読込後はサムネイルを \`<img class="mx-auto max-h-40 object-contain">\` で表示
- 差し替え overlay を追加:
  - hover / keyboard focus (\`group-focus-within\`) で 40% 黒スクリム + \`Replace\` / \`差し替え\` ラベル fade-in
  - dragOver: \`bg-fg/5\` 白うっすら + 枠線 \`border-fg\`
  - \`pointer-events: none\` で下層を邪魔しない
- input を \`class="hidden"\` → \`sr-only\` に変更 (display:none だと focus 不能で focus-within が機能しない)
- aria-label に Replace ヒントを動的付与、img alt は \`pickedThumbAlt\` で i18n
- decode 失敗時に thumb と name をクリア (失敗画像が成功扱いで残らない)

### strings.ts
- \`replaceImageHint\` (ja \`差し替え\` / en \`Replace\`)
- \`pickedThumbAlt\` (ja \`選択した画像: {name}\` / en \`Picked image: {name}\`)

### DESIGN.md §4 DropArea
- 「Filled state (thumbnail)」サブセクション追加 (max-h-40 / object-contain / overlay 仕様)
- 既存の Drag-over state border 色を \`fg-muted\` → \`fg\` に修正 (実装と整合)

### README.md
- Web GUI セクションに「サムネが残って差し替えられる」一文追記

## Test plan
- [ ] 画像読込後、サムネイルが表示される (object-contain)
- [ ] 差し替え時、前 URL がリークしない
- [ ] hover で「差し替え」ラベル fade-in
- [ ] キーボード Tab で focus → focus-within で枠と overlay が出る
- [ ] サムネイル上にドラッグでオーバーレイ強調
- [ ] サムネイル表示中もクリックで file picker
- [ ] decode 失敗で空状態に戻る