### PR TITLE
chore(web): wrangler.toml の name を Cloudflare Pages 実プロジェクト名に修正

### DIFF
--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -1,3 +1,3 @@
-name = "orber-web"
+name = "orber"
 compatibility_date = "2026-04-28"
 pages_build_output_dir = "dist"


### PR DESCRIPTION
ローカルから `npm run deploy` を打つと 'Project not found' (orber-web) になっていた。Cloudflare 側の実プロジェクト名は `orber`。Git 連携の自動デプロイは別パスで動くため気付きにくかった。

確認済: `npx wrangler pages deploy dist --project-name=orber` で本番デプロイ通過 (https://orber.llll-ll.com)。