### PR TITLE
feat: orber#60 出現演出をフェードインで統一

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -161,7 +161,7 @@ Tailwind spacing scale (4px base):
 
 ## 6. Motion
 
-Single transition idiom, used everywhere. In code, this is expressed with the Tailwind defaults `duration-200 ease-out` (no custom theme keys needed):
+Single transition idiom, used everywhere. The **source of truth** for duration / easing is the CSS variables `--orb-motion-duration` / `--orb-motion-easing` defined in `Base.astro`. The Tailwind utilities `duration-200 ease-out` happen to match those values today and are used inline because Tailwind v3 cannot consume CSS variables in `transition-duration` / `transition-timing-function` shorthand. If the variables ever change, update both places (the variables and the Tailwind utilities, or migrate to a Tailwind theme that reads the variables). In code, the transition reads:
 
 ```css
 transition: opacity 200ms ease-out;

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -176,11 +176,35 @@ transition:
   border-color 200ms ease-out;
 ```
 
-- New tiles **fade in** (`opacity 0 → 1`, 200ms ease-out) as they arrive from the wasm batch loop. This is the foundation Issue #60 will build on (staggered fade-in of generated tiles).
+- New tiles **fade in** (`opacity 0 → 1`, 200ms ease-out) as they arrive from the wasm batch loop, using the shared `.fade-in` class below (#60).
 - Selection marker fades (`opacity 0 → 1`, 200ms ease-out) on toggle.
-- No translate / scale / rotate transitions. No spring. No keyframes.
+- No translate / scale / rotate transitions. No spring. No keyframes other than the single `orb-fade-in` defined below.
 
-Reduced motion: respect `prefers-reduced-motion: reduce` by clamping all transitions to `0ms`. Implementation note: a single Tailwind `motion-reduce:transition-none` on the affected utility is sufficient.
+### `.fade-in` (mount-time fade)
+
+For elements that **appear** in the DOM (rather than toggle visibility), use the shared `.fade-in` class instead of a `transition`. It is one CSS animation, defined once globally in `Base.astro`, and reused everywhere a node is freshly mounted (drop-zone thumbnail, generated tile button, status text, error box, video swap on top of the still PNG, subtitle, future long-press preview overlay).
+
+```css
+:root {
+  --orb-motion-duration: 200ms;
+  --orb-motion-easing: ease-out;
+}
+@keyframes orb-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+.fade-in {
+  animation: orb-fade-in var(--orb-motion-duration) var(--orb-motion-easing) both;
+}
+```
+
+Rules:
+- Only `opacity` is animated (no `transform`, no layout). Compositor-only — cheap on mobile.
+- Duration / easing live in CSS variables so the whole house tunes from one place.
+- Use `.fade-in` for **appearance**; use `transition: opacity ...` for **toggling**. Both share the 200ms / ease-out idiom.
+- For PNG → MP4 swap on a video tile: the PNG stays mounted as the bottom layer, and the `<video>` is added above with `.fade-in` so the swap is a crossfade rather than a cut.
+
+Reduced motion: respect `prefers-reduced-motion: reduce` by clamping all transitions and the `.fade-in` animation to `0ms` (already wired in `Base.astro` via a media query that overrides `--orb-motion-duration` and `animation-duration`). Tailwind's `motion-reduce:transition-none` may be added per-element as a belt-and-suspenders.
 
 ## 7. Iconography
 

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -382,7 +382,7 @@ export default function Studio() {
             <img
               src={pickedThumbUrl()}
               alt={t('pickedThumbAlt', { name: pickedName() })}
-              class="mx-auto max-h-40 object-contain"
+              class="fade-in mx-auto max-h-40 object-contain"
             />
             {/* 差し替え overlay — hover / focus (group) で暗幕 + ラベル fade-in。
                 dragOver 時は薄い白オーバーレイで強調 (DESIGN.md §4 Filled state)。
@@ -480,24 +480,24 @@ export default function Studio() {
       </div>
 
       <Show when={wasmStatus() === 'error'}>
-        <div class="rounded border border-hairline bg-glassBg p-3 text-sm text-fg">
+        <div class="fade-in rounded border border-hairline bg-glassBg p-3 text-sm text-fg">
           {t('wasmLoadFailed')}
           <pre class="mt-2 text-xs whitespace-pre-wrap text-fgMuted">{wasmErr()}</pre>
         </div>
       </Show>
 
       <Show when={phase() === 'decoding'}>
-        <p class="text-sm text-fgMuted">{t('decoding')}</p>
+        <p class="fade-in text-sm text-fgMuted">{t('decoding')}</p>
       </Show>
       <Show when={phase() === 'generating'}>
-        <p class="text-sm text-fgMuted">{t('generating')} {progress()} / {batchN()}</p>
+        <p class="fade-in text-sm text-fgMuted">{t('generating')} {progress()} / {batchN()}</p>
       </Show>
       <Show when={phase() === 'animating'}>
-        <p class="text-sm text-fgMuted">{t('animating')}</p>
+        <p class="fade-in text-sm text-fgMuted">{t('animating')}</p>
       </Show>
 
       <Show when={errorMsg() && phase() === 'error'}>
-        <div class="rounded border border-hairline bg-glassBg p-3 text-sm text-fg">
+        <div class="fade-in rounded border border-hairline bg-glassBg p-3 text-sm text-fg">
           {errorMsg()}
         </div>
       </Show>
@@ -516,21 +516,21 @@ export default function Studio() {
               <button
                 type="button"
                 onClick={() => toggleTile(i())}
-                class="group relative block w-full overflow-hidden rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing"
+                class="fade-in group relative block w-full overflow-hidden rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing"
                 style={{
                   'aspect-ratio': aspect() === 'portrait' ? '540 / 960' : '960 / 540',
                 }}
               >
-                <Show
-                  when={tile.kind === 'video' && tile.videoBlobUrl}
-                  fallback={
-                    <img
-                      src={tile.blobUrl}
-                      alt={t('variationAlt', { n: i() + 1 })}
-                      class="block h-full w-full object-cover"
-                    />
-                  }
-                >
+                {/* 静止 PNG は常に下敷きとして表示し続ける。動画タイルでは
+                    videoBlobUrl が来たら <video> を上に絶対配置して fade-in
+                    させる (#60)。下敷きを残すことで差し替えの瞬間に空白が
+                    出ない。 */}
+                <img
+                  src={tile.blobUrl}
+                  alt={t('variationAlt', { n: i() + 1 })}
+                  class="block h-full w-full object-cover"
+                />
+                <Show when={tile.kind === 'video' && tile.videoBlobUrl}>
                   <video
                     src={tile.videoBlobUrl}
                     poster={tile.blobUrl}
@@ -538,7 +538,7 @@ export default function Studio() {
                     muted
                     playsinline
                     loop
-                    class="block h-full w-full object-cover"
+                    class="fade-in absolute inset-0 block h-full w-full object-cover"
                     aria-label={t('variationAnimatedAlt', { n: i() + 1 })}
                   />
                 </Show>

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -377,33 +377,41 @@ export default function Studio() {
             target.value = '';
           }}
         />
-        {pickedThumbUrl() ? (
-          <div class="relative">
-            <img
-              src={pickedThumbUrl()}
-              alt={t('pickedThumbAlt', { name: pickedName() })}
-              class="fade-in mx-auto max-h-40 object-contain"
-            />
-            {/* 差し替え overlay — hover / focus (group) で暗幕 + ラベル fade-in。
-                dragOver 時は薄い白オーバーレイで強調 (DESIGN.md §4 Filled state)。
-                opacity 値 (bg/40, fg/5) は §4 Filled state に明記済み。 */}
-            <div
-              class={
-                'pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity duration-200 ease-out ' +
-                (dragOver()
-                  ? 'opacity-100 bg-fg/5'
-                  : 'opacity-0 bg-bg/40 group-hover:opacity-100 group-focus-within:opacity-100')
-              }
-              aria-hidden="true"
-            >
-              <span class="font-display text-sm tracking-wide text-fg">
-                {t('replaceImageHint')}
-              </span>
+        {/* `Show keyed` で URL が変わると <img> が unmount → 再 mount され、
+            CSS animation `.fade-in` が再発火する (#60 セルフレビュー S1 対応)。
+            通常の三項演算子だと <img> ノードは同一のまま src が更新されるので
+            アニメーションが 1 回目しか走らない。 */}
+        <Show
+          when={pickedThumbUrl()}
+          keyed
+          fallback={<span class="text-fgMuted">{t('dropZonePlaceholder')}</span>}
+        >
+          {(url) => (
+            <div class="relative">
+              <img
+                src={url}
+                alt={t('pickedThumbAlt', { name: pickedName() })}
+                class="fade-in mx-auto max-h-40 object-contain"
+              />
+              {/* 差し替え overlay — hover / focus (group) で暗幕 + ラベル fade-in。
+                  dragOver 時は薄い白オーバーレイで強調 (DESIGN.md §4 Filled state)。
+                  opacity 値 (bg/40, fg/5) は §4 Filled state に明記済み。 */}
+              <div
+                class={
+                  'pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity duration-200 ease-out ' +
+                  (dragOver()
+                    ? 'opacity-100 bg-fg/5'
+                    : 'opacity-0 bg-bg/40 group-hover:opacity-100 group-focus-within:opacity-100')
+                }
+                aria-hidden="true"
+              >
+                <span class="font-display text-sm tracking-wide text-fg">
+                  {t('replaceImageHint')}
+                </span>
+              </div>
             </div>
-          </div>
-        ) : (
-          <span class="text-fgMuted">{t('dropZonePlaceholder')}</span>
-        )}
+          )}
+        </Show>
       </label>
 
       <div class="flex items-center justify-center gap-2">
@@ -490,6 +498,9 @@ export default function Studio() {
         <p class="fade-in text-sm text-fgMuted">{t('decoding')}</p>
       </Show>
       <Show when={phase() === 'generating'}>
+        {/* progress() の数字が変わっても <p> はマウントされたままなので
+            .fade-in は最初の 1 回 (Show が真になった瞬間) しか走らない。
+            毎刻みフェードすると目障りなので、これは意図通り。 */}
         <p class="fade-in text-sm text-fgMuted">{t('generating')} {progress()} / {batchN()}</p>
       </Show>
       <Show when={phase() === 'animating'}>
@@ -524,16 +535,19 @@ export default function Studio() {
                 {/* 静止 PNG は常に下敷きとして表示し続ける。動画タイルでは
                     videoBlobUrl が来たら <video> を上に絶対配置して fade-in
                     させる (#60)。下敷きを残すことで差し替えの瞬間に空白が
-                    出ない。 */}
+                    出ない。再ロール (runBatch) は clearTiles で全タイルを
+                    unmount してから push するので、再フェードインも自然に
+                    走る (将来 in-place 差し替えを入れたら Show keyed が要る)。 */}
                 <img
                   src={tile.blobUrl}
                   alt={t('variationAlt', { n: i() + 1 })}
                   class="block h-full w-full object-cover"
                 />
                 <Show when={tile.kind === 'video' && tile.videoBlobUrl}>
+                  {/* poster は冗長 (autoplay 即時 + 下敷き <img> が同等の役割)
+                      なので付けない。 */}
                   <video
                     src={tile.videoBlobUrl}
-                    poster={tile.blobUrl}
                     autoplay
                     muted
                     playsinline

--- a/web/src/components/Subtitle.tsx
+++ b/web/src/components/Subtitle.tsx
@@ -16,8 +16,11 @@ export default function Subtitle() {
   // Solid の JSX コンパイラは {expr} を effect でラップするため、
   // t() 内部の lang() 呼び出しで自動的に reactive 化される。
   // 明示的なトリガ (data-lang 等) は不要。
+  // Subtitle は SSR で既に描画されており above-the-fold で常時可視のため、
+  // .fade-in は付けない (hydration で再フェードするとちらつく)。
+  // これは DESIGN.md §6 「.fade-in は新規マウント時の出現演出」の対象外。
   return (
-    <p class="fade-in font-display text-sm tracking-wide text-fgMuted text-center mt-3 mb-10">
+    <p class="font-display text-sm tracking-wide text-fgMuted text-center mt-3 mb-10">
       {t('subtitle')}
     </p>
   );

--- a/web/src/components/Subtitle.tsx
+++ b/web/src/components/Subtitle.tsx
@@ -17,7 +17,7 @@ export default function Subtitle() {
   // t() 内部の lang() 呼び出しで自動的に reactive 化される。
   // 明示的なトリガ (data-lang 等) は不要。
   return (
-    <p class="font-display text-sm tracking-wide text-fgMuted text-center mt-3 mb-10">
+    <p class="fade-in font-display text-sm tracking-wide text-fgMuted text-center mt-3 mb-10">
       {t('subtitle')}
     </p>
   );

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -37,6 +37,34 @@ const { title = 'orber' } = Astro.props;
         /* noop — locale read failure must not block render. lang stays "en". */
       }
     </script>
+    <!--
+      orber#60 — Motion tokens & .fade-in class (DESIGN.md §6).
+      duration / easing は CSS 変数で 1 箇所集約。新しく要素が DOM に
+      マウントされる瞬間 (タイル追加 / サムネイル表示 / 進捗テキスト等)
+      に同じ class 1 つで「opacity 0 → 1」フェードを掛ける。
+      `animation: ... both` で初期 opacity:0 を保ちつつ完了状態を維持する。
+    -->
+    <style is:global>
+      :root {
+        --orb-motion-duration: 200ms;
+        --orb-motion-easing: ease-out;
+      }
+      @keyframes orb-fade-in {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+      .fade-in {
+        animation: orb-fade-in var(--orb-motion-duration) var(--orb-motion-easing) both;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        :root {
+          --orb-motion-duration: 0ms;
+        }
+        .fade-in {
+          animation-duration: 0ms;
+        }
+      }
+    </style>
   </head>
   <body class="min-h-screen bg-bg text-fg">
     <main class="mx-auto max-w-3xl p-8">

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -57,6 +57,8 @@ const { title = 'orber' } = Astro.props;
         animation: orb-fade-in var(--orb-motion-duration) var(--orb-motion-easing) both;
       }
       @media (prefers-reduced-motion: reduce) {
+        /* belt-and-suspenders — 変数を 0ms にすれば animation-duration も
+           解決時に 0ms になるが、念のため `.fade-in` 側でも明示する。 */
         :root {
           --orb-motion-duration: 0ms;
         }


### PR DESCRIPTION
## 関連 Issue
closes #60

## 変更内容

### Base.astro — グローバル CSS
- CSS 変数 \`--orb-motion-duration: 200ms\` / \`--orb-motion-easing: ease-out\` を \`:root\` に
- \`@keyframes orb-fade-in\` (opacity 0→1) + \`.fade-in\` クラス (\`animation ... both\`)
- \`prefers-reduced-motion: reduce\` で 0ms クランプ

### Studio.tsx — .fade-in 適用箇所
| 要素 | 効果 |
|---|---|
| ドロップエリア サムネ \`<img>\` | 読込時フェードイン |
| 進捗テキスト (decoding / generating / animating) | Show マウント時フェードイン |
| エラーボックス (wasmLoadFailed / phase=error) | フェードイン |
| 生成タイル (For 各アイテム) | 1 枚ずつフェードイン |
| 動画タイル \`<video>\` | PNG を下敷きに残し \`absolute inset-0 fade-in\` で **クロスフェード** |

### Subtitle.tsx
- subtitle \`<p>\` にも .fade-in

### DESIGN.md §6 Motion
- 「.fade-in (mount-time fade)」サブセクション新設
- 使い分け (\`.fade-in\` = 出現 / \`transition\` = 切替) を明文化
- reduced-motion 方針を明記

## 受け入れ条件
- [x] 出現時演出がすべてフェードイン
- [x] フェード時間・イージングが CSS 1 箇所 (\`:root\`) に集約
- [x] opacity だけで実装 (transform / scale なし、コンポジタ層で軽い)

## Test plan
- [x] \`cd web && npm run build\` 通過
- [ ] ブラウザで以下を確認:
  - 画像ドロップ → サムネイル fade-in
  - 生成タイル群が 1 枚ずつ fade-in
  - PNG → mp4 差し替え時、PNG が下敷きで残ったまま動画が fade-in
  - エラー時にエラーボックスが fade-in
  - \`prefers-reduced-motion: reduce\` を OS で有効化すると瞬時表示になる

## 関連
- #57 長押し拡大 — 同じ \`.fade-in\` を流用予定
- #58 ストリーミング描画 — タイル単位 fade-in と相性良し