### PR TITLE
feat: orber#57 サムネイル長押しで拡大プレビュー

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+- Drop-zone thumbnail long-press preview: pressing and holding the drop-zone for ~400ms opens a full-viewport overlay showing the source image at up to 90vh × 90vw (`object-contain`). Releasing closes it. A short tap is treated as a normal click and still opens the file picker. The long-press path uses `setPointerCapture` so the gesture stays bound to the label even if the finger slides outside, and the overlay itself is `pointer-events: none` so it never steals the eventual `pointerup`. iOS callout / loupe / drag are suppressed via `select-none touch-none draggable=false -webkit-touch-callout: none` on the thumbnail. Documented in DESIGN.md §4 PreviewOverlay. (#57)
+
 ### Changed
 - Web GUI tile count unified to **12** for both portrait and landscape (`BATCH_TILE_COUNT = 12`, replaces the old portrait-10 / landscape-9 split). 12 was picked because it is divisible by 1/2/3/4/6/12, so the grid lays out cleanly across phone widths. 8 stills + 4 videos. (#61)
 - Web GUI video tiles now start playing **simultaneously** once all four mp4 encodes finish, rather than each tile starting whenever its own encode completes. `<video autoplay>` is removed; references are collected via `ref` callbacks into `videoRefs`, and a single `play()` burst is fired at the end of the run after `await yieldFrame()` flushes the DOM mounts. PNG remains underneath as a still backdrop while encoding is in progress, so tiles read as paused snapshots until the simultaneous start. (#61)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -139,6 +139,26 @@ Not used in this iteration; reserved. The aspect Portrait / Landscape pair is in
 - Glass button base, **icon-only** (curved arrows / reload glyph, 16px stroke 1.5)
 - No "ガチャ" / "Roll again" text in the visual; full label lives in `aria-label` and `title` only
 
+### PreviewOverlay
+
+Press-and-hold preview for the drop-zone thumbnail (#57). Triggered by a long
+press of ~400ms, dismissed when the pointer is released.
+
+- `position: fixed`, `inset: 0`, `z-50`, full viewport
+- Background: `bg/80` (80% black scrim)
+- Content: the source image, centered, `max-h-[90vh] max-w-[90vw]`,
+  `object-contain` so it never crops
+- `pointer-events: none` — the overlay never intercepts the user's release;
+  the original drop-zone `<label>` keeps owning the gesture
+- Mounts via `.fade-in` (DESIGN.md §6) so the overlay rises smoothly
+- The thumbnail `<img>` underneath wears `select-none touch-none` (and an
+  inline `-webkit-touch-callout: none`) to suppress iOS callout / loupe and
+  text selection during the long press
+- A short tap (under 400ms) is treated as a normal label click and opens the
+  file picker; only the long-press path opens the overlay. The synthetic click
+  fired after a successful long-press is suppressed by an `isLongPress` flag
+  in the click handler.
+
 ## 5. Spacing & Layout
 
 Tailwind spacing scale (4px base):

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ animates as a single coordinated burst rather than staggered pop-ins. Pick
 favorites with the corner-marker toggle and download single (PNG / MP4) or
 multi (mixed-extension ZIP). After drop, the source image stays in the drop
 zone as a thumbnail; hover (or drag a new file over it) to swap it out without
-touching any other control.
+touching any other control. Long-press the thumbnail (~400ms) to peek at the
+source image full-size in an overlay, release to close — handy for verifying
+which photo is loaded without losing the rest of the GUI.
 
 The GUI runs entirely client-side. The `orber-wasm` crate handles rendering
 (measured ≈ 220 KB gzipped at v0.3.0); H.264 encoding is done in the browser via

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -91,6 +91,9 @@ export default function Studio() {
       if (t.videoBlobUrl) URL.revokeObjectURL(t.videoBlobUrl);
     }
     if (pickedThumbUrl()) URL.revokeObjectURL(pickedThumbUrl());
+    // #57 — 走行中の長押しタイマーを止める。コンポーネントが消えた後に
+    // setPreviewVisible が呼ばれるのを防ぐ。
+    if (longPressTimer !== undefined) clearTimeout(longPressTimer);
   });
 
   const clearTiles = () => {
@@ -306,20 +309,28 @@ export default function Studio() {
 
   // #57 — 長押しで拡大プレビュー。
   // pointerdown 時に LONG_PRESS_MS のタイマーを仕掛け、満了したらオーバーレイを
-  // 開きつつ isLongPress を立てる。pointerup / cancel / leave で常にタイマー
-  // をクリアし、オーバーレイを閉じる。click は label のネイティブ動作で
-  // ファイル選択を起動するので、isLongPress が立っていたら preventDefault で
-  // 抑止する。サムネイルが無い (空ドロップエリア) ときは何もしない。
-  const cancelLongPress = () => {
+  // 開きつつ isLongPress を立てる。pointerup / cancel で常にタイマーをクリア
+  // しオーバーレイを閉じる。pointerleave は使わない (S1: 押下中に指がラベル外
+  // に少しずれただけで閉じる UX を避けるため)。代わりに pointerdown で
+  // setPointerCapture を取り、指がラベル外に移動しても pointerup が必ず
+  // ラベルに届くようにする。
+  // click は label のネイティブ動作でファイル選択を起動するので、isLongPress
+  // が立っていたら preventDefault で抑止する。サムネイルが無い (空ドロップ
+  // エリア) ときは何もしない。
+  const endLongPress = () => {
     if (longPressTimer !== undefined) {
       clearTimeout(longPressTimer);
       longPressTimer = undefined;
     }
     setPreviewVisible(false);
   };
-  const onDropZonePointerDown = () => {
+  const onDropZonePointerDown = (e: PointerEvent) => {
     if (!pickedThumbUrl()) return;
     isLongPress = false;
+    // ジェスチャ全体を label に閉じ込める。指が外にスライドしても
+    // pointerup / pointercancel が必ず label に届く。
+    const target = e.currentTarget as HTMLElement | null;
+    target?.setPointerCapture?.(e.pointerId);
     longPressTimer = window.setTimeout(() => {
       isLongPress = true;
       setPreviewVisible(true);
@@ -327,7 +338,7 @@ export default function Studio() {
     }, LONG_PRESS_MS);
   };
   const onDropZonePointerEnd = () => {
-    cancelLongPress();
+    endLongPress();
   };
   const onDropZoneClick = (e: MouseEvent) => {
     if (isLongPress) {
@@ -424,10 +435,9 @@ export default function Studio() {
         onPointerDown={onDropZonePointerDown}
         onPointerUp={onDropZonePointerEnd}
         onPointerCancel={onDropZonePointerEnd}
-        onPointerLeave={onDropZonePointerEnd}
         onClick={onDropZoneClick}
         class={
-          'group relative block cursor-pointer rounded-xl border border-dashed py-10 px-8 text-center transition-colors duration-200 ease-out focus-within:border-focusRing ' +
+          'group relative block cursor-pointer touch-manipulation rounded-xl border border-dashed py-10 px-8 text-center transition-colors duration-200 ease-out focus-within:border-focusRing ' +
           (dragOver()
             ? 'border-fg bg-glassBg'
             : 'border-hairline hover:border-fgMuted')
@@ -737,7 +747,7 @@ export default function Studio() {
             src={pickedThumbUrl()}
             alt={t('pickedThumbAlt', { name: pickedName() })}
             draggable={false}
-            class="max-h-[90vh] max-w-[90vw] object-contain select-none"
+            class="max-h-[90vh] max-w-[90vw] object-contain select-none touch-none"
           />
         </div>
       </Show>

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -48,6 +48,8 @@ export default function Studio() {
   const [errorMsg, setErrorMsg] = createSignal<string>('');
   const [tiles, setTiles] = createSignal<Tile[]>([]);
   const [dragOver, setDragOver] = createSignal(false);
+  // #57: ドロップエリア長押し中だけ拡大プレビュー。
+  const [previewVisible, setPreviewVisible] = createSignal(false);
 
   let wasm: WasmModule | null = null;
   let fileInput: HTMLInputElement | undefined;
@@ -57,6 +59,12 @@ export default function Studio() {
   // #61: 動画タイル <video> の参照を tile index で集める。すべての mp4 化が
   // 完了した時点で一斉に play() を呼び、4 枚の動き始めを揃える。
   let videoRefs: (HTMLVideoElement | undefined)[] = [];
+  // #57: 長押し検出。pointerdown から 400ms 経つと拡大プレビューを開く。
+  // タイマーが発火した = 長押し成立した時に isLongPress を立て、
+  // 続いて発火する click を抑止してファイル選択ダイアログが開かないようにする。
+  const LONG_PRESS_MS = 400;
+  let longPressTimer: number | undefined;
+  let isLongPress = false;
 
   // タイル枚数は #61 から縦長 / 横長を問わず 12 枚で統一。依存 signal が
   // ないので createMemo は不要 (コスト払うだけ)。プレーンな関数で揃える。
@@ -296,6 +304,40 @@ export default function Studio() {
     setDragOver(false);
   };
 
+  // #57 — 長押しで拡大プレビュー。
+  // pointerdown 時に LONG_PRESS_MS のタイマーを仕掛け、満了したらオーバーレイを
+  // 開きつつ isLongPress を立てる。pointerup / cancel / leave で常にタイマー
+  // をクリアし、オーバーレイを閉じる。click は label のネイティブ動作で
+  // ファイル選択を起動するので、isLongPress が立っていたら preventDefault で
+  // 抑止する。サムネイルが無い (空ドロップエリア) ときは何もしない。
+  const cancelLongPress = () => {
+    if (longPressTimer !== undefined) {
+      clearTimeout(longPressTimer);
+      longPressTimer = undefined;
+    }
+    setPreviewVisible(false);
+  };
+  const onDropZonePointerDown = () => {
+    if (!pickedThumbUrl()) return;
+    isLongPress = false;
+    longPressTimer = window.setTimeout(() => {
+      isLongPress = true;
+      setPreviewVisible(true);
+      longPressTimer = undefined;
+    }, LONG_PRESS_MS);
+  };
+  const onDropZonePointerEnd = () => {
+    cancelLongPress();
+  };
+  const onDropZoneClick = (e: MouseEvent) => {
+    if (isLongPress) {
+      e.preventDefault();
+      e.stopPropagation();
+      // click は pointerup の後に来る一発限り。次の操作のために即リセット。
+      isLongPress = false;
+    }
+  };
+
   const setAspectAndMaybeRerun = (a: Aspect) => {
     if (aspect() === a) return;
     setAspect(a);
@@ -379,6 +421,11 @@ export default function Studio() {
         onDrop={onDrop}
         onDragOver={onDragOver}
         onDragLeave={onDragLeave}
+        onPointerDown={onDropZonePointerDown}
+        onPointerUp={onDropZonePointerEnd}
+        onPointerCancel={onDropZonePointerEnd}
+        onPointerLeave={onDropZonePointerEnd}
+        onClick={onDropZoneClick}
         class={
           'group relative block cursor-pointer rounded-xl border border-dashed py-10 px-8 text-center transition-colors duration-200 ease-out focus-within:border-focusRing ' +
           (dragOver()
@@ -412,10 +459,14 @@ export default function Studio() {
         >
           {(url) => (
             <div class="relative">
+              {/* select-none / touch-none / draggable=false で iOS の長押し
+                  callout・拡大鏡・テキスト選択・ドラッグを抑止 (#57)。 */}
               <img
                 src={url}
                 alt={t('pickedThumbAlt', { name: pickedName() })}
-                class="fade-in mx-auto max-h-40 object-contain"
+                draggable={false}
+                class="fade-in mx-auto max-h-40 object-contain select-none touch-none"
+                style={{ '-webkit-touch-callout': 'none' }}
               />
               {/* 差し替え overlay — hover / focus (group) で暗幕 + ラベル fade-in。
                   dragOver 時は薄い白オーバーレイで強調 (DESIGN.md §4 Filled state)。
@@ -671,6 +722,23 @@ export default function Studio() {
           >
             {t('downloadAll', { n: tiles().length })}
           </button>
+        </div>
+      </Show>
+
+      {/* #57 — 長押し中だけ表示する拡大プレビュー (DESIGN.md §4 PreviewOverlay)。
+          pointer-events-none で下のドロップエリアが pointerup を受けられる。
+          .fade-in (#60) を流用して 200ms フェードイン。 */}
+      <Show when={previewVisible() && pickedThumbUrl()}>
+        <div
+          class="fade-in pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-bg/80"
+          aria-hidden="true"
+        >
+          <img
+            src={pickedThumbUrl()}
+            alt={t('pickedThumbAlt', { name: pickedName() })}
+            draggable={false}
+            class="max-h-[90vh] max-w-[90vw] object-contain select-none"
+          />
         </div>
       </Show>
     </section>


### PR DESCRIPTION
## 関連 Issue
closes #57

## 変更内容

### Studio.tsx
- \`previewVisible\` signal + \`LONG_PRESS_MS = 400ms\` タイマー検出
- ドロップエリア \`<label>\` に \`pointerdown/up/cancel/leave\` で長押し検出
- \`onClick\` で \`isLongPress\` 時に \`preventDefault + stopPropagation\` してファイル選択ダイアログ起動を抑止
- サムネ \`<img>\` に \`select-none\` / \`touch-none\` / \`draggable=false\` / \`-webkit-touch-callout: none\` で iOS の callout・拡大鏡・テキスト選択・ドラッグを抑止
- プレビューオーバーレイ: \`fixed inset-0 z-50 bg-bg/80\` + 中央 \`<img max-h-[90vh] max-w-[90vw] object-contain>\`。\`pointer-events: none\` で下のドロップエリアが pointerup を受けられる。\`.fade-in\` (#60) でフェードイン

### DESIGN.md
- §4 に PreviewOverlay サブセクション追加 (寸法 / pointer-events / .fade-in 流用)

## 受け入れ条件
- [x] PC / スマホ両方で長押し拡大が動く (PC は mouse の pointerdown/up、スマホは touch の pointer events 共通経路)
- [x] 指を離すと閉じる (pointerup/cancel/leave で常に解除)
- [x] 短押し (通常クリック) では拡大しない (タイマー満了前に解除されれば isLongPress は立たない)
- [x] オーバーレイは pointer-events: none なので下のフォーム操作と競合しない

## Test plan
- [x] \`cd web && npm run build\` 通過
- [ ] PC: 画像を載せた状態でサムネを長押し → 拡大表示。離すと閉じる
- [ ] PC: サムネを通常クリック → ファイル選択ダイアログが開く
- [ ] スマホ: 同上 + iOS の callout / 拡大鏡が出ないこと
- [ ] サムネが無い (空ドロップエリア) ときに長押ししても何も起きないこと