### PR TITLE
feat(web,wasm): orber#73 DL 時に 1080×1920 で再描画して高解像度版を出す

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -231,6 +231,71 @@ pub fn generate_batch(params_js: JsValue, n: u32) -> Result<js_sys::Array, JsErr
     Ok(arr)
 }
 
+/// バッチ N 枚のうち `spec_idx` 番目だけを 1 枚 PNG として生成する。
+///
+/// `generate_batch` と同じ `random_batch_specs(seed, total, still_count)` で
+/// spec 列を再構築し、`spec_idx` 番目だけ描画する。`width`/`height` を上げて
+/// 呼べば「同じバリエーションの高解像版」が得られるので、GUI のダウンロード時
+/// に表示用プレビュー（540×960）と別の解像度で焼き直す用途を想定（#73）。
+///
+/// 動画タイル領域（`spec_idx >= still_count`）では
+/// `start_animation_for_batch_spec` と同じく `GUI_VIDEO_DIRECTIONS` で
+/// direction を 4 方向に上書きし、video タイルの t=0 フレームと完全一致させる。
+#[wasm_bindgen]
+pub fn generate_one_at_index(
+    params_js: JsValue,
+    n: u32,
+    spec_idx: u32,
+) -> Result<js_sys::Uint8Array, JsError> {
+    let mut p = deserialize_params(params_js).map_err(err_to_js)?;
+    let shape = parse_shape(&p.shape).map_err(err_to_js)?;
+
+    let total = (n as usize).clamp(1, 50);
+    let spec_idx = spec_idx as usize;
+    if spec_idx >= total {
+        return Err(JsError::new(&format!(
+            "spec_idx {spec_idx} is out of range [0, {total})"
+        )));
+    }
+    let still_count = total.saturating_sub(GUI_VIDEO_COUNT_DEFAULT);
+
+    let source = build_source_image(&mut p).map_err(err_to_js)?;
+    let clusters_full = extract_clusters(&source, p.k)
+        .map_err(|e| JsError::new(&format!("cluster extraction failed: {e}")))?;
+    let bg = derive_background_rgba(&clusters_full);
+    let clusters = drop_dominant(&clusters_full);
+
+    let specs = random_batch_specs(p.seed as u64, total, still_count);
+    let spec = specs[spec_idx];
+
+    // 動画タイル領域なら start_animation_for_batch_spec と同じ direction 上書き。
+    // 静止画タイルなら spec.direction をそのまま使う。
+    let direction = if spec_idx >= still_count {
+        let video_idx = spec_idx - still_count;
+        debug_assert!(video_idx < GUI_VIDEO_COUNT_DEFAULT);
+        GUI_VIDEO_DIRECTIONS[video_idx]
+    } else {
+        spec.direction
+    };
+
+    let opts = AnimateOptions {
+        width: p.width,
+        height: p.height,
+        seed: spec.seed,
+        direction,
+        speed: spec.speed,
+        count: Some(spec.count),
+        orb_size: spec.orb_size,
+        blur: spec.blur,
+        saturation: 1.0,
+        background: bg,
+        shape,
+    };
+    let frame = render_frame(&clusters, &opts, 0.0);
+    let png = encode_png_rgba(&frame)?;
+    Ok(js_sys::Uint8Array::from(&png[..]))
+}
+
 /// 動画 1 タイル分の RGBA フレームを 1 枚ずつ取り出すハンドル。
 ///
 /// `start_animation_for_batch_spec` で構築する。各 `next_frame()` は

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -36,6 +36,19 @@ const BATCH_TILE_COUNT = 12;
 // 1 枚ずつ重複なく見せる、wasm 側の start_animation_for_batch_spec が固定割当）。
 const VIDEO_TILE_COUNT = 4;
 
+// 解像度トークン (#73)。プレビューは選別用に軽量、DL は実用解像度。
+// すべて 9:16 / 16:9 を厳守。`generate_one_at_index` / `start_animation_for_batch_spec`
+// は同じ baseSeed + (total, index) で同じ spec を再現するので、width/height だけ
+// 上げれば「同じバリエーションの高解像版」が得られる（決定論性は wasm 側で担保）。
+const PREVIEW_W_PORTRAIT = 540;
+const PREVIEW_H_PORTRAIT = 960;
+const PREVIEW_W_LANDSCAPE = 960;
+const PREVIEW_H_LANDSCAPE = 540;
+const DL_W_PORTRAIT = 1080;
+const DL_H_PORTRAIT = 1920;
+const DL_W_LANDSCAPE = 1920;
+const DL_H_LANDSCAPE = 1080;
+
 export default function Studio() {
   const [wasmStatus, setWasmStatus] = createSignal<'loading' | 'ready' | 'error'>('loading');
   const [wasmErr, setWasmErr] = createSignal<string>('');
@@ -51,12 +64,24 @@ export default function Studio() {
   const [dragOver, setDragOver] = createSignal(false);
   // #57: ドロップエリア長押し中だけ拡大プレビュー。
   const [previewVisible, setPreviewVisible] = createSignal(false);
+  // #73: DL 時の hi-res 再描画進捗。downloading=true の間 DL ボタンを
+  // ロックし、進捗テキスト「高解像度版を準備中… {done} / {total}」を出す。
+  const [downloading, setDownloading] = createSignal(false);
+  const [dlProgress, setDlProgress] = createSignal<{ done: number; total: number }>({
+    done: 0,
+    total: 0,
+  });
 
   let wasm: WasmModule | null = null;
   let fileInput: HTMLInputElement | undefined;
   // 同時実行中の runBatch を区別するための世代カウンタ。
   // 進行中のループは自分の世代と現世代を比較して食い違ったら抜ける。
   let runGen = 0;
+  // #73: 直近の runBatch の baseSeed と aspect を保持する。DL 時に
+  // hi-res で再描画するときに同じ baseSeed を使うことで、プレビューと
+  // 同じバリエーション（spec 列）を解像度違いで再現する。
+  // null は「まだ runBatch していない / 失敗した」状態。
+  let lastBaseSeed: number | null = null;
   // #61: 動画タイル <video> の参照を tile index で集める。すべての mp4 化が
   // 完了した時点で一斉に play() を呼び、4 枚の動き始めを揃える。
   let videoRefs: (HTMLVideoElement | undefined)[] = [];
@@ -147,11 +172,16 @@ export default function Studio() {
     // #61: 新しい run の開始でビデオ参照テーブルもリセット。
     videoRefs = [];
 
-    const [w, h] = aspect() === 'portrait' ? [540, 960] : [960, 540];
+    const [w, h] =
+      aspect() === 'portrait'
+        ? [PREVIEW_W_PORTRAIT, PREVIEW_H_PORTRAIT]
+        : [PREVIEW_W_LANDSCAPE, PREVIEW_H_LANDSCAPE];
     // 2**48 までは JS Number で無損失。呼び出しごとに新しい base seed を引く
     // ことで、ドラッグするたびに N 枚すべての direction / count / orb_size /
     // blur / 配置がランダムに変わる（GUI 要件）。
     const baseSeed = Math.floor(Math.random() * 2 ** 48);
+    // DL 時の hi-res 再描画で同じ spec 列を再現できるよう保存（#73）。
+    lastBaseSeed = baseSeed;
     const params = {
       source_rgb: src.rgb,
       source_width: src.width,
@@ -291,6 +321,9 @@ export default function Studio() {
   };
 
   const acceptFile = async (file: File) => {
+    // #73: hi-res 再描画中に新しい画像を受け付けると baseSeed が
+    // 上書きされて生成中の DL ジョブと食い違う。完了まで弾く。
+    if (downloading()) return;
     setErrorMsg('');
     setPickedName(file.name);
     // サムネイル URL を差し替え。前回分は revoke してメモリリークを防ぐ。
@@ -405,44 +438,132 @@ export default function Studio() {
     URL.revokeObjectURL(url);
   };
 
-  // 動画タイルなら mp4 が出来ていれば mp4、まだなら静止フォールバック PNG。
-  // 静止タイルは常に PNG。skeleton 中（blob === null）は呼び出し側で除外
-  // 済みの想定: downloadAll は generating/animating 中は disabled、
-  // downloadSelected は !blob のタイルがそもそも select できない。
-  const tilePayload = (t: Tile): { blob: Blob; ext: 'png' | 'mp4' } | null => {
-    if (t.kind === 'video' && t.videoBlob) {
-      return { blob: t.videoBlob, ext: 'mp4' };
+  // #73: DL 時の hi-res 再描画。プレビュー（540×960）とは別に、同じ
+  // baseSeed + (total, index) で `generate_one_at_index` / `start_animation_for_batch_spec`
+  // を呼び、1080×1920 の PNG / mp4 を作る。プレビューと同じバリエーションが
+  // 再現される（決定論性は wasm 側 random_batch_specs が担保）。
+  //
+  // indices は **ソース配列内の元 index**。並びを保つために Map で持ち回し、
+  // 呼び出し側でソートする。
+  const renderHiResForIndices = async (
+    indices: number[],
+  ): Promise<Map<number, { blob: Blob; ext: 'png' | 'mp4' }>> => {
+    const src = decoded();
+    const out = new Map<number, { blob: Blob; ext: 'png' | 'mp4' }>();
+    if (indices.length === 0) return out;
+    if (!src || lastBaseSeed === null || !wasm) {
+      throw new Error('cannot render hi-res: missing source / seed / wasm');
     }
-    if (!t.blob) return null;
-    return { blob: t.blob, ext: 'png' };
+
+    const a = aspect();
+    const [hiW, hiH] =
+      a === 'portrait'
+        ? [DL_W_PORTRAIT, DL_H_PORTRAIT]
+        : [DL_W_LANDSCAPE, DL_H_LANDSCAPE];
+    const total = batchN();
+    const stillCount = total - VIDEO_TILE_COUNT;
+    const useWebCodecs = isWebCodecsSupported();
+
+    // wasm の WasmParams は `source_rgb` を `std::mem::take` で持っていく
+    // ので、毎回 JS 側 src.rgb の参照を渡せば serde-wasm-bindgen がコピー
+    // してくれる（src.rgb の中身は壊れない）。direction/speed/count/orb_size/
+    // blur は generate_batch / generate_one_at_index ではどのみち無視され、
+    // spec 側の値で上書きされるので、プレビュー時と同じダミー値で良い。
+    const hiParams = {
+      source_rgb: src.rgb,
+      source_width: src.width,
+      source_height: src.height,
+      k: 5,
+      width: hiW,
+      height: hiH,
+      seed: lastBaseSeed,
+      direction: 'lr',
+      speed: 'slow',
+      count: 20,
+      orb_size: 3.0,
+      blur: 0.5,
+      shape: 'circle',
+    };
+
+    setDlProgress({ done: 0, total: indices.length });
+    for (const i of indices) {
+      if (i < stillCount) {
+        const png = wasm.generate_one_at_index(hiParams, total, i) as Uint8Array;
+        out.set(i, {
+          blob: new Blob([png], { type: 'image/png' }),
+          ext: 'png',
+        });
+      } else if (useWebCodecs) {
+        // 動画タイルは hi-res で 96 フレーム再描画 → WebCodecs で h264 mp4 化。
+        // 1080×1920 × 96 はモバイルだと数秒〜十数秒かかる。WebCodecs 非対応
+        // ブラウザは else で hi-res の t=0 PNG にフォールバック。
+        const handle = wasm.start_animation_for_batch_spec(
+          hiParams,
+          total,
+          i,
+          ANIM_TOTAL_FRAMES,
+        );
+        try {
+          const mp4 = await encodeAnimationToMp4(handle);
+          out.set(i, { blob: mp4, ext: 'mp4' });
+        } finally {
+          handle.free?.();
+        }
+      } else {
+        const png = wasm.generate_one_at_index(hiParams, total, i) as Uint8Array;
+        out.set(i, {
+          blob: new Blob([png], { type: 'image/png' }),
+          ext: 'png',
+        });
+      }
+      setDlProgress((p) => ({ ...p, done: p.done + 1 }));
+      await yieldFrame();
+    }
+    return out;
   };
 
-  const downloadTiles = async (chosen: Tile[]) => {
-    const ready = chosen
-      .map((t) => tilePayload(t))
-      .filter((p): p is { blob: Blob; ext: 'png' | 'mp4' } => p !== null);
-    if (ready.length === 0) return;
-    if (ready.length === 1) {
-      triggerDownload(ready[0].blob, `orber.${ready[0].ext}`);
-      return;
+  const downloadIndices = async (indices: number[]) => {
+    if (indices.length === 0) return;
+    setDownloading(true);
+    setErrorMsg('');
+    try {
+      const rendered = await renderHiResForIndices(indices);
+      // index 順を保ってファイル名を 01, 02, ... に振る。
+      const sorted = Array.from(rendered.entries()).sort((a, b) => a[0] - b[0]);
+      if (sorted.length === 1) {
+        triggerDownload(sorted[0][1].blob, `orber.${sorted[0][1].ext}`);
+        return;
+      }
+      const { default: JSZip } = await import('jszip');
+      const zip = new JSZip();
+      sorted.forEach(([, { blob, ext }], n) => {
+        zip.file(`orber_${String(n + 1).padStart(2, '0')}.${ext}`, blob);
+      });
+      const zipBlob = await zip.generateAsync({ type: 'blob' });
+      triggerDownload(zipBlob, 'orber.zip');
+    } catch (e) {
+      console.error('hi-res download failed', e);
+      setErrorMsg(`${t('downloadFailed')}: ${String(e)}`);
+    } finally {
+      setDownloading(false);
+      setDlProgress({ done: 0, total: 0 });
     }
-    // jszip は ZIP 化する瞬間にしか使わないので、初回 DL 時に動的読み込みする。
-    // 訪問しただけのユーザーに 30KB 余分な JS を読ませない。
-    const { default: JSZip } = await import('jszip');
-    const zip = new JSZip();
-    ready.forEach(({ blob, ext }, i) => {
-      zip.file(`orber_${String(i + 1).padStart(2, '0')}.${ext}`, blob);
-    });
-    const zipBlob = await zip.generateAsync({ type: 'blob' });
-    triggerDownload(zipBlob, 'orber.zip');
   };
 
   const downloadSelected = () => {
-    void downloadTiles(tiles().filter((t) => t.selected));
+    const indices = tiles()
+      .map((t, i) => ({ t, i }))
+      .filter(({ t }) => t.selected && t.blob)
+      .map(({ i }) => i);
+    void downloadIndices(indices);
   };
 
   const downloadAll = () => {
-    void downloadTiles(tiles());
+    const indices = tiles()
+      .map((t, i) => ({ t, i }))
+      .filter(({ t }) => t.blob)
+      .map(({ i }) => i);
+    void downloadIndices(indices);
   };
 
   // glass スタイル統一トークン — DESIGN.md §1, §4
@@ -541,6 +662,7 @@ export default function Studio() {
           aria-label={t('aspectPortrait')}
           title={t('aspectPortraitTitle')}
           onClick={() => setAspectAndMaybeRerun('portrait')}
+          disabled={downloading()}
           class={GLASS_BTN + (aspect() === 'portrait' ? ' ' + GLASS_BTN_TOGGLED : '')}
         >
           {/* 縦長を示すシルエット (角丸縦長方形) */}
@@ -563,6 +685,7 @@ export default function Studio() {
           aria-label={t('aspectLandscape')}
           title={t('aspectLandscapeTitle')}
           onClick={() => setAspectAndMaybeRerun('landscape')}
+          disabled={downloading()}
           class={GLASS_BTN + (aspect() === 'landscape' ? ' ' + GLASS_BTN_TOGGLED : '')}
         >
           {/* 横長を示すシルエット (角丸横長方形) */}
@@ -582,7 +705,13 @@ export default function Studio() {
         <button
           type="button"
           onClick={() => void runBatch()}
-          disabled={!decoded() || phase() === 'decoding' || phase() === 'generating' || phase() === 'animating'}
+          disabled={
+            !decoded() ||
+            phase() === 'decoding' ||
+            phase() === 'generating' ||
+            phase() === 'animating' ||
+            downloading()
+          }
           aria-label={t('rerollLabel')}
           title={t('rerollTitle')}
           class={GLASS_BTN}
@@ -771,7 +900,7 @@ export default function Studio() {
           <button
             type="button"
             onClick={downloadSelected}
-            disabled={selectedCount() === 0}
+            disabled={selectedCount() === 0 || downloading()}
             class={GLASS_BTN + ' text-sm'}
           >
             {t('downloadSelected')} ({selectedCount()})
@@ -779,12 +908,26 @@ export default function Studio() {
           <button
             type="button"
             onClick={downloadAll}
-            disabled={phase() === 'generating' || phase() === 'animating' || tiles().length === 0}
+            disabled={
+              phase() === 'generating' ||
+              phase() === 'animating' ||
+              downloading() ||
+              tiles().length === 0
+            }
             class={GLASS_BTN + ' text-sm'}
           >
             {t('downloadAll', { n: tiles().length })}
           </button>
         </div>
+        {/* #73: hi-res 再描画の進捗。downloading=true の間表示。 */}
+        <Show when={downloading()}>
+          <p class="fade-in text-center text-sm text-fgMuted">
+            {t('preparingDownload', {
+              done: dlProgress().done,
+              total: dlProgress().total,
+            })}
+          </p>
+        </Show>
       </Show>
 
       {/* #57 — 長押し中だけ表示する拡大プレビュー (DESIGN.md §4 PreviewOverlay)。

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -29,9 +29,15 @@ export const STRINGS = {
     en: 'Picked image: {name}',
   },
   aspectPortrait: { ja: '縦長', en: 'Portrait' },
-  aspectPortraitTitle: { ja: '縦長 540×960', en: 'Portrait 540×960' },
+  aspectPortraitTitle: {
+    ja: '縦長 9:16（プレビュー 540×960 / DL 1080×1920）',
+    en: 'Portrait 9:16 (preview 540×960, DL 1080×1920)',
+  },
   aspectLandscape: { ja: '横長', en: 'Landscape' },
-  aspectLandscapeTitle: { ja: '横長 960×540', en: 'Landscape 960×540' },
+  aspectLandscapeTitle: {
+    ja: '横長 16:9（プレビュー 960×540 / DL 1920×1080）',
+    en: 'Landscape 16:9 (preview 960×540, DL 1920×1080)',
+  },
   rerollLabel: { ja: '同じ画像でガチャ', en: 'Roll again' },
   rerollTitle: {
     ja: '同じ画像でもう一度ガチャ',
@@ -50,6 +56,14 @@ export const STRINGS = {
   },
   downloadSelected: { ja: '選択を DL', en: 'Download selected' },
   downloadAll: { ja: '全 {n} 枚 DL', en: 'Download all {n}' },
+  preparingDownload: {
+    ja: '高解像度版を準備中… {done} / {total}',
+    en: 'Rendering high-res… {done} / {total}',
+  },
+  downloadFailed: {
+    ja: 'ダウンロード準備に失敗しました',
+    en: 'Failed to prepare download',
+  },
   variationAlt: { ja: 'バリエーション {n}', en: 'Variation {n}' },
   variationAnimatedAlt: {
     ja: 'バリエーション {n} (動画)',


### PR DESCRIPTION
Closes #73

## 変更点

プレビューは 540×960 / 960×540 のまま軽量を維持し、DL ボタンを押した瞬間に
**1080×1920 / 1920×1080 で wasm 再描画**する。比率 9:16 / 16:9 を厳守。

`random_batch_specs(seed, total, still_count)` の決定論性により、
同じ baseSeed + total + still_count で spec 列は完全一致する。よって
runBatch 時に baseSeed を保存しておけば、解像度だけ変えれば
「同じバリエーションの hi-res 版」を後から再現できる。

### `crates/wasm/src/lib.rs`
- `generate_one_at_index(params, n, spec_idx)` 新設
  - 12 枚再描画ではなく**必要な index だけ**焼く → 選択 DL が軽い
  - 動画タイル領域なら `GUI_VIDEO_DIRECTIONS` で direction 上書き（既存と一致）

### `web/src/components/Studio.tsx`
- 解像度トークン分離: `PREVIEW_W_*` / `DL_W_*`
- `lastBaseSeed` を runBatch で保存
- `renderHiResForIndices`: 静止 → `generate_one_at_index`、動画 → `start_animation_for_batch_spec` × WebCodecs（hi-res params）
- DL 単発なら直 DL、複数なら ZIP
- `downloading` signal で aspect / reroll / drop を弾く（中断時の不整合防止）
- 進捗テキスト「高解像度版を準備中… {done} / {total}」

### `web/src/lib/strings.ts`
- `preparingDownload` / `downloadFailed` 追加
- `aspect*Title` を「プレビュー X / DL Y」表記に更新

## トレードオフ

- 動画 4 枚を 1080×1920 × 96 フレームで焼くのはモバイル数秒〜十数秒
  - 体感は「DL ボタン押した時の覚悟」、プレビュー速度は犠牲にしない
  - 重すぎたら video 側だけ 720×1280 に落とす案あり（別 issue）
- WebCodecs 非対応ブラウザは hi-res の t=0 PNG にフォールバック

## テスト計画

- [ ] PC で portrait 1 枚選択 DL → 1080×1920 PNG が落ちる
- [ ] PC で landscape 全 12 枚 DL → 1920×1080 の 8 PNG + 4 mp4 が ZIP に入る
- [ ] DL 中に aspect / reroll / drop が disabled になる
- [ ] DL 中に進捗テキストが done/total で更新される
- [ ] スマホで実時間を観察（mp4 4 本 hi-res が許容範囲か）
- [ ] WebCodecs 非対応想定（Firefox 旧）で mp4 が PNG にフォールバックする