### PR TITLE
perf(web): orber#75 wasm 描画 + WebCodecs を Web Worker に追い出す

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -1,13 +1,13 @@
 import { createSignal, For, onCleanup, onMount, Show } from 'solid-js';
 import { decodeImageToRgb, type DecodedImage } from '../lib/decodeImage';
+import { ANIM_TOTAL_FRAMES, isWebCodecsSupported } from '../lib/encodeMp4';
 import {
-  ANIM_TOTAL_FRAMES,
-  encodeAnimationToMp4,
-  isWebCodecsSupported,
-} from '../lib/encodeMp4';
+  workerAnimateOne,
+  workerGenerateOne,
+  workerInit,
+  workerSetSource,
+} from '../lib/orberClient';
 import { t, lang } from '../lib/strings';
-
-type WasmModule = typeof import('../wasm/orber_wasm.js');
 
 type Aspect = 'portrait' | 'landscape';
 type Phase = 'idle' | 'decoding' | 'generating' | 'animating' | 'done' | 'error';
@@ -72,8 +72,10 @@ export default function Studio() {
     total: 0,
   });
 
-  let wasm: WasmModule | null = null;
   let fileInput: HTMLInputElement | undefined;
+  // #75: 直近 workerSetSource した DecodedImage の参照。同じ画像で reroll
+  // するときは setSource を再送しない（worker 側のキャッシュをそのまま使う）。
+  let lastSourceRef: DecodedImage | null = null;
   // 同時実行中の runBatch を区別するための世代カウンタ。
   // 進行中のループは自分の世代と現世代を比較して食い違ったら抜ける。
   let runGen = 0;
@@ -100,12 +102,12 @@ export default function Studio() {
   // pre-hydration では Base.astro の inline script が <html lang> を確定済み。
   onMount(async () => {
     try {
-      const mod = await import('../wasm/orber_wasm.js');
-      await mod.default();
-      wasm = mod;
+      // #75: wasm は worker 内でロード・実行する。ここで起動して初期化を
+      // 待つことで、初回ドロップ時の体感を「即生成開始」に保つ。
+      await workerInit();
       setWasmStatus('ready');
     } catch (e) {
-      console.error('failed to load orber-wasm', e);
+      console.error('failed to init orber worker', e);
       setWasmErr(String(e));
       setWasmStatus('error');
     }
@@ -156,11 +158,6 @@ export default function Studio() {
   const runBatch = async () => {
     const src = decoded();
     if (!src) return;
-    if (!wasm) {
-      setErrorMsg('wasm not ready');
-      setPhase('error');
-      return;
-    }
 
     runGen += 1;
     const myGen = runGen;
@@ -172,6 +169,22 @@ export default function Studio() {
     // #61: 新しい run の開始でビデオ参照テーブルもリセット。
     videoRefs = [];
 
+    // #75: 入力画像が変わっていれば worker にソースをアップロードする。
+    // 同じ画像で reroll するだけなら再送しない（worker 側キャッシュ流用）。
+    if (lastSourceRef !== src) {
+      try {
+        await workerSetSource(src.rgb, src.width, src.height);
+        if (myGen !== runGen) return;
+        lastSourceRef = src;
+      } catch (e) {
+        if (myGen !== runGen) return;
+        clearTiles();
+        setErrorMsg(String(e));
+        setPhase('error');
+        return;
+      }
+    }
+
     const [w, h] =
       aspect() === 'portrait'
         ? [PREVIEW_W_PORTRAIT, PREVIEW_H_PORTRAIT]
@@ -182,10 +195,10 @@ export default function Studio() {
     const baseSeed = Math.floor(Math.random() * 2 ** 48);
     // DL 時の hi-res 再描画で同じ spec 列を再現できるよう保存（#73）。
     lastBaseSeed = baseSeed;
+    // worker 側で source_* がキャッシュから自動マージされるので、ここでは
+    // spec パラメータだけ渡す（毎回 RGB を送らない）。direction/speed/count/
+    // orb_size/blur は generate_one_at_index ではどのみち spec で上書きされる。
     const params = {
-      source_rgb: src.rgb,
-      source_width: src.width,
-      source_height: src.height,
       k: 5,
       width: w,
       height: h,
@@ -198,35 +211,21 @@ export default function Studio() {
       shape: 'circle',
     };
 
-    // 重い WASM コール前に 1 フレーム描画させる
-    await yieldFrame();
-    if (myGen !== runGen) return;
+    const total = batchN();
+    const stillCount = total - VIDEO_TILE_COUNT;
 
-    let pngs: Uint8Array[];
+    // #75: 12 枚を 1 枚ずつ worker に投げる。1 タイル分の wasm 呼び出しは
+    // 数百 ms なので、各呼び出し完了ごとに main 側 setTiles → DOM 反映 →
+    // 次の postMessage が走る。worker スレッドで動いているのでメインの
+    // タップ・スクロールはブロックされない。
     try {
-      const result = wasm.generate_batch(params, batchN());
-      pngs = result as unknown as Uint8Array[];
-    } catch (e) {
-      if (myGen !== runGen) return;
-      // skeleton を残すと無限に shimmer して紛らわしい。エラー時は片付ける。
-      clearTiles();
-      setErrorMsg(String(e));
-      setPhase('error');
-      return;
-    }
-
-    const total = pngs.length;
-    const stillCount = Math.max(0, total - VIDEO_TILE_COUNT);
-
-    try {
-      for (let i = 0; i < pngs.length; i++) {
+      for (let i = 0; i < total; i++) {
         if (myGen !== runGen) return;
-        const png = pngs[i];
+        const png = await workerGenerateOne(params, total, i);
+        if (myGen !== runGen) return;
         const blob = new Blob([png], { type: 'image/png' });
         const blobUrl = URL.createObjectURL(blob);
         const kind: Tile['kind'] = i < stillCount ? 'still' : 'video';
-        // skeleton 12 個は seedSkeletons で先置きしてあるので、index で
-        // 差し替える。push にすると skeleton が消えずに重なってしまう。
         setTiles((prev) =>
           prev.map((t, idx) =>
             idx === i ? { ...t, blob, blobUrl, kind } : t,
@@ -238,15 +237,14 @@ export default function Studio() {
       if (myGen !== runGen) return;
     } catch (e) {
       if (myGen !== runGen) return;
-      // skeleton を残すと無限に shimmer して紛らわしい。エラー時は片付ける。
       clearTiles();
       setErrorMsg(String(e));
       setPhase('error');
       return;
     }
 
-    // 後半 4 タイルを WebCodecs で mp4 化する。終わったタイルから順次 <video>
-    // に差し替わる。WebCodecs 非対応ブラウザでは static PNG のまま表示される。
+    // 後半 4 タイルを WebCodecs で mp4 化する。worker 側で encodeAnimationToMp4
+    // が走るので、main は postMessage の応答を待つだけ。
     if (!isWebCodecsSupported()) {
       setPhase('done');
       return;
@@ -257,36 +255,16 @@ export default function Studio() {
     for (let i = stillCount; i < total; i++) {
       if (myGen !== runGen) return;
       try {
-        const handle = wasm.start_animation_for_batch_spec(
-          params,
-          batchN(),
-          i,
-          ANIM_TOTAL_FRAMES,
+        const mp4Blob = await workerAnimateOne(params, total, i, ANIM_TOTAL_FRAMES);
+        if (myGen !== runGen) return;
+        const videoBlobUrl = URL.createObjectURL(mp4Blob);
+        setTiles((prev) =>
+          prev.map((t, idx) => {
+            if (idx !== i) return t;
+            if (t.videoBlobUrl) URL.revokeObjectURL(t.videoBlobUrl);
+            return { ...t, videoBlob: mp4Blob, videoBlobUrl };
+          }),
         );
-        try {
-          const mp4Blob = await encodeAnimationToMp4(handle);
-          // 並走 run が始まっていたら自分のフレームは捨てる。先行 run の
-          // VideoEncoder / mp4-muxer は close 済み（encodeAnimationToMp4 が
-          // 完了した時点で内部で finalize されている）なので、ここで blob
-          // を流しても整合性は壊れない。ただ古い tile に書き込むのは無意味
-          // なのでそのまま return。
-          if (myGen !== runGen) return;
-          const videoBlobUrl = URL.createObjectURL(mp4Blob);
-          setTiles((prev) =>
-            prev.map((t, idx) => {
-              if (idx !== i) return t;
-              // 既存 videoBlobUrl があれば revoke してから差し替える（再ロール
-              // 時の防御。現状フローでは clearTiles が先に走るので発生しないが、
-              // 将来の挙動変更で漏れないように）。
-              if (t.videoBlobUrl) URL.revokeObjectURL(t.videoBlobUrl);
-              return { ...t, videoBlob: mp4Blob, videoBlobUrl };
-            }),
-          );
-        } finally {
-          // free() は wasm-bindgen 自動生成。AnimationHandle 内部の
-          // wasm 線形メモリを解放する。
-          handle.free?.();
-        }
       } catch (e) {
         // 1 タイル分の失敗は残りタイルの動画化を止めない。
         // 最初のエラーだけ表示して continue する。
@@ -448,11 +426,10 @@ export default function Studio() {
   const renderHiResForIndices = async (
     indices: number[],
   ): Promise<Map<number, { blob: Blob; ext: 'png' | 'mp4' }>> => {
-    const src = decoded();
     const out = new Map<number, { blob: Blob; ext: 'png' | 'mp4' }>();
     if (indices.length === 0) return out;
-    if (!src || lastBaseSeed === null || !wasm) {
-      throw new Error('cannot render hi-res: missing source / seed / wasm');
+    if (lastBaseSeed === null || lastSourceRef === null) {
+      throw new Error('cannot render hi-res: missing seed / source');
     }
 
     const a = aspect();
@@ -464,15 +441,10 @@ export default function Studio() {
     const stillCount = total - VIDEO_TILE_COUNT;
     const useWebCodecs = isWebCodecsSupported();
 
-    // wasm の WasmParams は `source_rgb` を `std::mem::take` で持っていく
-    // ので、毎回 JS 側 src.rgb の参照を渡せば serde-wasm-bindgen がコピー
-    // してくれる（src.rgb の中身は壊れない）。direction/speed/count/orb_size/
-    // blur は generate_batch / generate_one_at_index ではどのみち無視され、
-    // spec 側の値で上書きされるので、プレビュー時と同じダミー値で良い。
+    // worker 側に source RGB がキャッシュ済みなので、ここでは spec パラメータ
+    // だけ渡す。direction/speed/count/orb_size/blur は generate_one_at_index
+    // ではどのみち spec で上書きされる。
     const hiParams = {
-      source_rgb: src.rgb,
-      source_width: src.width,
-      source_height: src.height,
       k: 5,
       width: hiW,
       height: hiH,
@@ -487,34 +459,18 @@ export default function Studio() {
 
     setDlProgress({ done: 0, total: indices.length });
     for (const i of indices) {
-      if (i < stillCount) {
-        const png = wasm.generate_one_at_index(hiParams, total, i) as Uint8Array;
+      if (i < stillCount || !useWebCodecs) {
+        // 静止タイル、または WebCodecs 非対応環境では hi-res の t=0 PNG。
+        const png = await workerGenerateOne(hiParams, total, i);
         out.set(i, {
           blob: new Blob([png], { type: 'image/png' }),
           ext: 'png',
         });
-      } else if (useWebCodecs) {
-        // 動画タイルは hi-res で 96 フレーム再描画 → WebCodecs で h264 mp4 化。
-        // 1080×1920 × 96 はモバイルだと数秒〜十数秒かかる。WebCodecs 非対応
-        // ブラウザは else で hi-res の t=0 PNG にフォールバック。
-        const handle = wasm.start_animation_for_batch_spec(
-          hiParams,
-          total,
-          i,
-          ANIM_TOTAL_FRAMES,
-        );
-        try {
-          const mp4 = await encodeAnimationToMp4(handle);
-          out.set(i, { blob: mp4, ext: 'mp4' });
-        } finally {
-          handle.free?.();
-        }
       } else {
-        const png = wasm.generate_one_at_index(hiParams, total, i) as Uint8Array;
-        out.set(i, {
-          blob: new Blob([png], { type: 'image/png' }),
-          ext: 'png',
-        });
+        // 動画タイルは hi-res で 96 フレーム再描画 → WebCodecs で h264 mp4 化。
+        // worker 内で完結するので main 側はメッセージを待つだけ。
+        const mp4 = await workerAnimateOne(hiParams, total, i, ANIM_TOTAL_FRAMES);
+        out.set(i, { blob: mp4, ext: 'mp4' });
       }
       setDlProgress((p) => ({ ...p, done: p.done + 1 }));
       await yieldFrame();

--- a/web/src/lib/orberClient.ts
+++ b/web/src/lib/orberClient.ts
@@ -1,0 +1,123 @@
+// orber#75 — orberWorker のメインスレッド側クライアント。
+//
+// Worker をシングルトンで起動し、postMessage を Promise 化した RPC を提供する。
+// id 採番で複数の in-flight 呼び出しを区別し、各 Promise の resolve / reject
+// を pending Map で照合する。
+//
+// 設計上の選択:
+// - Worker は 1 本のシングルトンを使い回す（wasm 初期化コストを償却）
+// - source RGB は `workerSetSource` で 1 度だけ送り、以降の呼び出しは
+//   index と spec パラメータだけ送る（毎回 RGB 数 MB を送らない）
+// - mp4 / PNG の ArrayBuffer は Transferable で worker → main を zero-copy
+
+import OrberWorker from './orberWorker?worker';
+
+interface PendingResolver {
+  resolve: (v: unknown) => void;
+  reject: (e: unknown) => void;
+}
+
+interface BaseParams {
+  k: number;
+  width: number;
+  height: number;
+  seed: number;
+  direction: string;
+  speed: string;
+  count: number;
+  orb_size: number;
+  blur: number;
+  shape: string;
+}
+
+let worker: Worker | null = null;
+let nextId = 0;
+const pending = new Map<number, PendingResolver>();
+
+function ensureWorker(): Worker {
+  if (worker) return worker;
+  const w = new OrberWorker();
+  w.addEventListener('message', (e: MessageEvent) => {
+    const { id, ok, data, error } = e.data as {
+      id: number;
+      ok: boolean;
+      data?: unknown;
+      error?: string;
+    };
+    const p = pending.get(id);
+    if (!p) return;
+    pending.delete(id);
+    if (ok) p.resolve(data);
+    else p.reject(new Error(error ?? 'worker error (no message)'));
+  });
+  w.addEventListener('error', (e) => {
+    // Worker 全体が落ちると個別の id 照合では拾えないので、pending 全部に
+    // reject を流して呼び出し側が例外で気づけるようにする。
+    console.error('orber worker fatal error', e);
+    for (const [, p] of pending) p.reject(new Error('worker crashed'));
+    pending.clear();
+    worker = null;
+  });
+  worker = w;
+  return w;
+}
+
+function call<T>(req: Record<string, unknown>, transfers: Transferable[] = []): Promise<T> {
+  const w = ensureWorker();
+  const id = ++nextId;
+  return new Promise<T>((resolve, reject) => {
+    pending.set(id, {
+      resolve: resolve as (v: unknown) => void,
+      reject: reject as (e: unknown) => void,
+    });
+    w.postMessage({ ...req, id }, transfers);
+  });
+}
+
+/** Worker を起動して wasm を初期化する。複数回呼んでも安全（worker 側で冪等）。 */
+export async function workerInit(): Promise<void> {
+  await call<void>({ kind: 'init' });
+}
+
+/**
+ * 入力画像の RGB バッファを Worker にキャッシュ。
+ * 以降の `workerGenerateOne` / `workerAnimateOne` はこのキャッシュを使う。
+ *
+ * postMessage の structuredClone で worker 側に複製される（Transferable は
+ * 使わない）。main 側 `decoded()` signal の整合性を壊さないため。コピーは
+ * 1 画像につき 1 度しか発生しないので RGB 数 MB のコピーは許容コスト。
+ */
+export async function workerSetSource(
+  rgb: Uint8Array,
+  width: number,
+  height: number,
+): Promise<void> {
+  await call<void>({ kind: 'setSource', rgb, width, height });
+}
+
+/** 1 タイル分の PNG を hi-res / lo-res のどちらでも返す。 */
+export async function workerGenerateOne(
+  params: BaseParams,
+  n: number,
+  index: number,
+): Promise<Uint8Array> {
+  const buf = await call<ArrayBuffer>({ kind: 'generateOne', params, n, index });
+  return new Uint8Array(buf);
+}
+
+/** 1 タイル分の mp4 を返す（WebCodecs + mp4-muxer で h264 化）。 */
+export async function workerAnimateOne(
+  params: BaseParams,
+  n: number,
+  index: number,
+  totalFrames: number,
+): Promise<Blob> {
+  const buf = await call<ArrayBuffer>({
+    kind: 'animateOne',
+    params,
+    n,
+    index,
+    totalFrames,
+  });
+  return new Blob([buf], { type: 'video/mp4' });
+}

--- a/web/src/lib/orberWorker.ts
+++ b/web/src/lib/orberWorker.ts
@@ -1,0 +1,134 @@
+// orber#75 — wasm 描画 + WebCodecs エンコードを Worker スレッドで実行する。
+//
+// メインスレッドは UI / DOM / Solid signal だけに集中させ、重い計算は全部
+// ここに逃がす。これによりスマホでも生成中にスクロール / タップが死なない。
+//
+// アーキテクチャ:
+//   main → postMessage({ kind, id, ... }) → worker
+//   worker → wasm 呼び出し → postMessage({ id, ok, data }) → main
+//
+// データ転送:
+//   - PNG / mp4 の ArrayBuffer は Transferable で zero-copy 返却
+//   - source RGB は `setSource` で 1 度だけ送って worker 側にキャッシュする
+//     （runBatch / DL / アスペクト切替で使い回し）
+//
+// 互換性: OffscreenCanvas / VideoEncoder / VideoFrame in Worker が要る。
+// iOS Safari 16.4+ / Android Chrome / 最近の Firefox。古い端末は対象外
+// （isWebCodecsSupported() のメイン側チェックで弾く前提）。
+
+import init, * as wasm from '../wasm/orber_wasm.js';
+import { encodeAnimationToMp4 } from './encodeMp4';
+
+let initialized = false;
+async function ensureInit() {
+  if (initialized) return;
+  await init();
+  initialized = true;
+}
+
+// 入力画像の RGB バッファを worker 側にキャッシュ。同じ画像で複数回 wasm を
+// 呼ぶ（12 枚生成 / DL hi-res 12 枚）ので、毎回 postMessage で送るのは無駄。
+// `setSource` で 1 度送って、以降の generateOne / animateOne はキャッシュを
+// 自動で混ぜ込む。
+let cachedSource: { rgb: Uint8Array; width: number; height: number } | null = null;
+
+interface BaseParams {
+  k: number;
+  width: number;
+  height: number;
+  seed: number;
+  direction: string;
+  speed: string;
+  count: number;
+  orb_size: number;
+  blur: number;
+  shape: string;
+}
+
+function mergeParams(p: BaseParams) {
+  if (!cachedSource) {
+    throw new Error('source not set — call setSource before generate/animate');
+  }
+  return {
+    ...p,
+    source_rgb: cachedSource.rgb,
+    source_width: cachedSource.width,
+    source_height: cachedSource.height,
+  };
+}
+
+type Req =
+  | { kind: 'init'; id: number }
+  | {
+      kind: 'setSource';
+      id: number;
+      rgb: Uint8Array;
+      width: number;
+      height: number;
+    }
+  | { kind: 'generateOne'; id: number; params: BaseParams; n: number; index: number }
+  | {
+      kind: 'animateOne';
+      id: number;
+      params: BaseParams;
+      n: number;
+      index: number;
+      totalFrames: number;
+    };
+
+function post(msg: unknown, transfers: Transferable[] = []) {
+  (self as unknown as Worker).postMessage(msg, transfers);
+}
+
+self.addEventListener('message', async (e: MessageEvent<Req>) => {
+  const req = e.data;
+  try {
+    await ensureInit();
+    switch (req.kind) {
+      case 'init': {
+        post({ id: req.id, ok: true });
+        break;
+      }
+      case 'setSource': {
+        cachedSource = { rgb: req.rgb, width: req.width, height: req.height };
+        post({ id: req.id, ok: true });
+        break;
+      }
+      case 'generateOne': {
+        const params = mergeParams(req.params);
+        const png = wasm.generate_one_at_index(params, req.n, req.index);
+        // png は Uint8Array。基底 ArrayBuffer を Transferable で渡す。
+        // SharedArrayBuffer になるケースは想定しないので slice で実体コピー
+        // → main 側で再構築する。Transferable で zero-copy できれば理想だが、
+        // wasm 線形メモリの ArrayBuffer は detach できないので slice 必須。
+        const buf = png.slice().buffer;
+        post({ id: req.id, ok: true, data: buf }, [buf]);
+        break;
+      }
+      case 'animateOne': {
+        const params = mergeParams(req.params);
+        const handle = wasm.start_animation_for_batch_spec(
+          params,
+          req.n,
+          req.index,
+          req.totalFrames,
+        );
+        try {
+          const blob = await encodeAnimationToMp4(handle);
+          const buf = await blob.arrayBuffer();
+          post({ id: req.id, ok: true, data: buf }, [buf]);
+        } finally {
+          handle.free?.();
+        }
+        break;
+      }
+      default: {
+        // 網羅性チェック。型システムが req: never を要求する。
+        const exhaustive: never = req;
+        throw new Error(`unknown req kind: ${JSON.stringify(exhaustive)}`);
+      }
+    }
+  } catch (err) {
+    post({ id: (req as { id?: number }).id ?? -1, ok: false, error: String(err) });
+  }
+});


### PR DESCRIPTION
Closes #75

## 変更点

メインスレッドは UI / DOM / Solid signal だけにして、重い計算（wasm 描画 + WebCodecs エンコード + mp4-muxer）を **全部 Worker に逃がす**。これにより生成中もタップ・スクロールが反応する。

### `web/src/lib/orberWorker.ts` (新規)
- wasm 初期化 + メッセージ RPC
- `init` / `setSource` / `generateOne` / `animateOne` の 4 メッセージで動く
- source RGB は `setSource` で 1 度だけ送って worker 側にキャッシュ（毎回 RGB 数 MB を送らない）
- 既存 `encodeMp4.ts` を worker 内で再利用（VideoEncoder / VideoFrame は Worker context で利用可）

### `web/src/lib/orberClient.ts` (新規)
- メインスレッド側クライアント
- Worker をシングルトンで保持、id 採番で postMessage を Promise 化
- ArrayBuffer は Transferable で zero-copy 返却

### `web/src/components/Studio.tsx`
- wasm 直接 import を撤廃、worker 経由に統一
- runBatch: `generate_batch` 1 発 → `workerGenerateOne` × 12 の逐次呼び出し（main に PNG が返ってくるたびに skeleton が 1 枚ずつ埋まる）
- 動画 4 本は `workerAnimateOne` で worker 側 mp4 化
- hi-res DL も worker 経由
- 同じ画像で reroll するときは `setSource` を再送しない（`lastSourceRef`）

## 互換性方針

OffscreenCanvas / VideoEncoder / VideoFrame in Worker が要る。
iOS 16.4+ / Android Chrome / Firefox 130+。**フォールバックは作らない**
（死コード化を防ぐため、最新ブラウザ前提で割り切る）。

## バンドル変化

- Studio.tsx チャンク: 49.98 kB → 18.36 kB（wasm + encodeMp4 が worker 側に移動）
- 新規 worker チャンク: ~42 kB
- 合計バンドルサイズはほぼ同等

## テスト計画

- [ ] スマホ実機（iPhone / Pixel）で **生成中にスクロール・タップが反応する**ことを確認（最重要）
- [ ] DevTools Performance パネルで Long Task が消えていることを確認
- [ ] 12 枚生成 / 動画 4 本 / hi-res DL がすべて worker 経由で完走すること
- [ ] 同じ画像で reroll しても source 再アップロードが発生しないこと（DevTools Network/Worker でメッセージサイズ確認）
- [ ] 別画像にドロップ → 自動的に新 source を worker に送ること