### PR TITLE
feat(web,core): orber#77 動画スクロールを遅く + 動画タイル speed を固定割当

### DIFF
--- a/crates/core/src/variations.rs
+++ b/crates/core/src/variations.rs
@@ -243,6 +243,20 @@ pub const GUI_VIDEO_DIRECTIONS: [crate::animate::MotionDirection; GUI_VIDEO_COUN
     crate::animate::MotionDirection::BottomToTop,
 ];
 
+/// GUI バッチ後半 (= 動画タイル) の speed 並び。`video_idx = spec_idx -
+/// still_count` で添字すると VerySlow / Slow が必ず 2 枚ずつ含まれる。
+///
+/// 元々は `random_batch_specs` で speed をランダムに引いていたが、それだと
+/// 「4 つ全部速い run / 全部遅い run」が偶然発生してガチャ感が薄れる。
+/// direction と同様に固定割当して、4 タイルが必ず速度のばらつきを持つよう
+/// にする (#77)。alternating 配列にすることで隣接タイルの体感差を最大化。
+pub const GUI_VIDEO_SPEEDS: [crate::animate::MotionSpeed; GUI_VIDEO_COUNT_DEFAULT] = [
+    crate::animate::MotionSpeed::VerySlow,
+    crate::animate::MotionSpeed::Slow,
+    crate::animate::MotionSpeed::VerySlow,
+    crate::animate::MotionSpeed::Slow,
+];
+
 /// GUI バッチ生成用のランダム範囲。
 ///
 /// CLI の固定 preset (`DEFAULT_VARIATIONS`) では各位置の系統が決まっているが、

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -27,6 +27,7 @@ use orber_core::orb::OrbShape;
 use orber_core::style::{render_svg as core_render_svg, StyleOptions};
 use orber_core::variations::{
     random_batch_specs, VariationSpec, GUI_VIDEO_COUNT_DEFAULT, GUI_VIDEO_DIRECTIONS,
+    GUI_VIDEO_SPEEDS,
 };
 use serde::Deserialize;
 use wasm_bindgen::prelude::*;
@@ -168,6 +169,30 @@ fn direction_for_spec_idx(
     }
 }
 
+/// バッチ index に対応する speed を返す。
+///
+/// 静止画タイル領域では spec.speed をそのまま使い、動画タイル領域では
+/// `GUI_VIDEO_SPEEDS` の対応 index で上書きする。これにより GUI 経路の
+/// 動画 4 枚は VerySlow / Slow / VerySlow / Slow と必ずばらけて、
+/// 「4 つ全部速い / 全部遅い」のガチャ感低下を防ぐ (#77)。
+///
+/// `direction_for_spec_idx` と同じ責務分担で、core の `generate_batch`
+/// は spec.speed をそのまま使うので、speed 固定割当は wasm 入口経由の
+/// GUI 経路でのみ適用される。
+fn speed_for_spec_idx(
+    spec_idx: usize,
+    still_count: usize,
+    spec: &VariationSpec,
+) -> MotionSpeed {
+    if spec_idx >= still_count {
+        let video_idx = spec_idx - still_count;
+        debug_assert!(video_idx < GUI_VIDEO_COUNT_DEFAULT);
+        GUI_VIDEO_SPEEDS[video_idx]
+    } else {
+        spec.speed
+    }
+}
+
 fn encode_png_rgba(img: &image::RgbaImage) -> Result<Vec<u8>, JsError> {
     use image::codecs::png::PngEncoder;
     use image::{ExtendedColorType, ImageEncoder};
@@ -296,17 +321,18 @@ pub fn generate_one_at_index(
     let specs = random_batch_specs(p.seed as u64, total, still_count);
     let spec = specs[spec_idx];
 
-    // direction の決定は純粋関数 direction_for_spec_idx に集約。
-    // start_animation_for_batch_spec と同じロジックを共有することで、
-    // プレビュー静止 PNG と動画タイルの direction を構造的に揃える。
+    // direction / speed は純粋関数に集約。start_animation_for_batch_spec と
+    // 同じロジックを共有することで、プレビュー静止 PNG と動画タイルの
+    // 描画パラメータが構造的に揃う（#77 で speed も index 固定割当）。
     let direction = direction_for_spec_idx(spec_idx, still_count, &spec);
+    let speed = speed_for_spec_idx(spec_idx, still_count, &spec);
 
     let opts = AnimateOptions {
         width: p.width,
         height: p.height,
         seed: spec.seed,
         direction,
-        speed: spec.speed,
+        speed,
         count: Some(spec.count),
         orb_size: spec.orb_size,
         blur: spec.blur,
@@ -409,17 +435,19 @@ pub fn start_animation_for_batch_spec(
     let spec = specs[spec_idx];
 
     // #59: 動画タイル 4 枚に LR / RL / TB / BT を 1 枚ずつ重複なく割り当てる。
-    // direction_for_spec_idx を経由することで、`generate_one_at_index` で
-    // 描かれる t=0 PNG と完全に同じ direction を選ぶ（プレビュー静止画と
-    // 動画の整合性を構造的に保証）。
+    // #77: speed も VerySlow / Slow を 2 枚ずつ固定割当（ガチャ感の保証）。
+    // direction_for_spec_idx / speed_for_spec_idx を経由することで、
+    // `generate_one_at_index` で描かれる t=0 PNG と完全に同じパラメータで
+    // 動画化される（プレビュー静止画と動画の整合性を構造的に保証）。
     let direction = direction_for_spec_idx(spec_idx, still_count, &spec);
+    let speed = speed_for_spec_idx(spec_idx, still_count, &spec);
 
     let opts = AnimateOptions {
         width: p.width,
         height: p.height,
         seed: spec.seed,
         direction,
-        speed: spec.speed,
+        speed,
         count: Some(spec.count),
         orb_size: spec.orb_size,
         blur: spec.blur,
@@ -623,5 +651,44 @@ mod tests {
             GUI_VIDEO_DIRECTIONS[0],
             "spec_idx == still_count is video range index 0"
         );
+    }
+
+    /// #77: 動画タイル領域の speed は GUI_VIDEO_SPEEDS で固定割当される。
+    /// VerySlow / Slow が必ず 2 枚ずつ（4 タイルがガチャ感を保つ最小条件）。
+    #[test]
+    fn speed_for_spec_idx_overrides_video_range_with_assigned_speeds() {
+        let still_count = 8;
+        let total = 12;
+        // spec.speed は何を入れても video 領域では無視される。
+        let mut spec = synth_spec(MotionDirection::LeftToRight);
+        spec.speed = MotionSpeed::Slow;
+        let mut very_slow = 0;
+        let mut slow = 0;
+        for spec_idx in still_count..total {
+            let s = speed_for_spec_idx(spec_idx, still_count, &spec);
+            assert_eq!(s, GUI_VIDEO_SPEEDS[spec_idx - still_count]);
+            match s {
+                MotionSpeed::VerySlow => very_slow += 1,
+                MotionSpeed::Slow => slow += 1,
+            }
+        }
+        // 4 タイルで 2 + 2 のばらけが固定で保証される。
+        assert_eq!(very_slow, 2, "must have exactly 2 VerySlow tiles");
+        assert_eq!(slow, 2, "must have exactly 2 Slow tiles");
+    }
+
+    /// 静止画タイル領域では spec.speed をそのまま使う。
+    #[test]
+    fn speed_for_spec_idx_returns_spec_speed_for_still_range() {
+        let still_count = 8;
+        let mut spec = synth_spec(MotionDirection::TopToBottom);
+        spec.speed = MotionSpeed::VerySlow;
+        for spec_idx in 0..still_count {
+            assert_eq!(
+                speed_for_spec_idx(spec_idx, still_count, &spec),
+                MotionSpeed::VerySlow,
+                "still tile {spec_idx} must inherit spec.speed"
+            );
+        }
     }
 }

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -197,6 +197,23 @@ Determinism is provided by `random_batch_specs(seed, total, still_count)` in
 `crates/core::variations`: the same `baseSeed` reproduces the exact same
 variation specs at any resolution.
 
+**Video tile direction & speed assignment.** Each of the 4 video tiles in a
+batch gets its `direction` and `speed` deterministically assigned by index, not
+randomly. `GUI_VIDEO_DIRECTIONS = [LR, RL, TB, BT]` and
+`GUI_VIDEO_SPEEDS = [VerySlow, Slow, VerySlow, Slow]` guarantee that every
+roll contains all 4 directions exactly once and a 2:2 mix of slow/very-slow,
+so a batch never degenerates into "all 4 fast" or "all 4 slow". Static tiles
+keep their spec values; only the animated tiles get the override (#59 / #77).
+The wasm helpers `direction_for_spec_idx` / `speed_for_spec_idx` apply the
+same logic to both the preview PNG (`generate_one_at_index`) and the
+animation cursor (`start_animation_for_batch_spec`), so the t=0 frame and the
+mp4 are guaranteed to match.
+
+**Clip duration.** Animated tiles are **8 seconds long at 24 fps** (192 frames).
+Combined with the assigned speeds above, VerySlow tiles cross the screen once
+in 8 s — slow enough to feel "drifting", appropriate for use as overlay /
+background plates beneath text.
+
 **Browser requirements.** OffscreenCanvas / VideoEncoder / VideoFrame in Worker
 context. iOS Safari 16.4+, current Android Chrome / Firefox 130+. There is no
 fallback path for older browsers — the GUI shows an error if WebCodecs is

--- a/web/src/lib/encodeMp4.ts
+++ b/web/src/lib/encodeMp4.ts
@@ -20,9 +20,13 @@ export interface AnimationHandleLike {
 }
 
 export const ANIM_FPS = 24;
-// 4 秒ぶん。orber の motion model は t=0 と t=1 がピクセル一致するので、
-// `<video loop>` で継ぎ目なくエンドレス再生される。
-export const ANIM_DURATION_SECONDS = 4;
+// #77: 8 秒ぶん。背景・配信オーバーレイ用途では「ほとんど動いていないように
+// 見える」レベルの遅さが理想。VerySlow (cycle_count=1) なら 1 cross / 8s で
+// 画面端から端まで 8 秒かけて drift する。orber の motion model は t=0 と
+// t=1 がピクセル一致するので `<video loop>` で継ぎ目なくループする。
+// 4 → 8 で frame 数が倍になるため worker 側 mp4 化時間も倍だが、worker
+// 経由なので main thread はブロックしない（#75）。
+export const ANIM_DURATION_SECONDS = 8;
 export const ANIM_TOTAL_FRAMES = ANIM_FPS * ANIM_DURATION_SECONDS;
 
 export function isWebCodecsSupported(): boolean {


### PR DESCRIPTION
Closes #77

(1) ANIM_DURATION_SECONDS 4 → 8 で全体スローダウン
(2) GUI_VIDEO_SPEEDS = [VerySlow, Slow, VerySlow, Slow] で必ず 2:2 のばらけを保証

orber-wasm 11 → 13 (+2 tests), orber-core 88 全件 pass。