### PR TITLE
feat(web): ドロップエリア文言を短縮 (#89)

### DIFF
--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -20,8 +20,8 @@ export const STRINGS = {
     en: 'Choose or drop an image',
   },
   dropZonePlaceholder: {
-    ja: '画像を 1 つドロップ / クリックして選択',
-    en: 'Drop an image or click to choose',
+    ja: '画像をドロップ / クリック',
+    en: 'Drop or click an image',
   },
   replaceImageHint: { ja: '差し替え', en: 'Replace' },
   pickedThumbAlt: {


### PR DESCRIPTION
## 関連 Issue
closes #89

## 変更内容
- `dropZonePlaceholder` を短縮
  - ja: `画像を 1 つドロップ / クリックして選択` → `画像をドロップ / クリック`
  - en: `Drop an image or click to choose` → `Drop or click an image`

クリック可能であることは残し、スマホ幅 (~360px) で 1 行に収まる長さにした。
aria-label / title のリッチ文言は維持。

## 受け入れ条件
- [x] スマホ幅でプレースホルダーが 1 行に収まる
- [x] aria-label / title は維持
- [x] CSS ではなく文言短縮で対応