### PR TITLE
fix(web): 動画化部分失敗を warning として表示 (#94)

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -353,8 +353,11 @@ export default function Studio() {
         // #94: 動画化 4 枚のうち一部失敗は fatal ではない（残りタイルは
         // 静止画として完成済み、phase も 'done' に遷移する）。errorMsg
         // ではなく warningMsg に入れて、'done' 状態でも見える弱めの
-        // 通知バナーで表示する。
-        setWarningMsg(`${t('animateError')}: ${String(firstAnimErr)}`);
+        // 通知バナーで表示する。エラー詳細（DOMException メッセージ等）
+        // は end user に意味が薄いので console に留め、UI には事実
+        // ベースの warning 文言だけを出す。
+        console.error('animation partial failure detail:', firstAnimErr);
+        setWarningMsg(t('animatePartialFailure'));
       }
     }
 
@@ -805,13 +808,19 @@ export default function Studio() {
       </Show>
 
       <Show when={errorMsg() && phase() === 'error'}>
-        <div class="fade-in rounded border border-hairline bg-glassBg p-3 text-sm text-fg">
+        <div
+          role="alert"
+          class="fade-in rounded border border-hairline bg-glassBg p-3 text-sm text-fg"
+        >
           {errorMsg()}
         </div>
       </Show>
 
-      {/* #94: 部分失敗の弱め通知。phase='done' でも残しておく。 */}
-      <Show when={warningMsg() && phase() === 'done'}>
+      {/* #94: 部分失敗の弱め通知。fatal な error ではないので
+          phase !== 'error' のとき表示する（'done' に限らず将来の
+          他フェーズでも残す）。fatal が同時発生した場合は error バナーが
+          優先されて warning は隠れる。 */}
+      <Show when={warningMsg() && phase() !== 'error'}>
         <div
           role="status"
           class="fade-in rounded border border-hairline bg-glassBg p-3 text-sm text-fgMuted"

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -61,6 +61,10 @@ export default function Studio() {
   const [phase, setPhase] = createSignal<Phase>('idle');
   const [progress, setProgress] = createSignal<number>(0);
   const [errorMsg, setErrorMsg] = createSignal<string>('');
+  // #94: fatal な errorMsg と分けて、部分失敗（動画化 4 枚のうち一部だけ
+  // mp4 化に失敗、他は完走）を弱めの通知で出すための signal。phase が
+  // 'done' でも表示できるよう、専用の Show ブロックで描画する。
+  const [warningMsg, setWarningMsg] = createSignal<string>('');
   const [tiles, setTiles] = createSignal<Tile[]>([]);
   const [dragOver, setDragOver] = createSignal(false);
   // #57: ドロップエリア長押し中だけ拡大プレビュー。
@@ -175,6 +179,7 @@ export default function Studio() {
 
     seedSkeletons();
     setErrorMsg('');
+    setWarningMsg('');
     setProgress(0);
     setPhase('generating');
     // #61: 新しい run の開始でビデオ参照テーブルもリセット。
@@ -345,7 +350,11 @@ export default function Studio() {
       await Promise.all(animPromises);
       if (myGen !== runGen) return;
       if (firstAnimErr !== null) {
-        setErrorMsg(`${t('animateError')}: ${String(firstAnimErr)}`);
+        // #94: 動画化 4 枚のうち一部失敗は fatal ではない（残りタイルは
+        // 静止画として完成済み、phase も 'done' に遷移する）。errorMsg
+        // ではなく warningMsg に入れて、'done' 状態でも見える弱めの
+        // 通知バナーで表示する。
+        setWarningMsg(`${t('animateError')}: ${String(firstAnimErr)}`);
       }
     }
 
@@ -798,6 +807,16 @@ export default function Studio() {
       <Show when={errorMsg() && phase() === 'error'}>
         <div class="fade-in rounded border border-hairline bg-glassBg p-3 text-sm text-fg">
           {errorMsg()}
+        </div>
+      </Show>
+
+      {/* #94: 部分失敗の弱め通知。phase='done' でも残しておく。 */}
+      <Show when={warningMsg() && phase() === 'done'}>
+        <div
+          role="status"
+          class="fade-in rounded border border-hairline bg-glassBg p-3 text-sm text-fgMuted"
+        >
+          {warningMsg()}
         </div>
       </Show>
 

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -55,6 +55,12 @@ export const STRINGS = {
     ja: '動画生成に失敗したタイルがあります',
     en: 'Some tiles failed to encode to video',
   },
+  // #94: 部分失敗 warning 用。fatal 風に響かないよう「一部のタイルは
+  // 静止画のままです」という事実ベースの言い回しに分けてある。
+  animatePartialFailure: {
+    ja: '一部のタイルは動画化できず、静止画のままです',
+    en: 'Some tiles could not be animated and remain as stills',
+  },
   downloadSelected: { ja: '選択を DL', en: 'Download selected' },
   downloadAll: { ja: '全 {n} 枚 DL', en: 'Download all {n}' },
   preparingDownload: {


### PR DESCRIPTION
## 関連 Issue
closes #94

## 変更内容
- `Studio.tsx` に `warningMsg` signal を追加（fatal な errorMsg と分離）
- 動画化ループの `firstAnimErr` 集約を `setErrorMsg` → `setWarningMsg` に変更
- runBatch 冒頭で `warningMsg` もクリア
- UI: `<Show when={warningMsg() && phase() === 'done'}>` の弱めバナーを追加（hairline + glassBg + text-fgMuted、role="status"）
- DESIGN.md の glass UI に整合（accent color なし、hairline 境界、fg-muted テキスト）

## 動作
- 動画 4 枚のうち一部が mp4 化失敗 → 静止画は出ている → phase は 'done' に遷移 → warning バナーで「動画化に失敗：XX」を表示
- 全 fatal なエラー（worker クラッシュ、setSource 失敗等）は従来通り errorMsg + phase='error'

## 受け入れ条件
- [x] 動画化部分失敗時に UI にメッセージが出る
- [x] fatal エラーの表示は従来通り
- [x] DESIGN.md のスタイルトークンと整合