### PR TITLE
fix(web): 動画タイル長押し拡大プレビューを Android/Desktop 双方で発火させる

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -687,12 +687,11 @@ export default function Studio() {
         >
           {(url) => (
             <div class="relative">
-              {/* select-none / touch-none / draggable=false で iOS の長押し
-                  callout・拡大鏡・テキスト選択・ドラッグを抑止 (#57)。
-                  Android Chrome の「画像を保存」コンテキストメニューは
-                  touch-action では止まらないので oncontextmenu で抑止 (#87)。
-                  pointer-events-none で pointerdown を img ではなく親 label に
-                  届け、長押しタイマーを確実に発火させる (#87)。 */}
+              {/* select-none / touch-none / draggable=false / oncontextmenu /
+                  pointer-events-none で iOS の長押し callout・拡大鏡・
+                  テキスト選択・ドラッグ・Android の画像保存メニューを
+                  全て抑止し (#57 / #87)、pointerdown を確実に親 label の
+                  onPointerDown に届けて 400ms 長押しタイマーを発火させる。 */}
               <img
                 src={url}
                 alt={t('pickedThumbAlt', { name: pickedName() })}

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -688,12 +688,17 @@ export default function Studio() {
           {(url) => (
             <div class="relative">
               {/* select-none / touch-none / draggable=false で iOS の長押し
-                  callout・拡大鏡・テキスト選択・ドラッグを抑止 (#57)。 */}
+                  callout・拡大鏡・テキスト選択・ドラッグを抑止 (#57)。
+                  Android Chrome の「画像を保存」コンテキストメニューは
+                  touch-action では止まらないので oncontextmenu で抑止 (#87)。
+                  pointer-events-none で pointerdown を img ではなく親 label に
+                  届け、長押しタイマーを確実に発火させる (#87)。 */}
               <img
                 src={url}
                 alt={t('pickedThumbAlt', { name: pickedName() })}
                 draggable={false}
-                class="fade-in mx-auto max-h-40 object-contain select-none touch-none"
+                onContextMenu={(e) => e.preventDefault()}
+                class="fade-in pointer-events-none mx-auto max-h-40 object-contain select-none touch-none"
                 style={{ '-webkit-touch-callout': 'none' }}
               />
               {/* 差し替え overlay — hover / focus (group) で暗幕 + ラベル fade-in。

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -631,7 +631,7 @@ export default function Studio() {
         onPointerCancel={onDropZonePointerEnd}
         onClick={onDropZoneClick}
         class={
-          'group relative block cursor-pointer touch-manipulation rounded-xl py-10 px-8 text-center transition-colors duration-200 ease-out focus-within:text-focusRing ' +
+          'group relative block cursor-pointer touch-none rounded-xl py-10 px-8 text-center transition-colors duration-200 ease-out focus-within:text-focusRing ' +
           (dragOver()
             ? 'text-fg bg-glassBg'
             : 'text-hairline hover:text-fgMuted')


### PR DESCRIPTION
## 関連 Issue
closes #87

## 変更内容

### 1. ドロップエリア `<label>` を `touch-action: none` に
- `touch-manipulation` → `touch-none`
- Android Chrome は指の微小な動きで pointercancel を早期発火し、400ms タイマー満了前に `onDropZonePointerEnd` が呼ばれてクリアされていた
- `touch-action: none` でブラウザ既定のスクロール/ズーム判定を止める

### 2. サムネ `<img>` に `onContextMenu` 抑止
- Android Chrome の「画像を保存」長押しメニュー (context menu) は touch-action では止まらない
- `e.preventDefault()` で抑止し、ネイティブメニューが拡大プレビューを覆い隠す状態を解消

### 3. サムネ `<img>` を `pointer-events-none` に
- デスクトップでも長押しプレビューが発火しない件への対応
- `<img>` が pointerdown を受けるとブラウザ既定の image drag / context menu 経路に化け、400ms タイマー満了前にキャンセルされていた疑い
- `pointer-events-none` で pointerdown を確実に親 `<label>` に届ける
- group-hover はラベル側で判定するので hover overlay は不変

## 受け入れ条件
- [ ] Android Chrome 実機: サムネ長押し 400ms → プレビューオーバーレイ表示（ネイティブメニュー出ない）
- [ ] Desktop Chrome: マウス長押し 400ms → プレビューオーバーレイ表示
- [ ] iOS Safari: 従来通り動作
- [ ] ドロップエリアタップ → ファイル選択ダイアログ