### PR TITLE
fix(web): 動画タイルの shimmer 点滅を除去（進捗リングと冗長）

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -909,10 +909,11 @@ export default function Studio() {
                     />
                   </Show>
                   {/* 動画タイル限定: 静止 PNG は出たが mp4 がまだ来てない間、
-                      soft shimmer + コーナーバッジを重ねて「これから動く」
-                      ことを示す。skeleton（強い shimmer）= 何もない /
-                      skeleton-soft（弱い shimmer）= 静止は出たが動画は処理中
-                      の二段階で進行を表現する。
+                      コーナーバッジ + #95 進捗リングを重ねて「これから動く」
+                      ことを示す。以前は skeleton-soft の shimmer も重ねていたが、
+                      フレーム単位の進捗リングが出来た今は shimmer が点滅に
+                      見えるため除去（静止 PNG は既に出ているので点滅させる
+                      必然性がない）。
                       レビュー S3: WebCodecs 非対応環境では videoBlobUrl が
                       永遠に来ないので、バッジを出すと「処理中」が固着して
                       しまう。環境チェックで gating する。 */}
@@ -923,7 +924,6 @@ export default function Studio() {
                       isWebCodecsSupported()
                     }
                   >
-                    <div class="skeleton-soft fade-in absolute inset-0" aria-hidden="true" />
                     {/* レビュー N10/N11: text サイズは DESIGN.md の type scale
                         最小 (text-xs = 12px) に揃える。aria-label と表示テキスト
                         の二重指定はスクリーンリーダーで二重読みになるので、

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -75,22 +75,6 @@ const { title = 'orber' } = Astro.props;
         background-size: 200% 100%;
         animation: orb-skeleton-shimmer 1.6s linear infinite;
       }
-      /* orber#? — 静止 PNG が出来た後、動画化が完了するまで重ねる soft 版。
-         skeleton と同じ shimmer を bg-color なしで動かし、下の PNG が透ける
-         ようにする。「処理中」シグナルを skeleton と一貫した語彙で出すための
-         二段階表現（強い shimmer = まだ何もない、弱い shimmer = 静止は出た
-         けど動画はまだ）。 */
-      .skeleton-soft {
-        background-image: linear-gradient(
-          90deg,
-          rgba(255, 255, 255, 0) 0%,
-          rgba(255, 255, 255, 0.18) 50%,
-          rgba(255, 255, 255, 0) 100%
-        );
-        background-size: 200% 100%;
-        animation: orb-skeleton-shimmer 1.8s linear infinite;
-        pointer-events: none;
-      }
       @media (prefers-reduced-motion: reduce) {
         /* belt-and-suspenders — 変数を 0ms にすれば animation-duration も
            解決時に 0ms になるが、念のため `.fade-in` 側でも明示する。 */
@@ -101,10 +85,6 @@ const { title = 'orber' } = Astro.props;
           animation-duration: 0ms;
         }
         .skeleton {
-          animation: none;
-          background-image: none;
-        }
-        .skeleton-soft {
           animation: none;
           background-image: none;
         }


### PR DESCRIPTION
## 変更内容
動画化中の動画タイルに重なっていた `.skeleton-soft` の弱い shimmer を除去。

## 背景
#95 でフレーム単位の進捗リングを実装した結果、shimmer が点滅に見える状態に。静止 PNG は既に出ているので shimmer で「処理中」を示す必然性はなく、**進捗リング + コーナーバッジ** で十分。

## 修正
- `Studio.tsx`: 動画タイルの `<div class="skeleton-soft">` 削除
- `Base.astro`: `.skeleton-soft` の CSS 定義 + `prefers-reduced-motion` override 削除（他に利用箇所なし）

進捗リング (#95) / バッジ / fade-in は維持。