### PR TITLE
fix(web): タイル点滅解消 + 出力タイル長押しプレビュー + debug log revert

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -23,10 +23,6 @@ interface Tile {
   // 動画タイル限定: WebCodecs で生成した mp4。動画化が完了するまで undefined。
   videoBlob?: Blob;
   videoBlobUrl?: string;
-  // #95: 動画タイル限定。mp4 化のフレーム単位進捗。worker 側 encodeMp4 から
-  // 1 フレームごとに更新される。完成（videoBlobUrl 設定）と同時に undefined
-  // にクリアする。
-  animProgress?: { frame: number; total: number };
   selected: boolean;
 }
 
@@ -70,6 +66,15 @@ export default function Studio() {
   // 'done' でも表示できるよう、専用の Show ブロックで描画する。
   const [warningMsg, setWarningMsg] = createSignal<string>('');
   const [tiles, setTiles] = createSignal<Tile[]>([]);
+  // #95 + flicker fix: 動画タイルの mp4 化進捗を tiles とは別の signal で
+  // 持つ。tiles に animProgress を埋めると 1 フレームごとに setTiles で
+  // タイル参照が変わり、Solid の <For> がボタン全体を unmount/remount して
+  // <img class="fade-in"> の CSS アニメーションが再発火 → 静止 PNG が
+  // 点滅して見える。進捗だけ別 signal にすれば tile 参照は不変のまま、
+  // SVG リング部分だけが反応的に再描画される。Map のキーはタイル index。
+  const [animProgressMap, setAnimProgressMap] = createSignal<
+    Map<number, { frame: number; total: number }>
+  >(new Map());
   const [dragOver, setDragOver] = createSignal(false);
   // #57: ドロップエリア長押し中だけ拡大プレビュー。
   const [previewVisible, setPreviewVisible] = createSignal(false);
@@ -149,6 +154,7 @@ export default function Studio() {
       if (t.videoBlobUrl) URL.revokeObjectURL(t.videoBlobUrl);
     }
     setTiles([]);
+    setAnimProgressMap(new Map());
   };
 
   // runBatch 冒頭で呼ぶ: 既存タイルの URL を revoke し、新しい 12 個の
@@ -300,13 +306,11 @@ export default function Studio() {
           // 古い世代の更新は無視する（runGen ガード）。
           (frame, totalFrames) => {
             if (myGen !== runGen) return;
-            setTiles((prev) =>
-              prev.map((tile, idx) =>
-                idx === i
-                  ? { ...tile, animProgress: { frame, total: totalFrames } }
-                  : tile,
-              ),
-            );
+            setAnimProgressMap((prev) => {
+              const next = new Map(prev);
+              next.set(i, { frame, total: totalFrames });
+              return next;
+            });
           },
         );
         if (myGen !== runGen) return;
@@ -315,10 +319,16 @@ export default function Studio() {
           prev.map((t, idx) => {
             if (idx !== i) return t;
             if (t.videoBlobUrl) URL.revokeObjectURL(t.videoBlobUrl);
-            // #95: 完成と同時に animProgress をクリア。
-            return { ...t, videoBlob: mp4Blob, videoBlobUrl, animProgress: undefined };
+            return { ...t, videoBlob: mp4Blob, videoBlobUrl };
           }),
         );
+        // #95: 完成と同時に進捗リングをクリア。
+        setAnimProgressMap((prev) => {
+          if (!prev.has(i)) return prev;
+          const next = new Map(prev);
+          next.delete(i);
+          return next;
+        });
         // #61 + #88: setTiles → DOM mount → ref 確定 のサイクルを
         // 1 フレーム回してから play() を呼ぶ。myGen check は yieldFrame
         // 後にも入れて、再 run で世代が進んだら play() を抑止する。
@@ -348,12 +358,15 @@ export default function Studio() {
         // 最初のエラーだけ後段で表示する。
         console.error('mp4 encode failed for tile', i, e);
         if (firstAnimErr === null) firstAnimErr = e;
-        // #95 レビュー Q2: 失敗パスでも animProgress をクリアして
-        // 進捗リングを消す（残ったままだと「中途半端な進捗」が固まる）。
+        // #95 レビュー Q2: 失敗パスでも進捗リングをクリア
+        // （残ったままだと「中途半端な進捗」が固まる）。
         if (myGen === runGen) {
-          setTiles((prev) =>
-            prev.map((t, idx) => (idx === i ? { ...t, animProgress: undefined } : t)),
-          );
+          setAnimProgressMap((prev) => {
+            if (!prev.has(i)) return prev;
+            const next = new Map(prev);
+            next.delete(i);
+            return next;
+          });
         }
       }
     }
@@ -449,25 +462,19 @@ export default function Studio() {
     setPreviewVisible(false);
   };
   const onDropZonePointerDown = (e: PointerEvent) => {
-    console.log('[orber#87] pointerdown', { pointerType: e.pointerType, hasThumb: !!pickedThumbUrl(), target: (e.target as HTMLElement)?.tagName, currentTarget: (e.currentTarget as HTMLElement)?.tagName });
     if (!pickedThumbUrl()) return;
     isLongPress = false;
+    // ジェスチャ全体を label に閉じ込める。指が外にスライドしても
+    // pointerup / pointercancel が必ず label に届く。
     const target = e.currentTarget as HTMLElement | null;
-    try {
-      target?.setPointerCapture?.(e.pointerId);
-      console.log('[orber#87] setPointerCapture ok', e.pointerId);
-    } catch (err) {
-      console.log('[orber#87] setPointerCapture failed', err);
-    }
+    target?.setPointerCapture?.(e.pointerId);
     longPressTimer = window.setTimeout(() => {
-      console.log('[orber#87] timer fired → showing preview');
       isLongPress = true;
       setPreviewVisible(true);
       longPressTimer = undefined;
     }, LONG_PRESS_MS);
   };
-  const onDropZonePointerEnd = (e: PointerEvent) => {
-    console.log('[orber#87] pointerend', { type: e.type, pointerType: e.pointerType, timerActive: longPressTimer !== undefined });
+  const onDropZonePointerEnd = () => {
     endLongPress();
   };
   const onDropZoneClick = (e: MouseEvent) => {
@@ -941,7 +948,7 @@ export default function Studio() {
                         accent color なし、currentColor + text-fgMuted で淡く
                         重ねる。orb と被らない右上配置。SVG だけなので
                         glass-bg の塗りつぶしは付けない。 */}
-                    <Show when={tile.animProgress}>
+                    <Show when={animProgressMap().get(i())}>
                       {(progress) => {
                         const pct = () =>
                           progress().total > 0

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, onCleanup, onMount, Show } from 'solid-js';
+import { createMemo, createSignal, For, onCleanup, onMount, Show } from 'solid-js';
 import { decodeImageToRgb, type DecodedImage } from '../lib/decodeImage';
 import { ANIM_TOTAL_FRAMES, isWebCodecsSupported } from '../lib/encodeMp4';
 import {
@@ -81,6 +81,14 @@ export default function Studio() {
   // 出力 orb タイルの長押し拡大プレビュー（入力サムネ #57 と同じ UX）。
   // null = 非表示。number = 該当タイル index を全画面プレビュー中。
   const [tilePreviewIdx, setTilePreviewIdx] = createSignal<number | null>(null);
+  // プレビュー対象タイルを `createMemo` で集約し、Show 側で IIFE を避ける。
+  // tile.blob が無いタイル (skeleton) は対象外。
+  const previewTile = createMemo(() => {
+    const idx = tilePreviewIdx();
+    if (idx === null) return null;
+    const tile = tiles()[idx];
+    return tile?.blob ? tile : null;
+  });
   // #73: DL 時の hi-res 再描画進捗。downloading=true の間 DL ボタンを
   // ロックし、進捗テキスト「高解像度版を準備中… {done} / {total}」を出す。
   const [downloading, setDownloading] = createSignal(false);
@@ -178,6 +186,9 @@ export default function Studio() {
         selected: false,
       })),
     );
+    // S1: 前回 run の stale な進捗が新タイルに表示されるのを防ぐ。
+    // clearTiles 経由でない直接 runBatch 連打パスでも確実にリセット。
+    setAnimProgressMap(new Map());
   };
 
   // 1 frame ぶん描画を挟む（setTimeout(0) より意図が明確）。
@@ -492,6 +503,8 @@ export default function Studio() {
   // 出力 orb タイル長押し: 入力サムネ #57 と同じ UX。
   // 400ms 押し続けたら該当タイルを全画面プレビュー、release で閉じる。
   // 通常クリック（toggleTile による選択切替）は短いクリックでのみ発火。
+  // 単一ポインタ前提（複数指で同時に複数タイルを掴むケースは想定外、
+  // 後発の pointerdown で前のタイマーは上書きされ自然に最後の操作が勝つ）。
   let tileLongPressTimer: number | undefined;
   let isTileLongPress = false;
   const endTileLongPress = () => {
@@ -499,9 +512,12 @@ export default function Studio() {
       clearTimeout(tileLongPressTimer);
       tileLongPressTimer = undefined;
     }
-    setTilePreviewIdx(null);
+    if (tilePreviewIdx() !== null) setTilePreviewIdx(null);
   };
   const onTilePointerDown = (e: PointerEvent, idx: number) => {
+    // 生成済みタイルでのみ長押しを受け付ける。skeleton 中は何もしない
+    // （button disabled でほぼ届かないが念のため）。
+    if (!tiles()[idx]?.blob) return;
     const target = e.currentTarget as HTMLElement | null;
     target?.setPointerCapture?.(e.pointerId);
     isTileLongPress = false;
@@ -909,7 +925,7 @@ export default function Studio() {
               <button
                 type="button"
                 onClick={(e) => onTileClick(e, i())}
-                onPointerDown={(e) => tile.blob && onTilePointerDown(e, i())}
+                onPointerDown={(e) => onTilePointerDown(e, i())}
                 onPointerUp={onTilePointerEnd}
                 onPointerCancel={onTilePointerEnd}
                 onContextMenu={(e) => e.preventDefault()}
@@ -1162,14 +1178,7 @@ export default function Studio() {
       {/* 出力 orb タイル長押し時の全画面プレビュー。動画タイルで mp4 が
           完成済みなら video を、それ以外は静止 PNG を表示する。
           pointer-events-none で下のボタンが pointerup を受けられる。 */}
-      <Show
-        when={(() => {
-          const idx = tilePreviewIdx();
-          if (idx === null) return null;
-          const tile = tiles()[idx];
-          return tile?.blob ? tile : null;
-        })()}
-      >
+      <Show when={previewTile()}>
         {(tile) => (
           <div
             class="fade-in pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-bg/80"

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -78,6 +78,9 @@ export default function Studio() {
   const [dragOver, setDragOver] = createSignal(false);
   // #57: ドロップエリア長押し中だけ拡大プレビュー。
   const [previewVisible, setPreviewVisible] = createSignal(false);
+  // 出力 orb タイルの長押し拡大プレビュー（入力サムネ #57 と同じ UX）。
+  // null = 非表示。number = 該当タイル index を全画面プレビュー中。
+  const [tilePreviewIdx, setTilePreviewIdx] = createSignal<number | null>(null);
   // #73: DL 時の hi-res 再描画進捗。downloading=true の間 DL ボタンを
   // ロックし、進捗テキスト「高解像度版を準備中… {done} / {total}」を出す。
   const [downloading, setDownloading] = createSignal(false);
@@ -486,6 +489,42 @@ export default function Studio() {
     }
   };
 
+  // 出力 orb タイル長押し: 入力サムネ #57 と同じ UX。
+  // 400ms 押し続けたら該当タイルを全画面プレビュー、release で閉じる。
+  // 通常クリック（toggleTile による選択切替）は短いクリックでのみ発火。
+  let tileLongPressTimer: number | undefined;
+  let isTileLongPress = false;
+  const endTileLongPress = () => {
+    if (tileLongPressTimer !== undefined) {
+      clearTimeout(tileLongPressTimer);
+      tileLongPressTimer = undefined;
+    }
+    setTilePreviewIdx(null);
+  };
+  const onTilePointerDown = (e: PointerEvent, idx: number) => {
+    const target = e.currentTarget as HTMLElement | null;
+    target?.setPointerCapture?.(e.pointerId);
+    isTileLongPress = false;
+    tileLongPressTimer = window.setTimeout(() => {
+      isTileLongPress = true;
+      setTilePreviewIdx(idx);
+      tileLongPressTimer = undefined;
+    }, LONG_PRESS_MS);
+  };
+  const onTilePointerEnd = () => {
+    endTileLongPress();
+  };
+  const onTileClick = (e: MouseEvent, idx: number) => {
+    if (isTileLongPress) {
+      e.preventDefault();
+      e.stopPropagation();
+      isTileLongPress = false;
+      return;
+    }
+    const tile = tiles()[idx];
+    if (tile?.blob) toggleTile(idx);
+  };
+
   const setAspectAndMaybeRerun = (a: Aspect) => {
     if (aspect() === a) return;
     setAspect(a);
@@ -869,10 +908,14 @@ export default function Studio() {
             {(tile, i) => (
               <button
                 type="button"
-                onClick={() => tile.blob && toggleTile(i())}
+                onClick={(e) => onTileClick(e, i())}
+                onPointerDown={(e) => tile.blob && onTilePointerDown(e, i())}
+                onPointerUp={onTilePointerEnd}
+                onPointerCancel={onTilePointerEnd}
+                onContextMenu={(e) => e.preventDefault()}
                 disabled={!tile.blob}
                 aria-busy={!tile.blob}
-                class="group relative block w-full overflow-hidden rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing disabled:cursor-default"
+                class="group relative block w-full overflow-hidden rounded touch-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing disabled:cursor-default"
                 style={{
                   'aspect-ratio': aspect() === 'portrait' ? '540 / 960' : '960 / 540',
                 }}
@@ -1114,6 +1157,46 @@ export default function Studio() {
             class="max-h-[90vh] max-w-[90vw] object-contain select-none touch-none"
           />
         </div>
+      </Show>
+
+      {/* 出力 orb タイル長押し時の全画面プレビュー。動画タイルで mp4 が
+          完成済みなら video を、それ以外は静止 PNG を表示する。
+          pointer-events-none で下のボタンが pointerup を受けられる。 */}
+      <Show
+        when={(() => {
+          const idx = tilePreviewIdx();
+          if (idx === null) return null;
+          const tile = tiles()[idx];
+          return tile?.blob ? tile : null;
+        })()}
+      >
+        {(tile) => (
+          <div
+            class="fade-in pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-bg/80"
+            aria-hidden="true"
+          >
+            <Show
+              when={tile().kind === 'video' && tile().videoBlobUrl}
+              fallback={
+                <img
+                  src={tile().blobUrl}
+                  alt=""
+                  draggable={false}
+                  class="max-h-[90vh] max-w-[90vw] object-contain select-none touch-none"
+                />
+              }
+            >
+              <video
+                src={tile().videoBlobUrl}
+                muted
+                playsinline
+                loop
+                autoplay
+                class="max-h-[90vh] max-w-[90vw] object-contain select-none touch-none"
+              />
+            </Show>
+          </div>
+        )}
       </Show>
     </section>
   );


### PR DESCRIPTION
## 変更内容

### 1. 動画化中のタイル点滅を解消（fix）
#95 で動画タイルに埋め込んだ `animProgress` をフレーム毎に `setTiles` で更新していたため、Solid の `<For>` がタイル参照変更を検知してボタン全体を unmount/remount し、`<img class=\"fade-in\">` の CSS アニメがフレーム毎に再発火 → 静止 PNG が点滅していた。

`animProgress` を `Tile` 型から外し、独立した `Map<index, {frame,total}>` signal に分離。タイル参照は不変のまま、SVG 進捗リング部分だけが反応的に再描画される。完成・失敗・clearTiles 各経路で Map をクリア。

### 2. 出力 orb タイル長押し拡大プレビュー（feat）
入力サムネ #57 と同じ UX を出力グリッドの orb タイルにも適用。各タイル 400ms 長押し → 全画面プレビュー、release で閉じる。動画タイルで mp4 完成済みなら `<video autoplay loop muted>`、それ以外は静止 PNG。

短いクリックは従来通り `toggleTile`（選択切替）。長押し中の click は preventDefault。`onContextMenu` preventDefault と `touch-none` で Android 抑止も。

### 3. PR #104 debug log revert
入力サムネ長押しは実機で動作確認済みのため、調査用 console.log を撤去。

## 受け入れ条件
- [ ] 動画化中のタイル静止画が点滅しない
- [ ] 出力タイル長押し → 拡大プレビュー（動画タイルは動画再生）
- [ ] 出力タイル短クリック → 選択切替（従来通り）
- [ ] DevTools コンソールに debug log が出ない