### PR TITLE
feat(core): orb 縁のコントラストを下げる — 文字オーバーレイ可読性向上 (#78)

### DIFF
--- a/crates/core/src/orb.rs
+++ b/crates/core/src/orb.rs
@@ -216,9 +216,14 @@ pub fn render_one_orb(
 
     let stops = match style {
         OrbStyle::Rim => {
-            // 既存挙動: 中間 stop で alpha を半分に落としてリング感を作る。
+            // 中間 stop の alpha を下げ、縁の境界を柔らかくする (#78)。
+            // 旧値 128/255 ≒ 0.50 だと「中央 → 中間」と「中間 → 透明」の差が
+            // 等しく、中間 stop の位置に視覚的なエッジが立つ。80/255 ≒ 0.31
+            // に下げると中央→中間で alpha が 0.69 落ち、中間→透明で 0.31
+            // 落ちる非対称になり、縁が滑らかにフェードして文字オーバーレイ
+            // 時の可読性が上がる。
             // blur=0 で中間 stop が外寄り（不透明領域広い）、blur=1 で中心寄り（点に近い）。
-            let mid_a = ((opacity * 128.0).round().clamp(0.0, 255.0)) as u8;
+            let mid_a = ((opacity * 80.0).round().clamp(0.0, 255.0)) as u8;
             let mid_color = Color::from_rgba8(r, g, b, mid_a);
             let mid_stop = (1.0 - blur * 0.8).clamp(0.05, 0.95);
             vec![

--- a/crates/core/src/variations.rs
+++ b/crates/core/src/variations.rs
@@ -267,8 +267,12 @@ pub mod random_ranges {
     pub const COUNT_MAX: usize = 50;
     pub const ORB_SIZE_MIN: f32 = 1.5;
     pub const ORB_SIZE_MAX: f32 = 5.0;
-    pub const BLUR_MIN: f32 = 0.3;
-    pub const BLUR_MAX: f32 = 0.8;
+    // #78: 縁のコントラストを抑え、文字オーバーレイ時の可読性を上げるため
+    // ランダム生成の blur 下限を 0.3 → 0.5 に上げる（点光源寄りに偏らせ
+    // 中間 stop が中心寄りになるよう促す）。上限は 0.8 → 0.85 にわずかに
+    // 拡張して柔らかい側のバリエーションを増やす。
+    pub const BLUR_MIN: f32 = 0.5;
+    pub const BLUR_MAX: f32 = 0.85;
     pub const DURATION_MS_MIN: u64 = 6000;
     pub const DURATION_MS_MAX: u64 = 10000;
 }
@@ -467,7 +471,11 @@ mod tests {
         let specs = random_batch_specs(42, 10, 5);
         assert_eq!(specs.len(), 10);
         for s in &specs[..5] {
-            assert_eq!(s.kind, VariationKind::Png, "first 5 (still_count) must be PNG");
+            assert_eq!(
+                s.kind,
+                VariationKind::Png,
+                "first 5 (still_count) must be PNG"
+            );
             assert_eq!(s.duration_ms, 0, "PNG specs must have duration_ms=0");
         }
         for s in &specs[5..] {

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -179,11 +179,7 @@ fn direction_for_spec_idx(
 /// `direction_for_spec_idx` と同じ責務分担で、core の `generate_batch`
 /// は spec.speed をそのまま使うので、speed 固定割当は wasm 入口経由の
 /// GUI 経路でのみ適用される。
-fn speed_for_spec_idx(
-    spec_idx: usize,
-    still_count: usize,
-    spec: &VariationSpec,
-) -> MotionSpeed {
+fn speed_for_spec_idx(spec_idx: usize, still_count: usize, spec: &VariationSpec) -> MotionSpeed {
     if spec_idx >= still_count {
         let video_idx = spec_idx - still_count;
         debug_assert!(video_idx < GUI_VIDEO_COUNT_DEFAULT);


### PR DESCRIPTION
closes #78

## 変更
B案（中間 stop alpha 低下） + A案（ランダム blur 範囲シフト）を両方適用。

### B: `crates/core/src/orb.rs` — Rim style 中間 stop alpha
- 旧 `128/255 ≒ 0.50` → 新 `80/255 ≒ 0.31`
- 旧値は中央→中間と中間→透明の差が等しく、中間 stop 位置に視覚的なエッジが立っていた
- 新値で非対称化（中央→中間で 0.69 落ち、中間→透明で 0.31 落ち）し、縁が滑らかにフェード

### A: `crates/core/src/variations.rs` — random_ranges::BLUR
- 旧 `0.3..=0.8` → 新 `0.5..=0.85`
- 下限を上げて中間 stop が中心寄りになるよう促す
- 上限をわずかに拡張し柔らかい側のバリエーションを増やす

固定 `DEFAULT_VARIATIONS` の preset blur 値はクリエイター手作りなので変更しない。

## テスト
`cargo test -p orber-core --lib` 全 88 テストグリーン。