### PR TITLE
perf(web): プレビュー解像度を 540×960 → 360×640 に下げる (#99)

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -41,10 +41,15 @@ const VIDEO_TILE_COUNT = 4;
 // すべて 9:16 / 16:9 を厳守。`generate_one_at_index` / `start_animation_for_batch_spec`
 // は同じ baseSeed + (total, index) で同じ spec を再現するので、width/height だけ
 // 上げれば「同じバリエーションの高解像版」が得られる（決定論性は wasm 側で担保）。
-const PREVIEW_W_PORTRAIT = 540;
-const PREVIEW_H_PORTRAIT = 960;
-const PREVIEW_W_LANDSCAPE = 960;
-const PREVIEW_H_LANDSCAPE = 540;
+//
+// #99: プレビュー解像度を 540x960 (518,400px) → 360x640 (230,400px) に
+// 下げる（≒ 44% コスト削減）。DL 時は #73 の hi-res 再描画で 1080x1920
+// を出すので最終成果物は変わらない。タイル UI は max 200dvh 程度の
+// グリッドで縮小表示されるため 360x640 でも視認上の差は小さい。
+const PREVIEW_W_PORTRAIT = 360;
+const PREVIEW_H_PORTRAIT = 640;
+const PREVIEW_W_LANDSCAPE = 640;
+const PREVIEW_H_LANDSCAPE = 360;
 const DL_W_PORTRAIT = 1080;
 const DL_H_PORTRAIT = 1920;
 const DL_W_LANDSCAPE = 1920;
@@ -566,7 +571,7 @@ export default function Studio() {
     URL.revokeObjectURL(url);
   };
 
-  // #73: DL 時の hi-res 再描画。プレビュー（540×960）とは別に、同じ
+  // #73: DL 時の hi-res 再描画。プレビュー（#99 で 360×640）とは別に、同じ
   // baseSeed + (total, index) で `generate_one_at_index` / `start_animation_for_batch_spec`
   // を呼び、1080×1920 の PNG / mp4 を作る。プレビューと同じバリエーションが
   // 再現される（決定論性は wasm 側 random_batch_specs が担保）。

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -938,7 +938,7 @@ export default function Studio() {
                 aria-busy={!tile.blob}
                 class="group relative block w-full overflow-hidden rounded touch-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing disabled:cursor-default"
                 style={{
-                  'aspect-ratio': aspect() === 'portrait' ? '540 / 960' : '960 / 540',
+                  'aspect-ratio': aspect() === 'portrait' ? '9 / 16' : '16 / 9',
                 }}
               >
                 {/* tile.blob が null の間は skeleton shimmer。runBatch 冒頭で

--- a/web/src/lib/encodeMp4.ts
+++ b/web/src/lib/encodeMp4.ts
@@ -2,8 +2,8 @@
 //
 // orber-wasm から渡される `AnimationHandle` は RGBA フレームを 1 枚ずつ吐く
 // 反復子なので、それを順番に `VideoEncoder.encode` に流して mp4-muxer に
-// 詰め込む。フレームを保持しないことでメモリピークを 1 枚ぶん（≈ 2MB / 540×960）
-// に抑える設計。
+// 詰め込む。フレームを保持しないことでメモリピークを 1 枚ぶん（≈ 0.9MB / 360×640、
+// hi-res DL 時は ≈ 8MB / 1080×1920）に抑える設計。
 //
 // 互換性: VideoEncoder / VideoFrame / ImageData(buf, w, h) が要る。
 // Chrome 94+ / Safari 16.4+ / Firefox 130+。非対応ブラウザでは throw する

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -30,13 +30,13 @@ export const STRINGS = {
   },
   aspectPortrait: { ja: '縦長', en: 'Portrait' },
   aspectPortraitTitle: {
-    ja: '縦長 9:16（プレビュー 540×960 / DL 1080×1920）',
-    en: 'Portrait 9:16 (preview 540×960, DL 1080×1920)',
+    ja: '縦長 9:16（プレビュー 360×640 / DL 1080×1920）',
+    en: 'Portrait 9:16 (preview 360×640, DL 1080×1920)',
   },
   aspectLandscape: { ja: '横長', en: 'Landscape' },
   aspectLandscapeTitle: {
-    ja: '横長 16:9（プレビュー 960×540 / DL 1920×1080）',
-    en: 'Landscape 16:9 (preview 960×540, DL 1920×1080)',
+    ja: '横長 16:9（プレビュー 640×360 / DL 1920×1080）',
+    en: 'Landscape 16:9 (preview 640×360, DL 1920×1080)',
   },
   rerollLabel: { ja: '同じ画像でガチャ', en: 'Roll again' },
   rerollTitle: {


### PR DESCRIPTION
closes #99

## 変更
プレビュー解像度を ≒ 44% 削減し、wasm 描画 + WebCodecs encode の体感速度を改善。

| | 旧 | 新 | 削減率 |
|---|---|---|---|
| Portrait | 540×960 (518,400px) | 360×640 (230,400px) | -55.6% |
| Landscape | 960×540 (518,400px) | 640×360 (230,400px) | -55.6% |
| DL（変更なし） | 1080×1920 | 1080×1920 | 0% |

## 整合
- `strings.ts` の aspect title 文言（ja/en 両方）を新解像度に更新
- `encodeMp4.ts` のメモリピーク見積コメントを更新（≈ 0.9MB / 360×640）
- Studio.tsx 内の説明コメントを更新

## 受け入れ条件
- [ ] プレビュー生成が体感で明確に速い
- [ ] 動画化 4 枚も並行して短縮
- [ ] DL 成果物は従来通り 1080×1920
- [ ] スマホ実機でタイルが荒すぎないか確認