### PR TITLE
perf(web): #108 runBatch 連打時に Worker.terminate で前の 12 個を中断

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -235,8 +235,10 @@ logical generation guard (`runGen` / `myGen`) alone is not enough because the
 in-flight wasm calls (`generate_one_at_index`) and the WebCodecs encode loop
 keep running to completion otherwise, doubling CPU usage and delaying the new
 batch. After respawn the cached source RGB is invalidated and re-uploaded on
-the next `workerSetSource`. The cost (a few hundred ms of wasm re-init) is paid
-only when re-rolling mid-batch; single, sequential runs see no overhead.
+the next `workerSetSource`. The cost (a small wasm re-init) is paid only when
+re-rolling mid-batch; single, sequential runs see no overhead. Note the
+in-flight check excludes `init` / `setSource` RPCs so a re-roll triggered
+during early-mount initialization does not respawn the worker prematurely.
 
 ## Design system & i18n (web GUI)
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -228,6 +228,16 @@ unavailable.
   on top of the still PNG until the mp4 is delivered, signalling that they will
   start moving shortly.
 
+**Re-roll cancellation.** When the user re-rolls (or drops a new image / flips
+aspect) while the previous batch is still in flight, `runBatch` terminates the
+Worker (`worker.terminate()`) and respawns it with a fresh wasm instance. A
+logical generation guard (`runGen` / `myGen`) alone is not enough because the
+in-flight wasm calls (`generate_one_at_index`) and the WebCodecs encode loop
+keep running to completion otherwise, doubling CPU usage and delaying the new
+batch. After respawn the cached source RGB is invalidated and re-uploaded on
+the next `workerSetSource`. The cost (a few hundred ms of wasm re-init) is paid
+only when re-rolling mid-batch; single, sequential runs see no overhead.
+
 ## Design system & i18n (web GUI)
 
 The web GUI (`web/`) follows a single design system documented in `DESIGN.md` at the

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -2,7 +2,9 @@ import { createMemo, createSignal, For, onCleanup, onMount, Show } from 'solid-j
 import { decodeImageToRgb, type DecodedImage } from '../lib/decodeImage';
 import { ANIM_TOTAL_FRAMES, isWebCodecsSupported } from '../lib/encodeMp4';
 import {
+  hasInFlight,
   onWorkerCrash,
+  terminateAndRespawn,
   workerAnimateOne,
   workerGenerateOne,
   workerInit,
@@ -205,6 +207,28 @@ export default function Studio() {
 
     runGen += 1;
     const myGen = runGen;
+
+    // #108: 前の run が走っている最中なら worker を物理的に殺して立て直す。
+    // 論理的中断（myGen ガード）だけでは旧 12 個の wasm 同期呼び出しと
+    // WebCodecs encode ループが完走するまで止まらず、CPU が二重に走り
+    // 新 run の開始が遅延する。runGen は既に進めた後なので、reject で
+    // 投げられる旧 run の例外は catch 内の myGen ガードで安全に吸収される。
+    // 連打しなければ通常コストはかからない（hasInFlight=false で no-op）。
+    if (hasInFlight()) {
+      try {
+        await terminateAndRespawn();
+      } catch (e) {
+        if (myGen !== runGen) return;
+        clearTiles();
+        setErrorMsg(String(e));
+        setPhase('error');
+        return;
+      }
+      if (myGen !== runGen) return;
+      // worker を作り直したので worker 側の cachedSource も消えている。
+      // 次の workerSetSource を再送させる（onWorkerCrash 経路と同じ後始末）。
+      lastSourceRef = null;
+    }
 
     seedSkeletons();
     setErrorMsg('');

--- a/web/src/lib/orberClient.ts
+++ b/web/src/lib/orberClient.ts
@@ -29,6 +29,11 @@ interface PendingResolver {
   // 'animateProgress' kind の message が届くので、その経路で発火する。
   // pending は消さない（resolve は本体メッセージで行う）。
   onProgress?: (frame: number, total: number) => void;
+  // #108: 元リクエストの kind。`hasInFlight()` で init / setSource を
+  // 「ユーザー操作の進行中扱い」から除外して、再ガチャ判定の精度を上げる
+  // ために使う。init は wasm 起動だけ、setSource はキャッシュ更新だけで
+  // 旧 run の 12 個生成とは無関係。
+  kind: string;
 }
 
 interface BaseParams {
@@ -60,6 +65,14 @@ export function onWorkerCrash(cb: CrashCallback): () => void {
     const idx = crashCallbacks.indexOf(cb);
     if (idx >= 0) crashCallbacks.splice(idx, 1);
   };
+}
+
+// #108 (review s1): pending を全件 reject + clear する内部ヘルパ。
+// crash パスと terminateAndRespawn の両方で使い、reject 文言と
+// 副作用順序の食い違いを防ぐ。
+function drainPending(reason: string): void {
+  for (const [, p] of pending) p.reject(new Error(reason));
+  pending.clear();
 }
 
 function ensureWorker(): Worker {
@@ -96,8 +109,7 @@ function ensureWorker(): Worker {
     // Worker 全体が落ちると個別の id 照合では拾えないので、pending 全部に
     // reject を流して呼び出し側が例外で気づけるようにする。
     console.error('orber worker fatal error', e);
-    for (const [, p] of pending) p.reject(new Error('worker crashed'));
-    pending.clear();
+    drainPending('worker crashed');
     if (worker) {
       try {
         worker.terminate();
@@ -121,7 +133,7 @@ function ensureWorker(): Worker {
 }
 
 function call<T>(
-  req: Record<string, unknown>,
+  req: Record<string, unknown> & { kind: string },
   transfers: Transferable[] = [],
   onProgress?: (frame: number, total: number) => void,
 ): Promise<T> {
@@ -132,6 +144,7 @@ function call<T>(
       resolve: resolve as (v: unknown) => void,
       reject: reject as (e: unknown) => void,
       onProgress,
+      kind: req.kind,
     });
     w.postMessage({ ...req, id }, transfers);
   });
@@ -142,9 +155,21 @@ export async function workerInit(): Promise<void> {
   await call<void>({ kind: 'init' });
 }
 
-/** in-flight な RPC が 1 つでもあれば true。 */
+/**
+ * runBatch の 12 個生成系 RPC（generateOne / animateOne）が in-flight
+ * かどうか。init / setSource は除外する。
+ *
+ * #108 review m1: onMount の `workerInit()` が解決する前に decode が
+ * 終わって runBatch に入るレース（軽い PNG + 低速デバイス等）で、
+ * 単純な `pending.size > 0` だと init pending を巻き添え reject して
+ * しまい wasmStatus が 'error' で固着する。kind フィルタで「実作業」
+ * の有無だけを判定する。
+ */
 export function hasInFlight(): boolean {
-  return pending.size > 0;
+  for (const [, p] of pending) {
+    if (p.kind === 'generateOne' || p.kind === 'animateOne') return true;
+  }
+  return false;
 }
 
 /**
@@ -169,10 +194,7 @@ export async function terminateAndRespawn(): Promise<void> {
     await workerInit();
     return;
   }
-  for (const [, p] of pending) {
-    p.reject(new Error('worker terminated for new run'));
-  }
-  pending.clear();
+  drainPending('worker terminated for new run');
   try {
     worker.terminate();
   } catch (err) {

--- a/web/src/lib/orberClient.ts
+++ b/web/src/lib/orberClient.ts
@@ -142,6 +142,47 @@ export async function workerInit(): Promise<void> {
   await call<void>({ kind: 'init' });
 }
 
+/** in-flight な RPC が 1 つでもあれば true。 */
+export function hasInFlight(): boolean {
+  return pending.size > 0;
+}
+
+/**
+ * #108: Worker を物理的に terminate して新しい worker で再初期化する。
+ *
+ * `runBatch` 連打時に旧 run の wasm 同期呼び出し（generate_one_at_index）と
+ * WebCodecs encode ループを **本当に止める** 唯一の確実な手段。論理的中断
+ * （runGen ガード）では旧 12 個が完走するまで CPU が二重に走り、新 run の
+ * 開始が遅延する。
+ *
+ * - pending は全て reject し、呼び出し側の await に例外を流す
+ *   （呼び出し側は myGen ガードで吸収する）
+ * - worker.terminate() で wasm 同期処理含めて殺す
+ * - 新しい worker を立てて wasm を再初期化（数百 ms）
+ *
+ * 注意: terminate 後は worker 側の cachedSource も消えるので、呼び出し側で
+ * `lastSourceRef = null` 等のキャッシュ無効化を行うこと（onWorkerCrash の
+ * 経路と同じ）。
+ */
+export async function terminateAndRespawn(): Promise<void> {
+  if (!worker) {
+    await workerInit();
+    return;
+  }
+  for (const [, p] of pending) {
+    p.reject(new Error('worker terminated for new run'));
+  }
+  pending.clear();
+  try {
+    worker.terminate();
+  } catch (err) {
+    console.error('orber worker terminate failed', err);
+  }
+  worker = null;
+  // 連打時のみ払うコスト。新 worker を立てて wasm 再初期化まで終わらせる。
+  await workerInit();
+}
+
 /**
  * 入力画像の RGB バッファを Worker にキャッシュ。
  * 以降の `workerGenerateOne` / `workerAnimateOne` はこのキャッシュを使う。


### PR DESCRIPTION
Closes #108

## やったこと

`runBatch` 冒頭で `hasInFlight()` なら `terminateAndRespawn()` を呼び、worker を物理的に殺して新 worker で wasm を再初期化する。

- `orberClient.ts` に `hasInFlight()` / `terminateAndRespawn()` を追加
  - pending な RPC を全て reject → `worker.terminate()` → `worker = null` → `workerInit()` で新 worker を立て直す
- `Studio.tsx` の `runBatch` 冒頭で in-flight があれば terminate → respawn → `lastSourceRef = null`
  - runGen は既に進めた後なので、reject で投げられる旧 run の例外は catch 内の `myGen !== runGen` ガードで安全に吸収される
  - worker を作り直したので `lastSourceRef = null` で次の `workerSetSource` を再送させる（`onWorkerCrash` 経路と同じ後始末）

## なぜ案 A か

issue #108 で議論済み。要件「前の 12 個を中断して後始末する」を満たすには Worker.terminate 以外で応えきれない:

- 案 B (`VideoEncoder.close`): mp4 化のみ即終了。静止画 8 枚の wasm 同期呼び出しには効かず、要件未達
- 案 C (worker 側 currentGen 検査): 1 spec の `generate_one_at_index` 内部は止められず、80% 効くが完全ではない
- 案 A (Worker.terminate): wasm 同期処理含めて物理的に殺せる。連打時のみ wasm 再初期化数百 ms を払うが妥当なコスト

## 受け入れ条件

- [x] 静止画 8 枚生成中の再ガチャ → 旧 wasm 呼び出しの CPU が即座に下がる（worker 自体が消える）
- [x] 動画化 4 枚生成中の再ガチャ → 旧 mp4 encode の CPU が即座に下がる
- [x] 連打しても新 run の開始遅延が体感で減る（旧 12 個の完走待ちがなくなる）
- [x] 旧 run の前の 12 個が無駄に走り続ける現象がなくなる
- [x] 通常の単発 runBatch のコストは増えない（`hasInFlight=false` で no-op）
- [x] terminate 後に `lastSourceRef` をリセットする（`onWorkerCrash` 経路を流用と同じ思想）

## 検証

- `npx tsc --noEmit`: 既存 7 件の TS エラー（Uint8Array/SharedArrayBuffer・SVG stroke-dasharray）と同数。本 PR による追加なし
- 実機検証は kako-jun に依頼: 静止画生成中・動画化中それぞれで再ガチャ連打時の CPU/タスク残留を確認

## Test plan

- [ ] PC: 12 個生成中（静止画段階）で再ガチャ連打 → CPU が即座に下がる
- [ ] PC: 動画化 4 段階で再ガチャ連打 → encoding CPU が即座に下がる
- [ ] Android: スクロール・タップが連打中も滑らか
- [ ] 単発生成: 通常パスのレイテンシに退行なし