### PR TITLE
perf(web): #110 VideoEncoder に hardwareAcceleration: prefer-hardware

### DIFF
--- a/web/src/lib/encodeMp4.ts
+++ b/web/src/lib/encodeMp4.ts
@@ -81,12 +81,18 @@ export async function encodeAnimationToMp4(
   // 仕様上 `configure` は同期で完了し、直後の `encode` 呼び出しは合法。
   const codedArea = Math.ceil(width / 16) * 16 * Math.ceil(height / 16) * 16;
   const codecString = codedArea <= 921_600 ? 'avc1.42E01F' : 'avc1.42E02A';
+  // `hardwareAcceleration: 'prefer-hardware'` で HW h264 エンコーダがあれば
+  // それを使う。Android Chrome や iOS Safari の最近の機種は MediaCodec /
+  // VideoToolbox 経由で大幅に速い。HW 不在環境では仕様上ソフトウェアに
+  // フォールバックする（`require` ではなく `prefer` なので throw しない）。
+  // 1080×1920 × 192 frame の DL hi-res で体感差が出る。
   encoder.configure({
     codec: codecString,
     width,
     height,
     framerate: ANIM_FPS,
     bitrate: 2_000_000,
+    hardwareAcceleration: 'prefer-hardware',
   });
 
   const microsecondsPerFrame = 1_000_000 / ANIM_FPS;


### PR DESCRIPTION
Closes #110

## やったこと

`encodeMp4.ts` の `VideoEncoder.configure` に `hardwareAcceleration: 'prefer-hardware'` を 1 行追加。

## 期待効果

- Android Chrome → MediaCodec
- iOS Safari → VideoToolbox  
- Desktop Chrome → 各種 hw encoder

があれば自動で使われる。HW 不在なら仕様上 SW にフォールバック（`prefer` なので throw しない）。

## なぜこれを先に試すか

- 1 行変更でコスト最小、効果見込み大
- DL hi-res (1080×1920 × 192 frame) の SW x264 が律速だった
- ダメなら次手（解像度ダウン or フレーム数半減）に進む

## 検証

- [x] `npx tsc --noEmit`: 既存 7 件のエラーと同数（追加なし）
- [ ] Android 実機で DL hi-res の 1 タイル時間を計測（kako-jun に依頼）
- [ ] PC 実機でも同様に計測
- [ ] hw 不在環境（古い PC 等）で従来通り動作することを確認

ダメだった場合の次手は #110 の Issue 本文に記載。