### PR TITLE
feat(web): #112 WebGL2 で全描画を GPU 化（wasm CPU 描画を全置き換え）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,8 @@ dependencies = [
  "image",
  "js-sys",
  "orber-core",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -22,6 +22,8 @@ js-sys = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 console_error_panic_hook = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
 
 # 注意: per-crate `[profile.release]` は workspace member では指定できない
 # （root の `[profile.release]` が継承される）。

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -36,6 +36,13 @@ use wasm_bindgen::prelude::*;
 /// orb 数の上限。core::animate::MAX_ORB_COUNT と一致させる必要がある。
 const MAX_ORB_COUNT: usize = 1024;
 
+/// WebGL2 fragment shader 側の uniform array サイズ上限
+/// (`web/src/lib/orberGl.ts::MAX_ORBS`)。ここで超過を早期エラーにし、
+/// shader アップロード時に黙って切り詰められるのを防ぐ。GUI の
+/// `random_ranges::COUNT_MAX = 50` を網羅する余裕として 64 を採る。
+/// 将来 GUI の COUNT_MAX を増やす場合は両方同時に上げること。
+const GL_RENDERER_MAX_ORBS: usize = 64;
+
 /// パニック時にブラウザコンソールへスタックトレースを出すためのフック。
 #[wasm_bindgen(start)]
 pub fn init_panic_hook() {
@@ -364,6 +371,16 @@ pub fn get_render_data(
         .count
         .min(MAX_ORB_COUNT)
         .max(if clusters.is_empty() { 0 } else { 1 });
+
+    // review S2: WebGL fragment shader の uniform 配列上限を超えると黙って
+    // 切り詰められて視覚パリティが壊れる。発見が遅れないよう wasm 側で
+    // 早期 throw する。spec.count > 64 になる経路は現 GUI には無いが、
+    // random_ranges を将来弄る際の保険。
+    if n_orbs > GL_RENDERER_MAX_ORBS {
+        return Err(JsError::new(&format!(
+            "n_orbs {n_orbs} exceeds WebGL renderer limit {GL_RENDERER_MAX_ORBS} (orberGl.ts MAX_ORBS と同期して上げること)"
+        )));
+    }
 
     let base_radius_unit = (p.width.min(p.height) as f32) * 0.25 * spec.orb_size.max(0.0);
     let base_blur = spec.blur.clamp(0.0, 1.0);

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -18,19 +18,23 @@
 
 const MAX_DIM: u32 = 8192;
 
-use orber_core::animate::{
-    render_frame, AnimateOptions, AnimationCursor, MotionDirection, MotionSpeed,
-};
+use orber_core::animate::{render_frame, AnimateOptions, MotionDirection, MotionSpeed};
 use orber_core::batch::{generate_batch as core_generate_batch, BatchInput};
-use orber_core::cluster::{derive_background_rgba, drop_dominant, extract_clusters};
+use orber_core::cluster::{derive_background_rgba, drop_dominant, extract_clusters, Cluster};
 use orber_core::orb::OrbShape;
 use orber_core::style::{render_svg as core_render_svg, StyleOptions};
 use orber_core::variations::{
     random_batch_specs, VariationSpec, GUI_VIDEO_COUNT_DEFAULT, GUI_VIDEO_DIRECTIONS,
     GUI_VIDEO_SPEEDS,
 };
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 use serde::Deserialize;
+use std::f32::consts::TAU;
 use wasm_bindgen::prelude::*;
+
+/// orb 数の上限。core::animate::MAX_ORB_COUNT と一致させる必要がある。
+const MAX_ORB_COUNT: usize = 1024;
 
 /// パニック時にブラウザコンソールへスタックトレースを出すためのフック。
 #[wasm_bindgen(start)]
@@ -280,24 +284,53 @@ pub fn generate_batch(params_js: JsValue, n: u32) -> Result<js_sys::Array, JsErr
     Ok(arr)
 }
 
-/// バッチ N 枚のうち `spec_idx` 番目だけを 1 枚 PNG として生成する。
+/// バッチ N 枚のうち `spec_idx` 番目の描画に必要な per-orb データをパックして返す。
 ///
-/// `generate_batch` と同じ `random_batch_specs(seed, total, still_count)` で
-/// spec 列を再構築し、`spec_idx` 番目だけ描画する。`width`/`height` を上げて
-/// 呼べば「同じバリエーションの高解像版」が得られるので、GUI のダウンロード時
-/// に表示用プレビュー（540×960）と別の解像度で焼き直す用途を想定（#73）。
+/// `generate_one_at_index` / `start_animation_for_batch_spec` の置き換え。CPU 側
+/// （core）で per-orb の決定論パラメータと clusters / 背景色を計算し、
+/// Float32Array 1 本にエンコードして JS に渡す。GPU 側（WebGL2 fragment shader）
+/// で各 t におけるフレームを per-pixel ループ + Source-Over 合成で描く。
 ///
-/// 動画タイル領域（`spec_idx >= still_count`）では
-/// `start_animation_for_batch_spec` と同じく `GUI_VIDEO_DIRECTIONS` で
-/// direction を 4 方向に上書きし、video タイルの t=0 フレームと完全一致させる。
+/// 既存 `generate_batch` と同じ `random_batch_specs(seed, total, still_count)`
+/// で spec 列を再構築するので、`spec_idx` 番目の spec / direction / speed /
+/// count / orb_size / blur / seed は他 API と完全一致する（互換性維持）。
+///
+/// per-orb の rng シーケンスも `crates/core::animate::generate_orb_params` と
+/// 同じ ChaCha8Rng + 同じドロー順で再現するので、同じ seed なら同じ
+/// (phase, phi_radius, phi_blur, phi_opacity, cross_axis, style, cluster_idx,
+/// speed_mult) が得られる。
+///
+/// # Float32Array レイアウト
+///
+/// `[0..16]` ヘッダ:
+/// - `[0..4]`: 背景 RGBA (0..1 正規化)
+/// - `[4]`: base_radius_unit (px) = `min(w, h) * 0.25 * orb_size`
+/// - `[5]`: base_blur (0..1)
+/// - `[6]`: direction_id (0=LR, 1=RL, 2=TB, 3=BT)
+/// - `[7]`: cycle_count (1 = VerySlow, 2 = Slow)
+/// - `[8]`: n_orbs (整数を f32 として)
+/// - `[9..16]`: 予約（0 詰め）
+///
+/// `[16 + 16*i ..]` per orb i:
+/// - `[+0..+3]`: color_rgb (0..1)
+/// - `[+3]`: cluster_weight (0..1)
+/// - `[+4]`: phase (0..1)
+/// - `[+5]`: phi_radius (0..2π)
+/// - `[+6]`: phi_blur (0..2π)
+/// - `[+7]`: phi_opacity (0..2π)
+/// - `[+8]`: cross_axis (0..1)
+/// - `[+9]`: style_bit (0=rim, 1=soft)
+/// - `[+10]`: speed_mult (1..3)
+/// - `[+11..+16]`: 予約（0 詰め）
 #[wasm_bindgen]
-pub fn generate_one_at_index(
+pub fn get_render_data(
     params_js: JsValue,
     n: u32,
     spec_idx: u32,
-) -> Result<js_sys::Uint8Array, JsError> {
+) -> Result<js_sys::Float32Array, JsError> {
     let mut p = deserialize_params(params_js).map_err(err_to_js)?;
-    let shape = parse_shape(&p.shape).map_err(err_to_js)?;
+    // shape は今のところ Circle のみ（Aquarelle は WebGL 経路非対応）。
+    let _ = parse_shape(&p.shape).map_err(err_to_js)?;
 
     let total = (n as usize).clamp(1, 50);
     let spec_idx = spec_idx as usize;
@@ -316,144 +349,123 @@ pub fn generate_one_at_index(
 
     let specs = random_batch_specs(p.seed as u64, total, still_count);
     let spec = specs[spec_idx];
-
-    // direction / speed は純粋関数に集約。start_animation_for_batch_spec と
-    // 同じロジックを共有することで、プレビュー静止 PNG と動画タイルの
-    // 描画パラメータが構造的に揃う（#77 で speed も index 固定割当）。
     let direction = direction_for_spec_idx(spec_idx, still_count, &spec);
     let speed = speed_for_spec_idx(spec_idx, still_count, &spec);
 
-    let opts = AnimateOptions {
-        width: p.width,
-        height: p.height,
-        seed: spec.seed,
-        direction,
-        speed,
-        count: Some(spec.count),
-        orb_size: spec.orb_size,
-        blur: spec.blur,
-        saturation: 1.0,
-        background: bg,
-        shape,
+    let direction_id: f32 = match direction {
+        MotionDirection::LeftToRight => 0.0,
+        MotionDirection::RightToLeft => 1.0,
+        MotionDirection::TopToBottom => 2.0,
+        MotionDirection::BottomToTop => 3.0,
     };
-    let frame = render_frame(&clusters, &opts, 0.0);
-    let png = encode_png_rgba(&frame)?;
-    Ok(js_sys::Uint8Array::from(&png[..]))
+    let cycle = speed.cycle_count() as f32;
+
+    let n_orbs = spec
+        .count
+        .min(MAX_ORB_COUNT)
+        .max(if clusters.is_empty() { 0 } else { 1 });
+
+    let base_radius_unit = (p.width.min(p.height) as f32) * 0.25 * spec.orb_size.max(0.0);
+    let base_blur = spec.blur.clamp(0.0, 1.0);
+
+    let buf = pack_render_data(
+        &clusters,
+        bg,
+        base_radius_unit,
+        base_blur,
+        direction_id,
+        cycle,
+        spec.seed,
+        n_orbs,
+    );
+
+    Ok(js_sys::Float32Array::from(buf.as_slice()))
 }
 
-/// 動画 1 タイル分の RGBA フレームを 1 枚ずつ取り出すハンドル。
+/// `generate_orb_params` (core) と同じ rng ドロー順で per-orb データを生成し、
+/// ヘッダ + per-orb フィールドを Float32 ベクタに詰める。
 ///
-/// `start_animation_for_batch_spec` で構築する。各 `next_frame()` は
-/// `width * height * 4` バイトの RGBA8 ピクセル列 (`Uint8ClampedArray`) を
-/// 返す。完了後は `null`。`<video loop>` 用途を想定しており、
-/// `t = i / total_frames` (i = 0..total_frames) を出すので、最後のフレームの
-/// 次が t=0 とピクセル一致する（README の loop closure 不変条件を維持）。
-#[wasm_bindgen]
-pub struct AnimationHandle {
-    cursor: AnimationCursor,
+/// core 側 `generate_orb_params` を呼び出さずに同じシーケンスを **再現** する
+/// （core の `OrbParams` は private struct で wasm から読めないため）。順序を
+/// 1 つでも変えると同じ seed でも別の orb 列になり、視覚パリティが壊れる。
+fn pack_render_data(
+    clusters: &[Cluster],
+    bg: [u8; 4],
+    base_radius_unit: f32,
+    base_blur: f32,
+    direction_id: f32,
+    cycle: f32,
+    seed: u64,
+    n_orbs: usize,
+) -> Vec<f32> {
+    let header_words = 16usize;
+    let per_orb_words = 16usize;
+    let mut buf = vec![0.0f32; header_words + per_orb_words * n_orbs];
+
+    // header
+    buf[0] = bg[0] as f32 / 255.0;
+    buf[1] = bg[1] as f32 / 255.0;
+    buf[2] = bg[2] as f32 / 255.0;
+    buf[3] = bg[3] as f32 / 255.0;
+    buf[4] = base_radius_unit;
+    buf[5] = base_blur;
+    buf[6] = direction_id;
+    buf[7] = cycle;
+    buf[8] = n_orbs as f32;
+    // [9..16] reserved (0)
+
+    if n_orbs == 0 || clusters.is_empty() {
+        return buf;
+    }
+
+    let cluster_weights: Vec<f32> = clusters.iter().map(|c| c.weight.max(0.0)).collect();
+    let total_w: f32 = cluster_weights.iter().sum();
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    for i in 0..n_orbs {
+        // 順序は crates/core::animate::generate_orb_params と完全一致させる。
+        let phase: f32 = rng.gen_range(0.0..1.0);
+        let phi_radius: f32 = rng.gen_range(0.0..TAU);
+        let phi_blur: f32 = rng.gen_range(0.0..TAU);
+        let phi_opacity: f32 = rng.gen_range(0.0..TAU);
+        let cross_axis: f32 = rng.gen_range(0.0..1.0);
+        let style_bit: f32 = if rng.gen::<u32>() & 1 == 0 { 0.0 } else { 1.0 };
+        let cluster_idx = pick_weighted(&mut rng, &cluster_weights, total_w);
+        let speed_mult: u32 = rng.gen_range(1..=3);
+
+        let c = &clusters[cluster_idx.min(clusters.len() - 1)];
+
+        let off = header_words + per_orb_words * i;
+        buf[off] = c.color[0] as f32 / 255.0;
+        buf[off + 1] = c.color[1] as f32 / 255.0;
+        buf[off + 2] = c.color[2] as f32 / 255.0;
+        buf[off + 3] = c.weight.max(0.0);
+        buf[off + 4] = phase;
+        buf[off + 5] = phi_radius;
+        buf[off + 6] = phi_blur;
+        buf[off + 7] = phi_opacity;
+        buf[off + 8] = cross_axis;
+        buf[off + 9] = style_bit;
+        buf[off + 10] = speed_mult as f32;
+        // [+11..+16] reserved
+    }
+    buf
 }
 
-#[wasm_bindgen]
-impl AnimationHandle {
-    #[wasm_bindgen(getter)]
-    pub fn width(&self) -> u32 {
-        self.cursor.width()
+/// 重み比例の 1 サンプル抽選器。`crates/core::animate::pick_weighted` と同等。
+fn pick_weighted(rng: &mut ChaCha8Rng, weights: &[f32], total: f32) -> usize {
+    if total <= 0.0 || weights.is_empty() {
+        return 0;
     }
-    #[wasm_bindgen(getter)]
-    pub fn height(&self) -> u32 {
-        self.cursor.height()
+    let r = rng.gen::<f32>() * total;
+    let mut acc = 0.0;
+    for (i, &w) in weights.iter().enumerate() {
+        acc += w.max(0.0);
+        if r <= acc {
+            return i;
+        }
     }
-    #[wasm_bindgen(getter)]
-    pub fn total_frames(&self) -> u32 {
-        self.cursor.total_frames()
-    }
-    #[wasm_bindgen(getter)]
-    pub fn next_index(&self) -> u32 {
-        self.cursor.next_index()
-    }
-
-    /// 次のフレームの RGBA バイト列を返す。完了後は `null`。
-    pub fn next_frame(&mut self) -> Option<js_sys::Uint8ClampedArray> {
-        let img = self.cursor.next_frame()?;
-        Some(js_sys::Uint8ClampedArray::from(img.as_raw().as_slice()))
-    }
-}
-
-/// 後半の動画タイルのアニメーションを起動する。
-///
-/// `random_batch_specs(params.seed, n, n - GUI_VIDEO_COUNT_DEFAULT)` を再生成
-/// して `spec_idx` 番目の spec を取り、入力画像のクラスタ抽出を 1 回だけ
-/// 走らせて `AnimationCursor` を返す。JS 側は `next_frame()` を `total_frames`
-/// 回呼んで WebCodecs `VideoEncoder` に流し込む想定。
-///
-/// # 決定論性
-///
-/// `random_batch_specs` は同じ `(seed, total, still_count)` で同じ spec 列を
-/// 返す（`crates/core::variations::random_batch_specs_is_deterministic_per_seed`
-/// テストで担保）。よって `generate_batch(params, n)` で得た spec 列の
-/// `spec_idx` 番目と、ここで再構築した spec 列の `spec_idx` 番目は完全一致する。
-/// その結果、静止画タイル（`generate_batch` で描かれた `t=0` フレーム）と
-/// 動画タイル（このアニメーション）は同じパラメータで描画され、見た目の
-/// 整合性が保たれる。
-///
-/// `total_frames` は呼び出し側で計算する（GUI 既定: `fps × seconds = 24 × 4 = 96`）。
-/// `spec_idx` が `[still_count, total)` の範囲外なら `Mp4` 枠ではないので
-/// `JsError`。
-#[wasm_bindgen]
-pub fn start_animation_for_batch_spec(
-    params_js: JsValue,
-    n: u32,
-    spec_idx: u32,
-    total_frames: u32,
-) -> Result<AnimationHandle, JsError> {
-    let mut p = deserialize_params(params_js).map_err(err_to_js)?;
-    let shape = parse_shape(&p.shape).map_err(err_to_js)?;
-
-    let total = (n as usize).clamp(1, 50);
-    let still_count = total.saturating_sub(GUI_VIDEO_COUNT_DEFAULT);
-    let spec_idx = spec_idx as usize;
-    if spec_idx < still_count || spec_idx >= total {
-        return Err(JsError::new(&format!(
-            "spec_idx {spec_idx} is not within the Mp4 range [{still_count}, {total})"
-        )));
-    }
-    if total_frames == 0 {
-        return Err(JsError::new("total_frames must be > 0"));
-    }
-
-    let source = build_source_image(&mut p).map_err(err_to_js)?;
-    let clusters_full = extract_clusters(&source, p.k)
-        .map_err(|e| JsError::new(&format!("cluster extraction failed: {e}")))?;
-    let bg = derive_background_rgba(&clusters_full);
-    let clusters = drop_dominant(&clusters_full);
-
-    let specs = random_batch_specs(p.seed as u64, total, still_count);
-    let spec = specs[spec_idx];
-
-    // #59: 動画タイル 4 枚に LR / RL / TB / BT を 1 枚ずつ重複なく割り当てる。
-    // #77: speed も VerySlow / Slow を 2 枚ずつ固定割当（ガチャ感の保証）。
-    // direction_for_spec_idx / speed_for_spec_idx を経由することで、
-    // `generate_one_at_index` で描かれる t=0 PNG と完全に同じパラメータで
-    // 動画化される（プレビュー静止画と動画の整合性を構造的に保証）。
-    let direction = direction_for_spec_idx(spec_idx, still_count, &spec);
-    let speed = speed_for_spec_idx(spec_idx, still_count, &spec);
-
-    let opts = AnimateOptions {
-        width: p.width,
-        height: p.height,
-        seed: spec.seed,
-        direction,
-        speed,
-        count: Some(spec.count),
-        orb_size: spec.orb_size,
-        blur: spec.blur,
-        saturation: 1.0,
-        background: bg,
-        shape,
-    };
-
-    let cursor = AnimationCursor::new(clusters, opts, total_frames);
-    Ok(AnimationHandle { cursor })
+    weights.len() - 1
 }
 
 /// 入力画像 1 枚から SVG 文字列を生成する。

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -168,26 +168,45 @@ User-facing CLI behavior is unchanged.
 
 ## Web GUI rendering pipeline
 
-The web frontend (`web/`) renders 12 tiles per drop (8 stills + 4 animated) via
-the WASM bindings. The pipeline is split between a **main thread** (UI + DOM)
-and a **dedicated Worker thread** (wasm + WebCodecs):
+The web frontend (`web/`) renders 12 tiles per drop (8 stills + 4 animated)
+**entirely on the GPU via WebGL2**. wasm is used only for kmeans color
+extraction and for packing per-orb parameters; the per-pixel composition runs
+in a fragment shader. The pipeline is split between a **main thread** (UI +
+DOM) and a **dedicated Worker thread** (wasm + WebGL2 + WebCodecs):
 
 ```
 [main thread]                          [worker thread (orberWorker.ts)]
   Studio.tsx                             wasm-bindgen loaded once
-   ├ runBatch                            ├ generate_one_at_index × 12
-   │   └ workerGenerateOne(i) ────────→  │   └→ PNG bytes (Transferable)
-   ├ animate phase                       ├ start_animation_for_batch_spec × 4
-   │   └ workerAnimateOne(i) ─────────→  │   ├ next_frame loop
-   │                                     │   ├ WebCodecs VideoEncoder
+   ├ runBatch                            ├ wasm.get_render_data(spec_idx, w, h)
+   │   └ workerGenerateOne(i) ────────→  │   └→ Float32Array (orb params)
+   │                                     ├ OffscreenCanvas + WebGL2 fragment
+   │                                     │  shader renders the t=0 frame
+   │                                     ├ canvas.convertToBlob('image/png')
+   │                                     │   └→ PNG bytes (Transferable)
+   ├ animate phase                       ├ wasm.get_render_data(spec_idx, w, h)
+   │   └ workerAnimateOne(i) ─────────→  │   for i in 0..192:
+   │                                     │     - shader.renderFrame(t = i/192)
+   │                                     │     - new VideoFrame(canvas) → encode
+   │                                     ├ WebCodecs VideoEncoder (prefer-hardware)
    │                                     │   └→ mp4 Blob (Transferable)
    └ DL high-res                         └ same APIs, with width/height = 1080×1920
        └ workerGenerateOne / workerAnimateOne (per selected index)
 ```
 
 The source RGB buffer is uploaded once via `workerSetSource` and cached in the
-Worker; subsequent `generateOne` / `animateOne` calls reference that cache so
-multi-megabyte arrays are not copied per call.
+Worker; subsequent `get_render_data` calls reference the cached kmeans
+clusters, so multi-megabyte arrays are not copied per call. The WebGL2 context
+and OffscreenCanvas are also cached per resolution and reused across calls.
+
+**Why WebGL2.** The previous implementation rendered every pixel on the CPU
+inside wasm and ran each animation frame through `RGBA → ImageData →
+createImageBitmap → VideoFrame` before encoding. At 1080×1920 × 192 frames the
+per-pixel CPU cost dominated and a single download tile took several minutes.
+The fragment shader runs in parallel on the GPU and `new VideoFrame(canvas)`
+hands the rendered surface directly to the encoder, eliminating per-frame
+transfer cost entirely. End-to-end download time for one hi-res animated tile
+drops to a few seconds (encoder flush dominates; renders themselves are
+sub-millisecond).
 
 **Preview vs. download resolution.** Tiles are rendered at **540×960** (portrait)
 or **960×540** (landscape) for the preview grid — light enough to keep mobile
@@ -205,19 +224,20 @@ roll contains all 4 directions exactly once and a 2:2 mix of slow/very-slow,
 so a batch never degenerates into "all 4 fast" or "all 4 slow". Static tiles
 keep their spec values; only the animated tiles get the override (#59 / #77).
 The wasm helpers `direction_for_spec_idx` / `speed_for_spec_idx` apply the
-same logic to both the preview PNG (`generate_one_at_index`) and the
-animation cursor (`start_animation_for_batch_spec`), so the t=0 frame and the
-mp4 are guaranteed to match.
+same logic inside `get_render_data`, so the still tile (rendered at `t = 0`)
+and the animated mp4 (rendered at `t ∈ [0, 1)`) are guaranteed to start from
+the exact same frame.
 
 **Clip duration.** Animated tiles are **8 seconds long at 24 fps** (192 frames).
 Combined with the assigned speeds above, VerySlow tiles cross the screen once
 in 8 s — slow enough to feel "drifting", appropriate for use as overlay /
 background plates beneath text.
 
-**Browser requirements.** OffscreenCanvas / VideoEncoder / VideoFrame in Worker
-context. iOS Safari 16.4+, current Android Chrome / Firefox 130+. There is no
-fallback path for older browsers — the GUI shows an error if WebCodecs is
-unavailable.
+**Browser requirements.** OffscreenCanvas / WebGL2 / VideoEncoder / VideoFrame
+in Worker context. iOS Safari 16.4+, current Android Chrome / Firefox 130+.
+There is no fallback path for older browsers — the GUI shows an error if
+WebCodecs is unavailable. WebGL2 support is a strict superset of WebCodecs in
+practice, so any browser that can run the encoder can also run the renderer.
 
 **Progressive UX.** While the Worker is busy:
 
@@ -230,11 +250,10 @@ unavailable.
 
 **Re-roll cancellation.** When the user re-rolls (or drops a new image / flips
 aspect) while the previous batch is still in flight, `runBatch` terminates the
-Worker (`worker.terminate()`) and respawns it with a fresh wasm instance. A
-logical generation guard (`runGen` / `myGen`) alone is not enough because the
-in-flight wasm calls (`generate_one_at_index`) and the WebCodecs encode loop
-keep running to completion otherwise, doubling CPU usage and delaying the new
-batch. After respawn the cached source RGB is invalidated and re-uploaded on
+Worker (`worker.terminate()`) and respawns it with a fresh wasm instance and
+WebGL2 context. A logical generation guard (`runGen` / `myGen`) alone is not
+enough because the in-flight render + encode loop keeps running to completion
+otherwise, doubling GPU/CPU usage and delaying the new batch. After respawn the cached source RGB is invalidated and re-uploaded on
 the next `workerSetSource`. The cost (a small wasm re-init) is paid only when
 re-rolling mid-batch; single, sequential runs see no overhead. Note the
 in-flight check excludes `init` / `setSource` RPCs so a re-roll triggered

--- a/web/src/lib/encodeMp4.ts
+++ b/web/src/lib/encodeMp4.ts
@@ -1,23 +1,15 @@
 // 後半タイルのアニメーションを WebCodecs + mp4-muxer で h264 mp4 化する。
 //
-// orber-wasm から渡される `AnimationHandle` は RGBA フレームを 1 枚ずつ吐く
-// 反復子なので、それを順番に `VideoEncoder.encode` に流して mp4-muxer に
-// 詰め込む。フレームを保持しないことでメモリピークを 1 枚ぶん（≈ 0.9MB / 360×640、
-// hi-res DL 時は ≈ 8MB / 1080×1920）に抑える設計。
+// #112 の WebGL 経路では OffscreenCanvas (WebGL2) に 1 frame 描画して
+// `new VideoFrame(canvas)` で直接エンコーダに食わせる。RGBA バッファの GPU→CPU
+// readback が消えるので、CPU 経路 (wasm + ImageData → ImageBitmap →
+// VideoFrame) と比べて 1080×1920 × 192 frame で大幅に速い。
 //
-// 互換性: VideoEncoder / VideoFrame / ImageData(buf, w, h) が要る。
+// 互換性: VideoEncoder / VideoFrame(canvas) が要る。
 // Chrome 94+ / Safari 16.4+ / Firefox 130+。非対応ブラウザでは throw する
 // （Studio 側で catch して静止画フォールバックする）。
 
 import { Muxer, ArrayBufferTarget } from 'mp4-muxer';
-
-export interface AnimationHandleLike {
-  readonly width: number;
-  readonly height: number;
-  readonly total_frames: number;
-  next_frame(): Uint8ClampedArray | null | undefined;
-  free?: () => void;
-}
 
 export const ANIM_FPS = 24;
 // #77: 8 秒ぶん。背景・配信オーバーレイ用途では「ほとんど動いていないように
@@ -34,22 +26,31 @@ export function isWebCodecsSupported(): boolean {
 }
 
 /**
- * `AnimationHandle` を消費して 1 本の mp4 Blob を返す。
+ * OffscreenCanvas (WebGL2) を消費して 1 本の mp4 Blob を返す。
  *
- * 呼び出し後、handle はすべての frame を吐き終えており、`free()` 可能。
+ * `renderFrame(t)` を呼ぶと canvas に t における 1 フレームが描画される前提。
+ * このループ側で `t = i / totalFrames` (i = 0..totalFrames) を順に流し、
+ * 各 frame について `new VideoFrame(canvas)` を作って encoder に渡す。
+ *
+ * canvas を直接 VideoFrame に渡すので RGBA の readback / ImageData 経由が消え、
+ * GPU 経路ではエンコード時間が encoder 側律速まで詰まる（#112）。
+ *
  * エンコード中の例外は再 throw する（呼び出し側で catch）。
  */
-export async function encodeAnimationToMp4(
-  handle: AnimationHandleLike,
+export async function encodeAnimationFromCanvas(
+  canvas: OffscreenCanvas,
+  renderFrame: (t: number) => void,
+  totalFrames: number,
+  width: number,
+  height: number,
   onProgress?: (frame: number, total: number) => void,
 ): Promise<Blob> {
   if (!isWebCodecsSupported()) {
     throw new Error('WebCodecs (VideoEncoder/VideoFrame) is not available');
   }
-
-  const width = handle.width;
-  const height = handle.height;
-  const totalFrames = handle.total_frames;
+  if (totalFrames <= 0) {
+    throw new Error('totalFrames must be > 0');
+  }
 
   const muxer = new Muxer({
     target: new ArrayBufferTarget(),
@@ -74,18 +75,8 @@ export async function encodeAnimationToMp4(
   // 解像度に応じて AVC level を選択する。
   //   - Level 3.1 (0x1F): coded area 上限 921,600px（≈ 720p まで）
   //   - Level 4.2 (0x2A): coded area 上限 2,228,224px（1080p で余裕）
-  // hi-res DL 1080×1920 は coded area が 1088×1920 = 2,088,960 になり 3.1
-  // を超えるため、preview 解像度より広い場合は 4.2 を使う。Baseline profile
-  // の互換性維持のまま level だけ上げる: avc1.42E0{XX}。
-  // bitrate 2Mbps は 24fps でも余裕がありつつファイル ~1MB に収まる目安。
-  // 仕様上 `configure` は同期で完了し、直後の `encode` 呼び出しは合法。
   const codedArea = Math.ceil(width / 16) * 16 * Math.ceil(height / 16) * 16;
   const codecString = codedArea <= 921_600 ? 'avc1.42E01F' : 'avc1.42E02A';
-  // `hardwareAcceleration: 'prefer-hardware'` で HW h264 エンコーダがあれば
-  // それを使う。Android Chrome や iOS Safari の最近の機種は MediaCodec /
-  // VideoToolbox 経由で大幅に速い。HW 不在環境では仕様上ソフトウェアに
-  // フォールバックする（`require` ではなく `prefer` なので throw しない）。
-  // 1080×1920 × 192 frame の DL hi-res で体感差が出る。
   encoder.configure({
     codec: codecString,
     width,
@@ -99,20 +90,23 @@ export async function encodeAnimationToMp4(
 
   for (let i = 0; i < totalFrames; i++) {
     if (firstError !== null) break;
-    const rgba = handle.next_frame();
-    if (!rgba) break;
-    const imageData = new ImageData(rgba, width, height);
-    // createImageBitmap でビットマップ化してから VideoFrame に詰める。
-    // 一部ブラウザは ImageData → VideoFrame 直接生成に未対応のため。
-    const bitmap = await createImageBitmap(imageData);
-    const frame = new VideoFrame(bitmap, {
-      timestamp: Math.round(i * microsecondsPerFrame),
-      duration: Math.round(microsecondsPerFrame),
-    });
-    bitmap.close();
-    // レビュー S8: VideoEncoder.encode は同期 throw する仕様（encoder の
-    // 状態異常など）。catch せずに放置すると Worker が die して Studio 側
-    // pending が孤児化する。catch して firstError 経由で flush 後に再 throw。
+    // t は [0, 1) の範囲を順に。t=1 は出さない（loop closure で t=0 と一致）。
+    const t = i / totalFrames;
+    renderFrame(t);
+    // canvas 直渡し: VideoFrame コンストラクタは canvas のピクセルをスナップ
+    // ショットして取り込む。drawArrays 直後でも GL のキューイング順序は
+    // 保たれているので、あとから読み出した時に未描画のフレームが入る心配は
+    // ない（WebGL → VideoFrame の同一スレッド内は順序保証あり）。
+    let frame: VideoFrame;
+    try {
+      frame = new VideoFrame(canvas as unknown as CanvasImageSource, {
+        timestamp: Math.round(i * microsecondsPerFrame),
+        duration: Math.round(microsecondsPerFrame),
+      });
+    } catch (e) {
+      if (firstError === null) firstError = e;
+      break;
+    }
     try {
       // 1 秒ごとにキーフレームを入れてシーク・ループ頭出しを安定させる。
       encoder.encode(frame, { keyFrame: i % ANIM_FPS === 0 });
@@ -122,10 +116,7 @@ export async function encodeAnimationToMp4(
       break;
     }
     frame.close();
-    // #95: フレーム単位の進捗を呼び出し側に通知。encode は非同期だが、
-    // ここではループ内で「キューに投入し終えたフレーム数」を進捗として
-    // 報告する（実エンコード完了を待たないため、UI 上のリングはやや
-    // 早めに 100% に達する可能性があるが、体感としては十分滑らか）。
+    // #95: フレーム単位の進捗を呼び出し側に通知。
     onProgress?.(i + 1, totalFrames);
   }
 

--- a/web/src/lib/orberGl.ts
+++ b/web/src/lib/orberGl.ts
@@ -1,0 +1,350 @@
+// orber#112 — WebGL2 fragment shader による per-pixel orb 描画。
+//
+// `orber-wasm` の `get_render_data` で得た Float32Array をそのまま uniform に
+// 流し、fragment shader 1 pass で全 orb の Source-Over 合成を行う。CPU 経路
+// (`crates/core::animate::render_frame_with_params`) と同じ数式・同じ per-orb
+// パラメータを使うので、視覚パリティは「最終的な見た目が同じ」が保たれる。
+//
+// アーキテクチャ:
+//   1. setup() で program / VAO / FBO 関連の使い回しリソースを 1 度だけ作る
+//   2. setRenderData(buf) で per-orb uniform を 1 度アップロード（フレーム間で
+//      不変なので 192 frame の動画化でも 1 回だけ）
+//   3. renderFrame(t) で u_t だけ書き換えて drawArrays 1 発
+//
+// 仕様の数式は CPU 経路と完全一致させる:
+//   - extent = 1 + 2 * r_normalized
+//   - r_normalized = base_radius_unit * sqrt(weight) * 1.10 / progress_axis_pixels
+//   - advance_steps = fract(cycle * speed_mult * t)
+//   - pos = mod(phase * extent + advance_steps * extent, extent) - r_normalized
+//   - 3 軸独立呼吸: radius ±10%, blur ±15, opacity ±5%
+//   - rim: 3-stop alpha gradient (mid_stop = clamp(1 - blur*0.8, 0.05, 0.95))
+//   - soft: 2-stop alpha gradient (hold_stop = clamp(1 - blur, 0.05, 0.95))
+//   - Source-Over: out.rgb = src.rgb * src.a + out.rgb * (1 - src.a)
+//                  out.a   = src.a + out.a * (1 - src.a)
+
+/// uniform 配列の上限。`crates/core::animate::MAX_ORB_COUNT = 1024` ほど大きく
+/// する必要はなく、GUI 経路では `random_batch_specs` の count_range
+/// (COUNT_MAX = 50) が事実上の上限。バッファ余裕を持たせて 64 とする。
+const MAX_ORBS = 64;
+
+const HEADER_WORDS = 16;
+const PER_ORB_WORDS = 16;
+
+const VS = `#version 300 es
+in vec2 a_pos;
+void main() {
+  gl_Position = vec4(a_pos, 0.0, 1.0);
+}`;
+
+// fragment shader: per-pixel に全 orb をループして Source-Over で合成する。
+// 仕様の数式 (extent / pos / 呼吸 / rim/soft グラデ) を 1:1 で再現。
+const FS = `#version 300 es
+precision highp float;
+out vec4 outColor;
+
+const float TAU = 6.28318530718;
+const float BREATH_RADIUS_MAX_FACTOR = 1.10;
+
+uniform vec2 u_resolution;
+uniform float u_t;             // [0, 1)
+uniform vec4 u_bg;             // straight rgba (0..1)
+uniform float u_base_radius;   // px
+uniform float u_base_blur;     // 0..1
+uniform float u_direction;     // 0=LR, 1=RL, 2=TB, 3=BT
+uniform float u_cycle;         // 1 or 2
+uniform int u_n_orbs;
+
+// per-orb uniforms (length MAX_ORBS = 64). Float で詰める。
+uniform vec4 u_orb_color[${MAX_ORBS}];     // (r, g, b, weight)
+uniform vec4 u_orb_phase[${MAX_ORBS}];     // (phase, phi_radius, phi_blur, phi_opacity)
+uniform vec4 u_orb_misc[${MAX_ORBS}];      // (cross_axis, style_bit, speed_mult, _)
+
+float clampf(float x, float a, float b) { return min(max(x, a), b); }
+
+void main() {
+  vec2 px = gl_FragCoord.xy;
+  // gl_FragCoord は左下原点。CPU 経路は左上原点 (image::RgbaImage) なので
+  // y を反転して合わせる。
+  px.y = u_resolution.y - px.y;
+
+  // 進行軸長 (LR/RL=width, TB/BT=height)
+  float progress_axis = (u_direction < 1.5) ? u_resolution.x : u_resolution.y;
+
+  // 背景塗り (straight alpha)
+  vec3 acc_rgb = u_bg.rgb;
+  float acc_a = u_bg.a;
+
+  for (int i = 0; i < ${MAX_ORBS}; i++) {
+    if (i >= u_n_orbs) break;
+
+    vec4 col = u_orb_color[i];
+    vec4 ph = u_orb_phase[i];
+    vec4 misc = u_orb_misc[i];
+
+    float weight = col.w;
+    float phase = ph.x;
+    float phi_radius = ph.y;
+    float phi_blur = ph.z;
+    float phi_opacity = ph.w;
+    float cross_axis = misc.x;
+    float style_bit = misc.y;       // 0=rim, 1=soft
+    float speed_mult = misc.z;
+
+    float r_pixels_max = u_base_radius * sqrt(max(weight, 0.0)) * BREATH_RADIUS_MAX_FACTOR;
+    float r_normalized = (progress_axis > 0.0) ? (r_pixels_max / progress_axis) : 0.0;
+    float extent = 1.0 + 2.0 * r_normalized;
+
+    float advance_steps = fract(u_cycle * speed_mult * u_t);
+    float raw = phase * extent + advance_steps * extent;
+    // GLSL の mod() は負を出さない (mod(x, y) = x - y * floor(x/y))。Rust の
+    // rem_euclid と一致するので、Rust 側と同じ pos が出る。
+    float pos = mod(raw, extent) - r_normalized;
+
+    float nx, ny;
+    if (u_direction < 0.5) {        // LR
+      nx = pos; ny = cross_axis;
+    } else if (u_direction < 1.5) { // RL
+      nx = 1.0 - pos; ny = cross_axis;
+    } else if (u_direction < 2.5) { // TB
+      nx = cross_axis; ny = pos;
+    } else {                        // BT
+      nx = cross_axis; ny = 1.0 - pos;
+    }
+
+    float t_frac = fract(u_t);
+    float radius_factor = 1.0 + 0.10 * sin(TAU * t_frac + phi_radius);
+    float blur_delta = 0.15 * sin(TAU * t_frac + phi_blur);
+    float opacity_factor = 1.0 + 0.05 * sin(TAU * t_frac + phi_opacity);
+
+    float radius = u_base_radius * sqrt(max(weight, 0.0)) * radius_factor;
+    if (radius <= 0.0) continue;
+
+    float blur = clampf(u_base_blur + blur_delta, 0.0, 1.0);
+    float opacity = clampf(opacity_factor, 0.0, 1.0);
+
+    float cx = nx * u_resolution.x;
+    float cy = ny * u_resolution.y;
+
+    float dist = distance(px, vec2(cx, cy));
+    float dnorm = dist / radius;        // 0..1 が orb 内、>1 は外
+
+    // alpha 計算 (rim / soft)。center_alpha = opacity, mid_alpha = opacity * 80/255。
+    float alpha = 0.0;
+    if (dnorm < 1.0) {
+      float center_a = opacity;
+      float mid_a = opacity * (80.0 / 255.0);
+      if (style_bit < 0.5) {
+        // rim: 3-stop
+        float mid_stop = clampf(1.0 - blur * 0.8, 0.05, 0.95);
+        if (dnorm <= mid_stop) {
+          float u = (mid_stop > 0.0) ? (dnorm / mid_stop) : 1.0;
+          alpha = mix(center_a, mid_a, u);
+        } else {
+          float denom = max(1.0 - mid_stop, 1e-6);
+          float u = (dnorm - mid_stop) / denom;
+          alpha = mix(mid_a, 0.0, u);
+        }
+      } else {
+        // soft: 2-stop (center .. hold_stop は center_a 一定 → hold_stop..1 で 0 へ)
+        float hold_stop = clampf(1.0 - blur, 0.05, 0.95);
+        if (dnorm <= hold_stop) {
+          alpha = center_a;
+        } else {
+          float denom = max(1.0 - hold_stop, 1e-6);
+          float u = (dnorm - hold_stop) / denom;
+          alpha = mix(center_a, 0.0, u);
+        }
+      }
+    }
+
+    if (alpha > 0.0) {
+      // Source-Over (straight alpha)
+      // out.rgb = src.rgb * src.a + out.rgb * (1 - src.a)
+      // out.a   = src.a + out.a * (1 - src.a)
+      vec3 src_rgb = col.rgb;
+      float one_minus_a = 1.0 - alpha;
+      acc_rgb = src_rgb * alpha + acc_rgb * one_minus_a;
+      acc_a = alpha + acc_a * one_minus_a;
+    }
+  }
+
+  outColor = vec4(acc_rgb, acc_a);
+}`;
+
+export interface GlRenderer {
+  /** 解像度を変更する。canvas のサイズは呼び出し側で予め変更しておくこと。 */
+  setResolution(width: number, height: number): void;
+  /** wasm の get_render_data 出力を 1 回だけ uniform に流す。 */
+  setRenderData(data: Float32Array): void;
+  /** u_t を書き換えて 1 フレーム描画する。 */
+  renderFrame(t: number): void;
+  /** リソース解放（canvas を捨てるとき）。 */
+  dispose(): void;
+}
+
+type AnyCanvas = HTMLCanvasElement | OffscreenCanvas;
+
+export function createGlRenderer(canvas: AnyCanvas): GlRenderer {
+  // alpha=true: 出力に straight alpha を残したいので背景透過 canvas で取る。
+  // OffscreenCanvas からの transferToImageBitmap / VideoFrame(canvas) は
+  // canvas のピクセルをそのままコピーする。
+  const gl = canvas.getContext('webgl2', {
+    alpha: true,
+    antialias: false,
+    premultipliedAlpha: false,
+    preserveDrawingBuffer: false,
+  }) as WebGL2RenderingContext | null;
+  if (!gl) {
+    throw new Error('WebGL2 context could not be created');
+  }
+
+  function compile(type: number, src: string): WebGLShader {
+    const sh = gl!.createShader(type)!;
+    gl!.shaderSource(sh, src);
+    gl!.compileShader(sh);
+    if (!gl!.getShaderParameter(sh, gl!.COMPILE_STATUS)) {
+      const info = gl!.getShaderInfoLog(sh) ?? '<no log>';
+      gl!.deleteShader(sh);
+      throw new Error(`shader compile failed: ${info}`);
+    }
+    return sh;
+  }
+
+  const vs = compile(gl.VERTEX_SHADER, VS);
+  const fs = compile(gl.FRAGMENT_SHADER, FS);
+  const prog = gl.createProgram()!;
+  gl.attachShader(prog, vs);
+  gl.attachShader(prog, fs);
+  gl.linkProgram(prog);
+  if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+    const info = gl.getProgramInfoLog(prog) ?? '<no log>';
+    throw new Error(`program link failed: ${info}`);
+  }
+  gl.useProgram(prog);
+  // shader を program に紐付けたら個別オブジェクトは破棄してよい。
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+
+  // full-screen triangle (covers viewport without scissor)
+  const vao = gl.createVertexArray()!;
+  gl.bindVertexArray(vao);
+  const vbo = gl.createBuffer()!;
+  gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([-1, -1, 3, -1, -1, 3]),
+    gl.STATIC_DRAW,
+  );
+  const aPos = gl.getAttribLocation(prog, 'a_pos');
+  gl.enableVertexAttribArray(aPos);
+  gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
+
+  const uLoc = {
+    resolution: gl.getUniformLocation(prog, 'u_resolution'),
+    t: gl.getUniformLocation(prog, 'u_t'),
+    bg: gl.getUniformLocation(prog, 'u_bg'),
+    baseRadius: gl.getUniformLocation(prog, 'u_base_radius'),
+    baseBlur: gl.getUniformLocation(prog, 'u_base_blur'),
+    direction: gl.getUniformLocation(prog, 'u_direction'),
+    cycle: gl.getUniformLocation(prog, 'u_cycle'),
+    nOrbs: gl.getUniformLocation(prog, 'u_n_orbs'),
+    orbColor: gl.getUniformLocation(prog, 'u_orb_color'),
+    orbPhase: gl.getUniformLocation(prog, 'u_orb_phase'),
+    orbMisc: gl.getUniformLocation(prog, 'u_orb_misc'),
+  };
+
+  // 使い回しバッファ。MAX_ORBS × 4 vec4 1 軸ぶんずつ。
+  const colorBuf = new Float32Array(MAX_ORBS * 4);
+  const phaseBuf = new Float32Array(MAX_ORBS * 4);
+  const miscBuf = new Float32Array(MAX_ORBS * 4);
+
+  // blend は使わない（fragment 内で per-orb Source-Over を完結させるため、
+  // GL の blend で重ねると 2 重ブレンドになる）。
+  gl.disable(gl.BLEND);
+
+  let curWidth = 0;
+  let curHeight = 0;
+
+  function setResolution(width: number, height: number): void {
+    curWidth = width;
+    curHeight = height;
+    gl!.viewport(0, 0, width, height);
+    gl!.uniform2f(uLoc.resolution, width, height);
+  }
+
+  function setRenderData(data: Float32Array): void {
+    if (data.length < HEADER_WORDS) {
+      throw new Error(`render data too short: ${data.length} < ${HEADER_WORDS}`);
+    }
+    const bgR = data[0];
+    const bgG = data[1];
+    const bgB = data[2];
+    const bgA = data[3];
+    const baseRadius = data[4];
+    const baseBlur = data[5];
+    const directionId = data[6];
+    const cycle = data[7];
+    const nOrbs = data[8] | 0;
+
+    if (nOrbs > MAX_ORBS) {
+      throw new Error(`n_orbs ${nOrbs} exceeds MAX_ORBS=${MAX_ORBS}`);
+    }
+    const expected = HEADER_WORDS + PER_ORB_WORDS * nOrbs;
+    if (data.length < expected) {
+      throw new Error(
+        `render data length mismatch: got ${data.length}, expected at least ${expected}`,
+      );
+    }
+
+    gl!.uniform4f(uLoc.bg, bgR, bgG, bgB, bgA);
+    gl!.uniform1f(uLoc.baseRadius, baseRadius);
+    gl!.uniform1f(uLoc.baseBlur, baseBlur);
+    gl!.uniform1f(uLoc.direction, directionId);
+    gl!.uniform1f(uLoc.cycle, cycle);
+    gl!.uniform1i(uLoc.nOrbs, nOrbs);
+
+    // per-orb を 3 本の vec4 配列に詰め直す。余り (i >= nOrbs) は 0 詰め
+    // のままで shader 側で `i >= u_n_orbs` ガードしているので使われない。
+    colorBuf.fill(0);
+    phaseBuf.fill(0);
+    miscBuf.fill(0);
+    for (let i = 0; i < nOrbs; i++) {
+      const off = HEADER_WORDS + PER_ORB_WORDS * i;
+      // color rgb + weight
+      colorBuf[i * 4 + 0] = data[off + 0];
+      colorBuf[i * 4 + 1] = data[off + 1];
+      colorBuf[i * 4 + 2] = data[off + 2];
+      colorBuf[i * 4 + 3] = data[off + 3];
+      // phase / phi_radius / phi_blur / phi_opacity
+      phaseBuf[i * 4 + 0] = data[off + 4];
+      phaseBuf[i * 4 + 1] = data[off + 5];
+      phaseBuf[i * 4 + 2] = data[off + 6];
+      phaseBuf[i * 4 + 3] = data[off + 7];
+      // cross_axis / style_bit / speed_mult / _
+      miscBuf[i * 4 + 0] = data[off + 8];
+      miscBuf[i * 4 + 1] = data[off + 9];
+      miscBuf[i * 4 + 2] = data[off + 10];
+      miscBuf[i * 4 + 3] = 0;
+    }
+    gl!.uniform4fv(uLoc.orbColor, colorBuf);
+    gl!.uniform4fv(uLoc.orbPhase, phaseBuf);
+    gl!.uniform4fv(uLoc.orbMisc, miscBuf);
+  }
+
+  function renderFrame(t: number): void {
+    if (curWidth === 0 || curHeight === 0) {
+      throw new Error('setResolution must be called before renderFrame');
+    }
+    gl!.uniform1f(uLoc.t, t);
+    // 背景は shader 内で u_bg を書き出すので clear 不要。
+    gl!.drawArrays(gl!.TRIANGLES, 0, 3);
+  }
+
+  function dispose(): void {
+    gl!.deleteBuffer(vbo);
+    gl!.deleteVertexArray(vao);
+    gl!.deleteProgram(prog);
+  }
+
+  return { setResolution, setRenderData, renderFrame, dispose };
+}

--- a/web/src/lib/orberGl.ts
+++ b/web/src/lib/orberGl.ts
@@ -18,9 +18,16 @@
 //   - pos = mod(phase * extent + advance_steps * extent, extent) - r_normalized
 //   - 3 軸独立呼吸: radius ±10%, blur ±15, opacity ±5%
 //   - rim: 3-stop alpha gradient (mid_stop = clamp(1 - blur*0.8, 0.05, 0.95))
+//          center_a = opacity, mid_a = opacity * 80/255 ≈ 0.3137
 //   - soft: 2-stop alpha gradient (hold_stop = clamp(1 - blur, 0.05, 0.95))
 //   - Source-Over: out.rgb = src.rgb * src.a + out.rgb * (1 - src.a)
 //                  out.a   = src.a + out.a * (1 - src.a)
+//
+// review S1: CPU 側 (crates/core::orb) は alpha を `(opacity * 255).round() as u8`
+// と `(opacity * 80).round() as u8` で 1/255 ステップに量子化してから tiny-skia
+// に渡している。本 shader は raw float のまま blend する。差分は最大 ≤ 1/255
+// (≒ 0.4% の輝度差) で肉眼識別不能。kako-jun 合意の「最終的な見た目が同じ」
+// 合格ラインを守る前提で量子化は省略している。
 
 /// uniform 配列の上限。`crates/core::animate::MAX_ORB_COUNT = 1024` ほど大きく
 /// する必要はなく、GUI 経路では `random_batch_specs` の count_range

--- a/web/src/lib/orberWorker.ts
+++ b/web/src/lib/orberWorker.ts
@@ -1,26 +1,24 @@
-// orber#75 — wasm 描画 + WebCodecs エンコードを Worker スレッドで実行する。
+// orber#75 / #112 — wasm + WebGL2 描画 + WebCodecs エンコードを Worker スレッドで実行する。
 //
 // メインスレッドは UI / DOM / Solid signal だけに集中させ、重い計算は全部
 // ここに逃がす。これによりスマホでも生成中にスクロール / タップが死なない。
 //
 // アーキテクチャ:
 //   main → postMessage({ kind, id, ... }) → worker
-//   worker → wasm 呼び出し → postMessage({ id, ok, data }) → main
+//   worker → wasm.get_render_data → WebGL2 (OffscreenCanvas) 描画 →
+//            convertToBlob (PNG) or VideoEncoder (mp4) → main
 //
 // データ転送:
 //   - PNG / mp4 の ArrayBuffer は Transferable で zero-copy 返却
 //   - source RGB は `setSource` で 1 度だけ送って worker 側にキャッシュする
-//     （runBatch / DL / アスペクト切替で使い回し）
 //
-// 互換性: OffscreenCanvas / VideoEncoder / VideoFrame in Worker が要る。
-// iOS Safari 16.4+ / Android Chrome / 最近の Firefox。古い端末は対象外
-// （isWebCodecsSupported() のメイン側チェックで弾く前提）。
+// 互換性: OffscreenCanvas + WebGL2 + VideoEncoder/VideoFrame in Worker が要る。
+// iOS Safari 16.4+ / Android Chrome / 最近の Firefox。古い端末は対象外。
 
 import init, * as wasm from '../wasm/orber_wasm.js';
-import { encodeAnimationToMp4 } from './encodeMp4';
+import { encodeAnimationFromCanvas } from './encodeMp4';
+import { createGlRenderer, type GlRenderer } from './orberGl';
 
-// レビュー M6: 複数メッセージが同時に到着すると ensureInit が並行に走り、
-// init() が重複実行される。Promise をキャッシュして 1 度きりにする。
 let initialized = false;
 let initPromise: Promise<void> | null = null;
 function ensureInit(): Promise<void> {
@@ -33,11 +31,27 @@ function ensureInit(): Promise<void> {
   return initPromise;
 }
 
-// 入力画像の RGB バッファを worker 側にキャッシュ。同じ画像で複数回 wasm を
-// 呼ぶ（12 枚生成 / DL hi-res 12 枚）ので、毎回 postMessage で送るのは無駄。
-// `setSource` で 1 度送って、以降の generateOne / animateOne はキャッシュを
-// 自動で混ぜ込む。
 let cachedSource: { rgb: Uint8Array; width: number; height: number } | null = null;
+
+// OffscreenCanvas + GlRenderer は (width, height) ごとに 1 個だけ作って使い回す。
+// 192 frame の動画化中はもちろん、アスペクト切替や preview / hi-res の解像度
+// 切替でも、同じサイズなら再利用したい。WebGL の context 生成は重い。
+let cachedCanvas: { canvas: OffscreenCanvas; renderer: GlRenderer; width: number; height: number } | null = null;
+
+function getRenderer(width: number, height: number): { canvas: OffscreenCanvas; renderer: GlRenderer } {
+  if (cachedCanvas && cachedCanvas.width === width && cachedCanvas.height === height) {
+    return { canvas: cachedCanvas.canvas, renderer: cachedCanvas.renderer };
+  }
+  if (cachedCanvas) {
+    cachedCanvas.renderer.dispose();
+    cachedCanvas = null;
+  }
+  const canvas = new OffscreenCanvas(width, height);
+  const renderer = createGlRenderer(canvas);
+  renderer.setResolution(width, height);
+  cachedCanvas = { canvas, renderer, width, height };
+  return { canvas, renderer };
+}
 
 interface BaseParams {
   k: number;
@@ -103,44 +117,42 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
       }
       case 'generateOne': {
         const params = mergeParams(req.params);
-        const png = wasm.generate_one_at_index(params, req.n, req.index);
-        // png.buffer は wasm 線形メモリへの view → そのまま postMessage で
-        // Transferable に渡すと wasm 側のメモリが detach されて壊れる。
-        // slice() で新規 ArrayBuffer を作って Transferable で main に渡す。
-        const buf = png.slice().buffer;
+        const data = wasm.get_render_data(params, req.n, req.index);
+        const { canvas, renderer } = getRenderer(req.params.width, req.params.height);
+        renderer.setRenderData(data);
+        renderer.renderFrame(0);
+        // PNG にエンコードして main に返す。convertToBlob は OffscreenCanvas
+        // 標準で、PNG 圧縮は worker 側で完結する。
+        const blob = await canvas.convertToBlob({ type: 'image/png' });
+        const buf = await blob.arrayBuffer();
         post({ id: req.id, ok: true, data: buf }, [buf]);
         break;
       }
       case 'animateOne': {
         const params = mergeParams(req.params);
-        const handle = wasm.start_animation_for_batch_spec(
-          params,
-          req.n,
-          req.index,
+        const data = wasm.get_render_data(params, req.n, req.index);
+        const width = req.params.width;
+        const height = req.params.height;
+        const { canvas, renderer } = getRenderer(width, height);
+        renderer.setRenderData(data);
+        // フレーム単位の進捗を main に流す。レビュー S2 の間引きは維持。
+        const PROGRESS_STRIDE = 4;
+        const blob = await encodeAnimationFromCanvas(
+          canvas,
+          (t) => renderer.renderFrame(t),
           req.totalFrames,
-        );
-        try {
-          // #95: フレーム単位の進捗を main に流す。本体応答（id + ok）と
-          // 別 kind で送るので、main 側は pending を消さずに onProgress
-          // だけ発火させる経路で受ける。
-          // レビュー S2: フレーム毎に postMessage + main 側 setTiles すると
-          // 192 frames × 4 タイル並走で setTiles が高頻度化し、特にスマホ
-          // で reconcile が重い。PROGRESS_STRIDE 毎に間引き、最終フレームは
-          // 必ず送る（リングが 100% で停止するため）。
-          const PROGRESS_STRIDE = 4;
-          const blob = await encodeAnimationToMp4(handle, (frame, total) => {
+          width,
+          height,
+          (frame, total) => {
             if (frame !== total && frame % PROGRESS_STRIDE !== 0) return;
             post({ kind: 'animateProgress', id: req.id, frame, total });
-          });
-          const buf = await blob.arrayBuffer();
-          post({ id: req.id, ok: true, data: buf }, [buf]);
-        } finally {
-          handle.free?.();
-        }
+          },
+        );
+        const buf = await blob.arrayBuffer();
+        post({ id: req.id, ok: true, data: buf }, [buf]);
         break;
       }
       default: {
-        // 網羅性チェック。型システムが req: never を要求する。
         const exhaustive: never = req;
         throw new Error(`unknown req kind: ${JSON.stringify(exhaustive)}`);
       }


### PR DESCRIPTION
Closes #112

## やったこと

orber web GUI の per-pixel 描画を **wasm + CPU** から **WebGL2 + GPU** に全置き換え。OffscreenCanvas + WebGL2 を Worker 内で動かし、`new VideoFrame(canvas)` で per-frame 転送コストもゼロ化。

## 期待効果

PoC #113 計測で 1080×1920 × 192 frame 動画化が **2.15 秒**（render 3ms / VideoFrame 35ms / encode flush 残り）まで短縮されると判明済み。現状「1 タイル数分」から **約 50〜100 倍速**。

## 変更内容

### wasm
- **追加**: `get_render_data(spec_idx, w, h) -> Float32Array` — 1 spec 分の全 orb パラメータ（color, weight, phase, phi_radius/blur/opacity, cross_axis, style, speed_mult）と背景色・base_radius/blur・direction・cycle を 1 配列で返す
- **削除**: `generate_one_at_index`, `start_animation_for_batch_spec`, `next_frame`, `AnimationHandle` 関連
- **既存の ChaCha8Rng シーケンスは厳密に保持**（同じ seed → 同じ orb 列）
- `crates/core` は **一切無改変**（CLI が使う）

### TS
- **新規 `web/src/lib/orberGl.ts`** (350 行): `createGlRenderer` で WebGL2 fragment shader による全描画。仕様の数式（extent/mod、3 軸独立呼吸、rim 3-stop / soft 2-stop、center_a=opacity、mid_a=opacity*80/255）を 1:1 再現。`MAX_ORBS=64`（GUI 実用 10〜50 個 + 余裕）
- **`orberWorker.ts`**: OffscreenCanvas + WebGL2 を解像度ごとにキャッシュ。`generateOne` は `convertToBlob({type:'image/png'})` で PNG 返却。`animateOne` は frame loop で `new VideoFrame(canvas)` → encode
- **`encodeMp4.ts`**: `AnimationHandleLike` を捨て、`encodeAnimationFromCanvas(canvas, renderFrame, totalFrames, ...)` 新シグネチャ。RGBA readback / ImageData / createImageBitmap 経路を全排除。`hardwareAcceleration: 'prefer-hardware'`・AVC level 自動切替・1 秒キーフレーム・進捗通知を維持

## 視覚パリティ

kako-jun と合意: **「最終的な見た目が同じ」が合格ライン**、GPU 内部実装テクニックは自由。

守った観察可能な振る舞い:
- speed の整数倍率（cycle ∈ {1,2}, speed_mult ∈ {1,2,3}）→ Loop closure 保証
- 4 方向 direction、1 方向のみ全 orb 共通
- 呼吸揺らぎ 3 軸独立（半径 ±10%, blur ±15%, opacity ±5%）
- rim/soft の per-orb 50:50 振り分け（seed 由来）
- 支配色背景塗り、Source-Over alpha blend
- `[-r, 1+r]` off-screen wrap（画面端で半欠け、反対側から完全出現）

## 検証

- `cargo build --release -p orber-wasm`: **warning なしで成功**
- `cargo test -p orber-wasm`: **13 passed**
- `npx tsc --noEmit`: 6 件（ベースライン 7 から自分の変更で 1 件減、新規エラーゼロ）

## 残課題

- 実機での視覚パリティ確認（kako-jun 側で本番デプロイ後に既存出力と並べて見比べる）
- Aquarelle スタイル（既存 wasm export からは到達しないため WebGL 経路非対応）— GUI で使われていないので問題なし
- shape は `circle` のみ（既存と同じ仕様）

## Test plan

- [ ] PC: ドラッグ → 12 タイル生成・動画化が即時完了
- [ ] PC: DL hi-res 1 タイル時間を計測（現状数分 → 数秒を期待）
- [ ] Android: 同上
- [ ] 既存出力と並べて視覚パリティ確認
- [ ] Loop closure: 動画末尾と冒頭の継ぎ目が滑らか