### PR TITLE
fix(web): ドロップエリア非ホバー時のコントラストを上げる

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -18,7 +18,7 @@ No accent color. The generated artwork supplies all color; the chrome stays in m
 | `fg`             | `#FFFFFF`                   | Primary text, logo, active control text                 |
 | `fg-muted`       | `rgba(255,255,255,0.55)`    | Subtitle, status text, inactive control text            |
 | `fg-subtle`      | `rgba(255,255,255,0.32)`    | Placeholder text, disabled label                        |
-| `hairline`       | `rgba(255,255,255,0.12)`    | Drop-area dashed border, separators                     |
+| `hairline`       | `rgba(255,255,255,0.12)`    | Separators, glass borders                               |
 | `glass-bg`       | `rgba(255,255,255,0.06)`    | Default button / toggle / segmented surface             |
 | `glass-bg-hover` | `rgba(255,255,255,0.10)`    | Hover state for glass surfaces                          |
 | `glass-blur`     | `blur(12px)`                | `backdrop-filter` on glass surfaces                     |
@@ -61,7 +61,8 @@ No bold anywhere. Headers are deliberately light.
 
 - Flat, **not** glass (acts as content surface, not control)
 - Background: transparent
-- Border: `1px dashed hairline`, radius `0.75rem`
+- Border: dotted ring (SVG `stroke-dasharray="0 14"` + `stroke-linecap="round"`),
+  default color `fg-subtle` (`rgba(255,255,255,0.32)`), radius `0.75rem`
 - Padding: `2.5rem` (40px) vertical, `2rem` (32px) horizontal
 - Hover state (empty): border swaps to `fg-muted`
 - Drag-over state: border swaps to `fg`, fill `glass-bg`

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -731,7 +731,7 @@ export default function Studio() {
           'group relative block cursor-pointer touch-none rounded-xl py-10 px-8 text-center transition-colors duration-200 ease-out focus-within:text-focusRing ' +
           (dragOver()
             ? 'text-fg bg-glassBg'
-            : 'text-hairline hover:text-fgMuted')
+            : 'text-fgSubtle hover:text-fgMuted')
         }
       >
         {/* #79: 丸ドット周回ボーダー — orb との視覚統一。


### PR DESCRIPTION
## やったこと

ドロップエリアの dot ring を非ホバー時に見えるようにする。

- `text-hairline` (rgba 0.12) → `text-fgSubtle` (rgba 0.32) — 2.7× 濃く
- 既存の design token を使うのでパレット拡張なし
- ホバー時 `fgMuted` (0.55) / drag-over 時 `fg` (1.0) は変更なし、階層は維持

## DESIGN.md 追従

- §2 token table: `hairline` の用途記述から「Drop-area dashed border」を外す
- §4 DropArea: 「1px dashed hairline」を実装通りの「dotted ring + default fg-subtle」に修正

## 報告

実機で kako-jun から「ホバー時は濃くなるので見えるが、ホバーでないときももっと濃くしないと見えない」のフィードバック。