### PR TITLE
fix(web): タッチスクロール復活 + Android 用 perf 診断ログ

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -4,6 +4,7 @@ import { ANIM_TOTAL_FRAMES, isWebCodecsSupported } from '../lib/encodeMp4';
 import {
   hasInFlight,
   onWorkerCrash,
+  onWorkerDebug,
   terminateAndRespawn,
   workerAnimateOne,
   workerGenerateOne,
@@ -60,6 +61,9 @@ const DL_H_LANDSCAPE = 1080;
 export default function Studio() {
   const [wasmStatus, setWasmStatus] = createSignal<'loading' | 'ready' | 'error'>('loading');
   const [wasmErr, setWasmErr] = createSignal<string>('');
+  // 実機（Android）で console を拾えないため、worker からの per-stage 計測ログを
+  // 画面 <pre> に出して kako-jun が確認できるようにする。直近 20 件保持。
+  const [debugLog, setDebugLog] = createSignal<string[]>([]);
   const [aspect, setAspect] = createSignal<Aspect>('portrait');
   const [decoded, setDecoded] = createSignal<DecodedImage | null>(null);
   const [pickedName, setPickedName] = createSignal<string>('');
@@ -153,6 +157,14 @@ export default function Studio() {
       setWasmStatus('error');
     });
     onCleanup(offCrash);
+    // perf 診断ログ: worker から流れる per-stage 計測を画面に表示
+    const offDebug = onWorkerDebug((text) => {
+      setDebugLog((prev) => {
+        const next = [...prev, text];
+        return next.length > 20 ? next.slice(-20) : next;
+      });
+    });
+    onCleanup(offDebug);
   });
 
   onCleanup(() => {
@@ -728,7 +740,12 @@ export default function Studio() {
         onPointerCancel={onDropZonePointerEnd}
         onClick={onDropZoneClick}
         class={
-          'group relative block cursor-pointer touch-none rounded-xl py-10 px-8 text-center transition-colors duration-200 ease-out focus-within:text-focusRing ' +
+          // touch-pan-y: 縦スクロールはブラウザに任せる（指を縦に動かすと
+          // pointercancel が来て endLongPress が走る → スクロール開始）。
+          // 静止押下のみ 400ms タイマーで長押しオーバーレイ起動。
+          // 旧 touch-none は Android で「ドロップエリアからのフリックで
+          // ページがスクロールできない」副作用があったため pan-y に変更。
+          'group relative block cursor-pointer touch-pan-y rounded-xl py-10 px-8 text-center transition-colors duration-200 ease-out focus-within:text-focusRing ' +
           (dragOver()
             ? 'text-fg bg-glassBg'
             : 'text-fgSubtle hover:text-fgMuted')
@@ -960,7 +977,7 @@ export default function Studio() {
                 onContextMenu={(e) => e.preventDefault()}
                 disabled={!tile.blob}
                 aria-busy={!tile.blob}
-                class="group relative block w-full overflow-hidden rounded touch-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing disabled:cursor-default"
+                class="group relative block w-full overflow-hidden rounded touch-pan-y focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing disabled:cursor-default"
                 style={{
                   'aspect-ratio': aspect() === 'portrait' ? '9 / 16' : '16 / 9',
                 }}
@@ -1235,6 +1252,16 @@ export default function Studio() {
             </Show>
           </div>
         )}
+      </Show>
+      {/* perf 診断ログ。実機 (Android) では console を拾えないため画面に表示。
+          落ち着いたら消す。 */}
+      <Show when={debugLog().length > 0}>
+        <pre
+          class="fixed bottom-0 left-0 right-0 z-50 max-h-[40vh] overflow-auto bg-black/80 p-2 text-[10px] leading-tight text-fgMuted whitespace-pre-wrap break-all"
+          aria-hidden="true"
+        >
+          {debugLog().join('\n')}
+        </pre>
       </Show>
     </section>
   );

--- a/web/src/lib/orberClient.ts
+++ b/web/src/lib/orberClient.ts
@@ -67,6 +67,18 @@ export function onWorkerCrash(cb: CrashCallback): () => void {
   };
 }
 
+// Worker から流れる per-stage 計測ログ。Android で console を拾えないため
+// Studio.tsx で画面 <pre> に出して kako-jun が実機で見られるようにする。
+type DebugCallback = (text: string) => void;
+const debugCallbacks: DebugCallback[] = [];
+export function onWorkerDebug(cb: DebugCallback): () => void {
+  debugCallbacks.push(cb);
+  return () => {
+    const idx = debugCallbacks.indexOf(cb);
+    if (idx >= 0) debugCallbacks.splice(idx, 1);
+  };
+}
+
 // #108 (review s1): pending を全件 reject + clear する内部ヘルパ。
 // crash パスと terminateAndRespawn の両方で使い、reject 文言と
 // 副作用順序の食い違いを防ぐ。
@@ -85,7 +97,8 @@ function ensureWorker(): Worker {
     // 将来 kind が増えるなら明示分岐を追加すること。
     type Resp =
       | { id: number; ok: boolean; data?: unknown; error?: string }
-      | { kind: 'animateProgress'; id: number; frame: number; total: number };
+      | { kind: 'animateProgress'; id: number; frame: number; total: number }
+      | { kind: 'debug'; text: string };
     const msg = e.data as Resp;
     if ('kind' in msg && msg.kind === 'animateProgress') {
       const pp = pending.get(msg.id);
@@ -94,6 +107,16 @@ function ensureWorker(): Worker {
           pp.onProgress(msg.frame, msg.total);
         } catch (err) {
           console.error('orber onProgress callback failed', err);
+        }
+      }
+      return;
+    }
+    if ('kind' in msg && msg.kind === 'debug') {
+      for (const cb of debugCallbacks) {
+        try {
+          cb(msg.text);
+        } catch (err) {
+          console.error('orber debug callback failed', err);
         }
       }
       return;

--- a/web/src/lib/orberWorker.ts
+++ b/web/src/lib/orberWorker.ts
@@ -101,6 +101,12 @@ function post(msg: unknown, transfers: Transferable[] = []) {
   (self as unknown as Worker).postMessage(msg, transfers);
 }
 
+// 画面ログ用。Android では console を拾えないので debug 行を main thread に
+// 流して Studio.tsx の <pre> に表示させる。
+function debug(text: string) {
+  post({ kind: 'debug', text });
+}
+
 self.addEventListener('message', async (e: MessageEvent<Req>) => {
   const req = e.data;
   try {
@@ -116,30 +122,46 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
         break;
       }
       case 'generateOne': {
+        const t0 = performance.now();
         const params = mergeParams(req.params);
         const data = wasm.get_render_data(params, req.n, req.index);
+        const t1 = performance.now();
         const { canvas, renderer } = getRenderer(req.params.width, req.params.height);
+        const t2 = performance.now();
         renderer.setRenderData(data);
         renderer.renderFrame(0);
-        // PNG にエンコードして main に返す。convertToBlob は OffscreenCanvas
-        // 標準で、PNG 圧縮は worker 側で完結する。
+        const t3 = performance.now();
         const blob = await canvas.convertToBlob({ type: 'image/png' });
+        const t4 = performance.now();
         const buf = await blob.arrayBuffer();
+        const t5 = performance.now();
+        debug(
+          `still #${req.index} ${req.params.width}x${req.params.height}: ` +
+            `getData=${(t1 - t0).toFixed(1)} ctx=${(t2 - t1).toFixed(1)} ` +
+            `render=${(t3 - t2).toFixed(1)} png=${(t4 - t3).toFixed(1)} ` +
+            `buf=${(t5 - t4).toFixed(1)} total=${(t5 - t0).toFixed(1)}ms`,
+        );
         post({ id: req.id, ok: true, data: buf }, [buf]);
         break;
       }
       case 'animateOne': {
+        const t0 = performance.now();
         const params = mergeParams(req.params);
         const data = wasm.get_render_data(params, req.n, req.index);
         const width = req.params.width;
         const height = req.params.height;
         const { canvas, renderer } = getRenderer(width, height);
         renderer.setRenderData(data);
-        // フレーム単位の進捗を main に流す。レビュー S2 の間引きは維持。
+        const t1 = performance.now();
         const PROGRESS_STRIDE = 4;
+        let renderTotal = 0;
         const blob = await encodeAnimationFromCanvas(
           canvas,
-          (t) => renderer.renderFrame(t),
+          (t) => {
+            const r0 = performance.now();
+            renderer.renderFrame(t);
+            renderTotal += performance.now() - r0;
+          },
           req.totalFrames,
           width,
           height,
@@ -148,7 +170,15 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
             post({ kind: 'animateProgress', id: req.id, frame, total });
           },
         );
+        const t2 = performance.now();
         const buf = await blob.arrayBuffer();
+        const t3 = performance.now();
+        debug(
+          `mp4 #${req.index} ${width}x${height}: ` +
+            `setup=${(t1 - t0).toFixed(1)} encode_loop+flush=${(t2 - t1).toFixed(1)} ` +
+            `(of which render=${renderTotal.toFixed(1)}) ` +
+            `buf=${(t3 - t2).toFixed(1)} total=${(t3 - t0).toFixed(1)}ms`,
+        );
         post({ id: req.id, ok: true, data: buf }, [buf]);
         break;
       }


### PR DESCRIPTION
## やったこと

### 問題 1: フリックでスクロール不可
ドロップエリア / タイルから始めた縦フリックでページが動かない問題を修正。

- `touch-none` → `touch-pan-y` でブラウザに縦スクロールを返す
- 指が動けば pointercancel → endLongPress → スクロール開始
- 静止押下なら 400ms タイマーで長押しオーバーレイは引き続き起動
- 旧 `touch-none` は #87 Android pointercancel 早期発火抑止のために入れていたが副作用大きすぎ

### 問題 2: Android で WebGL 化後も生成が遅い
kako-jun 実機報告「Android では逆に動作が遅くなっている」の診断材料を集める。

- Worker に per-stage 計測ログを仕込み、`{kind:'debug', text}` メッセージで main に流す
- `orberClient.ts` に `onWorkerDebug(cb)` 登録 API
- `Studio.tsx` で fixed-position `<pre class="fixed bottom-0">` に直近 20 行表示
- Android では console を拾えないので画面表示必須

#### 計測項目
- **generateOne**: `getData / ctx / render / png(convertToBlob) / buf / total`
- **animateOne**: `setup / encode_loop+flush / render累計 / buf / total`

これで律速箇所（shader compile? convertToBlob? GPU readback?）が特定できる。

## 検証

- `npx tsc --noEmit`: 既存 3 件のみ（前 baseline 6 だが本 PR 不問）、新規エラーゼロ

## Test plan

- [ ] Android: ドロップエリアからの縦フリックでスクロールできる
- [ ] Android: ドロップエリア中央で 400ms 押下で拡大プレビューが出る
- [ ] Android: タイルからの縦フリックでスクロールできる
- [ ] Android: タイル長押しで拡大プレビューが出る
- [ ] Android: 画面下に per-tile の時間内訳が出る → kako-jun が共有 → 律速特定

## 後始末

律速判明 + 修正後、debug `<pre>` 表示と onWorkerDebug 配線は別 PR で除去予定。