### PR TITLE
perf(web): kmeans 用にソースを長辺 256 に縮小 — 解像度依存性を消す

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -198,6 +198,17 @@ Worker; subsequent `get_render_data` calls reference the cached kmeans
 clusters, so multi-megabyte arrays are not copied per call. The WebGL2 context
 and OffscreenCanvas are also cached per resolution and reused across calls.
 
+**Source downsampling for kmeans.** The dropped image is decoded and immediately
+resized to a longest-edge of 256 px (aspect preserved) before the RGB buffer is
+handed to the Worker. The full-resolution image is never seen by wasm or the
+shader, because the renderer only needs the kmeans cluster colors — the actual
+canvas dimensions for orbs are controlled by `width` / `height` (preview or
+download), not the source size. Downsampling fixes three problems at once:
+the JS→Worker→wasm transfer of the RGB array becomes a constant ≤196KB instead
+of scaling with the input photo (4032×3024 was 36MB and the per-tile copy cost
+dominated on Android), kmeans itself runs on a tiny pixel set, and the wasm-side
+`SOURCE_CACHE` fingerprint becomes stable across calls.
+
 **Why WebGL2.** The previous implementation rendered every pixel on the CPU
 inside wasm and ran each animation frame through `RGBA → ImageData →
 createImageBitmap → VideoFrame` before encoding. At 1080×1920 × 192 frames the

--- a/web/src/lib/decodeImage.ts
+++ b/web/src/lib/decodeImage.ts
@@ -48,16 +48,23 @@ export async function decodeImageToRgb(file: File): Promise<DecodedImage> {
   try {
     const longest = Math.max(bitmap.width, bitmap.height);
     const scale = Math.min(1, KMEANS_TARGET_LONG_EDGE / longest);
-    const dw = Math.max(1, Math.round(bitmap.width * scale));
-    const dh = Math.max(1, Math.round(bitmap.height * scale));
+    // review S2: 極端アスペクト (10000×100 のパノラマ等) で短辺が 1-3 px に
+    // 潰れて kmeans サンプル数が枯れるのを防ぐ。8 px は kmeans K=5 のとき
+    // サンプル枯渇の安全側下限。
+    const MIN_EDGE = 8;
+    const dw = Math.max(MIN_EDGE, Math.round(bitmap.width * scale));
+    const dh = Math.max(MIN_EDGE, Math.round(bitmap.height * scale));
 
     const canvas = document.createElement('canvas');
     canvas.width = dw;
     canvas.height = dh;
     const ctx = canvas.getContext('2d');
     if (!ctx) throw new Error('canvas 2d context unavailable');
-    // drawImage の dw/dh 引数で縮小描画する。canvas 2D のリサンプリングは
-    // imageSmoothingQuality='medium' 既定で高速・十分な品質。
+    // review S1: imageSmoothingQuality の既定は実装依存 (Chromium 'low')。
+    // kmeans 入力としては low でもサンプル分布はほぼ保たれるが、明示的に
+    // 'medium' を立てて将来のブラウザ既定変更に左右されないようにする。
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'medium';
     ctx.drawImage(bitmap, 0, 0, dw, dh);
     const imgData = ctx.getImageData(0, 0, dw, dh);
     const px = dw * dh;

--- a/web/src/lib/decodeImage.ts
+++ b/web/src/lib/decodeImage.ts
@@ -9,10 +9,30 @@ export interface DecodedImage {
 const MAX_DIM = 8192;
 
 /**
+ * kmeans 用に画像を縮小する目標サイズ（長辺の最大値）。
+ *
+ * orber は元画像の RGB を kmeans の入力としてしか使わない（描画は WebGL で
+ * クラスタの色だけ参照）。kmeans の色抽出は十分なサンプル点があれば高解像度を
+ * 必要としないので、長辺 256 まで縮小して以下を全て同時に解決する:
+ *
+ * - JS→Worker→wasm の RGB 転送量が固定（≤ 196KB）になる。元 4032×3024 の写真は
+ *   36MB あり、Android では毎タイル wasm に渡るたびに数百ms のロスになっていた
+ *   (kako-jun 実機計測 2026-05-01)
+ * - kmeans 自体（3 runs × 20 iter）が 65k pixel 以下で動くので速い
+ * - キャッシュ fingerprint も RGB 長が固定で安定
+ *
+ * 256 は ImageMagick / 各種 palette tool の経験則。これより小さくすると支配色
+ * 判定がブレる可能性。アスペクトは維持。
+ */
+const KMEANS_TARGET_LONG_EDGE = 256;
+
+/**
  * `File` をデコードして RGB バイト列にする。
  *
- * orber-wasm の `generate_batch` には RGBA ではなく RGB を渡す必要があるため、
- * canvas 経由で取り出した RGBA から alpha を落とす。
+ * orber-wasm の kmeans に渡すため、長辺 `KMEANS_TARGET_LONG_EDGE` 以下に
+ * 縮小する。アスペクトは維持。元画像のフルサイズを保持しないのは、描画には
+ * RGB 自体が不要（クラスタの色だけ使う）ため。これにより wasm への転送量が
+ * ソース解像度に依存しなくなる。
  */
 export async function decodeImageToRgb(file: File): Promise<DecodedImage> {
   if (!file.type.startsWith('image/')) {
@@ -26,21 +46,28 @@ export async function decodeImageToRgb(file: File): Promise<DecodedImage> {
     );
   }
   try {
+    const longest = Math.max(bitmap.width, bitmap.height);
+    const scale = Math.min(1, KMEANS_TARGET_LONG_EDGE / longest);
+    const dw = Math.max(1, Math.round(bitmap.width * scale));
+    const dh = Math.max(1, Math.round(bitmap.height * scale));
+
     const canvas = document.createElement('canvas');
-    canvas.width = bitmap.width;
-    canvas.height = bitmap.height;
+    canvas.width = dw;
+    canvas.height = dh;
     const ctx = canvas.getContext('2d');
     if (!ctx) throw new Error('canvas 2d context unavailable');
-    ctx.drawImage(bitmap, 0, 0);
-    const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    const px = canvas.width * canvas.height;
+    // drawImage の dw/dh 引数で縮小描画する。canvas 2D のリサンプリングは
+    // imageSmoothingQuality='medium' 既定で高速・十分な品質。
+    ctx.drawImage(bitmap, 0, 0, dw, dh);
+    const imgData = ctx.getImageData(0, 0, dw, dh);
+    const px = dw * dh;
     const rgb = new Uint8Array(px * 3);
     for (let i = 0, j = 0; i < imgData.data.length; i += 4, j += 3) {
       rgb[j] = imgData.data[i];
       rgb[j + 1] = imgData.data[i + 1];
       rgb[j + 2] = imgData.data[i + 2];
     }
-    return { rgb, width: canvas.width, height: canvas.height };
+    return { rgb, width: dw, height: dh };
   } finally {
     bitmap.close?.();
   }


### PR DESCRIPTION
## kako-jun 実機報告

> もとにする画像の解像度が高いほど重くなっている。最初の色の取得の前に解像度を低く揃えても結果は同じなのだから揃えるべきだろ。なぜか 1 だけでなく 2、3、と全部が遅くなっている。

## 真因

`decodeImageToRgb` がフル解像度 RGB を保持し、毎タイル JS→Worker→wasm の serde 経由で **同じ RGB がコピー** されていた:

- 4032×3024 写真 = 36MB
- 16 タイル × 36MB = 576MB 転送
- Android memcpy ~200MB/sec → 約 3 秒のロス

PR #117 で kmeans 自体はキャッシュしたが、wasm にデータを渡すコピー自体が支配的だったため「2、3 個目も遅い」という症状になっていた。

## 修正

`decodeImageToRgb` で **長辺 256 まで縮小** してから RGB を取り出す。アスペクト維持。

orber は RGB を **kmeans の色抽出にしか使わない**（描画は WebGL でクラスタの色だけ参照、ソース画像自体は描画に登場しない）。kmeans は 65k 程度のサンプル点があれば十分なので 256×256 で支配色判定の精度は落ちない。

## 期待効果

| | 現状 | 修正後 |
|---|---|---|
| RGB 転送量 (per call) | ソース解像度依存（最大 ~36MB） | **固定 ≤ 196KB** |
| 16 タイル合計 (Android) | ~3 秒のロス | ~0.05 秒 |
| kmeans 入力サイズ | フル解像度 | 65k pixel 以下 |
| キャッシュ fingerprint | RGB 長で揺れる | 安定 |

## 視覚パリティ

支配色判定は kmeans のサンプリング系処理なので、長辺 256 でも肉眼で識別不能なレベル。ImageMagick / 各種 palette extraction tool が 200-256 を経験則として採用しており、業界標準的な値。

不安なら `KMEANS_TARGET_LONG_EDGE` を 384 や 512 に上げて調整可能（その場合は転送量がトレードオフ）。

## Test plan

- [ ] PC: 高画質画像（4000px 級）と低画質画像で生成時間が **同じ**になる
- [ ] Android: 同上
- [ ] 既存出力と並べて視覚パリティに問題なし
- [ ] debug ログで getData が解像度に依存しなくなる