### PR TITLE
chore(web): perf 診断ログ機構を削除（役目完了）

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -4,7 +4,6 @@ import { ANIM_TOTAL_FRAMES, isWebCodecsSupported } from '../lib/encodeMp4';
 import {
   hasInFlight,
   onWorkerCrash,
-  onWorkerDebug,
   terminateAndRespawn,
   workerAnimateOne,
   workerGenerateOne,
@@ -61,9 +60,6 @@ const DL_H_LANDSCAPE = 1080;
 export default function Studio() {
   const [wasmStatus, setWasmStatus] = createSignal<'loading' | 'ready' | 'error'>('loading');
   const [wasmErr, setWasmErr] = createSignal<string>('');
-  // 実機（Android）で console を拾えないため、worker からの per-stage 計測ログを
-  // 画面 <pre> に出して kako-jun が確認できるようにする。直近 20 件保持。
-  const [debugLog, setDebugLog] = createSignal<string[]>([]);
   const [aspect, setAspect] = createSignal<Aspect>('portrait');
   const [decoded, setDecoded] = createSignal<DecodedImage | null>(null);
   const [pickedName, setPickedName] = createSignal<string>('');
@@ -157,14 +153,6 @@ export default function Studio() {
       setWasmStatus('error');
     });
     onCleanup(offCrash);
-    // perf 診断ログ: worker から流れる per-stage 計測を画面に表示
-    const offDebug = onWorkerDebug((text) => {
-      setDebugLog((prev) => {
-        const next = [...prev, text];
-        return next.length > 20 ? next.slice(-20) : next;
-      });
-    });
-    onCleanup(offDebug);
   });
 
   onCleanup(() => {
@@ -1252,16 +1240,6 @@ export default function Studio() {
             </Show>
           </div>
         )}
-      </Show>
-      {/* perf 診断ログ。実機 (Android) では console を拾えないため画面に表示。
-          落ち着いたら消す。 */}
-      <Show when={debugLog().length > 0}>
-        <pre
-          class="fixed bottom-0 left-0 right-0 z-50 max-h-[40vh] overflow-auto bg-black/80 p-2 text-[10px] leading-tight text-fgMuted whitespace-pre-wrap break-all"
-          aria-hidden="true"
-        >
-          {debugLog().join('\n')}
-        </pre>
       </Show>
     </section>
   );

--- a/web/src/lib/orberClient.ts
+++ b/web/src/lib/orberClient.ts
@@ -67,18 +67,6 @@ export function onWorkerCrash(cb: CrashCallback): () => void {
   };
 }
 
-// Worker から流れる per-stage 計測ログ。Android で console を拾えないため
-// Studio.tsx で画面 <pre> に出して kako-jun が実機で見られるようにする。
-type DebugCallback = (text: string) => void;
-const debugCallbacks: DebugCallback[] = [];
-export function onWorkerDebug(cb: DebugCallback): () => void {
-  debugCallbacks.push(cb);
-  return () => {
-    const idx = debugCallbacks.indexOf(cb);
-    if (idx >= 0) debugCallbacks.splice(idx, 1);
-  };
-}
-
 // #108 (review s1): pending を全件 reject + clear する内部ヘルパ。
 // crash パスと terminateAndRespawn の両方で使い、reject 文言と
 // 副作用順序の食い違いを防ぐ。
@@ -97,8 +85,7 @@ function ensureWorker(): Worker {
     // 将来 kind が増えるなら明示分岐を追加すること。
     type Resp =
       | { id: number; ok: boolean; data?: unknown; error?: string }
-      | { kind: 'animateProgress'; id: number; frame: number; total: number }
-      | { kind: 'debug'; text: string };
+      | { kind: 'animateProgress'; id: number; frame: number; total: number };
     const msg = e.data as Resp;
     if ('kind' in msg && msg.kind === 'animateProgress') {
       const pp = pending.get(msg.id);
@@ -107,16 +94,6 @@ function ensureWorker(): Worker {
           pp.onProgress(msg.frame, msg.total);
         } catch (err) {
           console.error('orber onProgress callback failed', err);
-        }
-      }
-      return;
-    }
-    if ('kind' in msg && msg.kind === 'debug') {
-      for (const cb of debugCallbacks) {
-        try {
-          cb(msg.text);
-        } catch (err) {
-          console.error('orber debug callback failed', err);
         }
       }
       return;

--- a/web/src/lib/orberWorker.ts
+++ b/web/src/lib/orberWorker.ts
@@ -101,12 +101,6 @@ function post(msg: unknown, transfers: Transferable[] = []) {
   (self as unknown as Worker).postMessage(msg, transfers);
 }
 
-// 画面ログ用。Android では console を拾えないので debug 行を main thread に
-// 流して Studio.tsx の <pre> に表示させる。
-function debug(text: string) {
-  post({ kind: 'debug', text });
-}
-
 self.addEventListener('message', async (e: MessageEvent<Req>) => {
   const req = e.data;
   try {
@@ -122,46 +116,27 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
         break;
       }
       case 'generateOne': {
-        const t0 = performance.now();
         const params = mergeParams(req.params);
         const data = wasm.get_render_data(params, req.n, req.index);
-        const t1 = performance.now();
         const { canvas, renderer } = getRenderer(req.params.width, req.params.height);
-        const t2 = performance.now();
         renderer.setRenderData(data);
         renderer.renderFrame(0);
-        const t3 = performance.now();
         const blob = await canvas.convertToBlob({ type: 'image/png' });
-        const t4 = performance.now();
         const buf = await blob.arrayBuffer();
-        const t5 = performance.now();
-        debug(
-          `still #${req.index} ${req.params.width}x${req.params.height}: ` +
-            `getData=${(t1 - t0).toFixed(1)} ctx=${(t2 - t1).toFixed(1)} ` +
-            `render=${(t3 - t2).toFixed(1)} png=${(t4 - t3).toFixed(1)} ` +
-            `buf=${(t5 - t4).toFixed(1)} total=${(t5 - t0).toFixed(1)}ms`,
-        );
         post({ id: req.id, ok: true, data: buf }, [buf]);
         break;
       }
       case 'animateOne': {
-        const t0 = performance.now();
         const params = mergeParams(req.params);
         const data = wasm.get_render_data(params, req.n, req.index);
         const width = req.params.width;
         const height = req.params.height;
         const { canvas, renderer } = getRenderer(width, height);
         renderer.setRenderData(data);
-        const t1 = performance.now();
         const PROGRESS_STRIDE = 4;
-        let renderTotal = 0;
         const blob = await encodeAnimationFromCanvas(
           canvas,
-          (t) => {
-            const r0 = performance.now();
-            renderer.renderFrame(t);
-            renderTotal += performance.now() - r0;
-          },
+          (t) => renderer.renderFrame(t),
           req.totalFrames,
           width,
           height,
@@ -170,15 +145,7 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
             post({ kind: 'animateProgress', id: req.id, frame, total });
           },
         );
-        const t2 = performance.now();
         const buf = await blob.arrayBuffer();
-        const t3 = performance.now();
-        debug(
-          `mp4 #${req.index} ${width}x${height}: ` +
-            `setup=${(t1 - t0).toFixed(1)} encode_loop+flush=${(t2 - t1).toFixed(1)} ` +
-            `(of which render=${renderTotal.toFixed(1)}) ` +
-            `buf=${(t3 - t2).toFixed(1)} total=${(t3 - t0).toFixed(1)}ms`,
-        );
         post({ id: req.id, ok: true, data: buf }, [buf]);
         break;
       }


### PR DESCRIPTION
PR #116 で実機計測のために入れた診断ログ機構を全削除。

## 削除対象
- `Studio.tsx`: `debugLog` signal、`onWorkerDebug` 登録、画面下 `<pre>` 描画
- `orberClient.ts`: `onWorkerDebug` export、`debugCallbacks`、`debug` message handling
- `orberWorker.ts`: `debug()` helper、`generateOne` / `animateOne` の per-stage 計測

## 役目
kako-jun Android 計測で律速箇所（kmeans 重複実行）を特定 → PR #117/#118/#119 で **3500ms → <50ms (70×+) を達成**、Android <50ms / PC 20ms まで到達。診断機構自体が不要になった。

本番ユーザーに画面下 `<pre>` が見えていた状態も解消。

## 検証
- `npx tsc --noEmit`: ベースライン 6 件（PR #116 前と同数）、新規エラーゼロ