### PR TITLE
fix(web): #121 進捗行のレイアウトジャンプ防止 + #122 DL ファイル名にタイムスタンプ

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -156,10 +156,10 @@ fn fingerprint(rgb: &[u8], w: u32, h: u32, k: usize) -> u64 {
 /// キャッシュヒットして O(1)、違う画像なら kmeans 実行 + キャッシュ更新。
 ///
 /// SAFETY: wasm は single-threaded なので静的可変参照は問題ない。
+type ClustersBundle = (Vec<Cluster>, [u8; 4], Vec<Cluster>);
+
 #[allow(static_mut_refs)]
-fn get_or_build_clusters(
-    p: &mut WasmParams,
-) -> Result<(Vec<Cluster>, [u8; 4], Vec<Cluster>), String> {
+fn get_or_build_clusters(p: &mut WasmParams) -> Result<ClustersBundle, String> {
     let fp = fingerprint(&p.source_rgb, p.source_width, p.source_height, p.k);
     unsafe {
         if let Some(c) = &SOURCE_CACHE {
@@ -475,6 +475,7 @@ pub fn get_render_data(
 /// core 側 `generate_orb_params` を呼び出さずに同じシーケンスを **再現** する
 /// （core の `OrbParams` は private struct で wasm から読めないため）。順序を
 /// 1 つでも変えると同じ seed でも別の orb 列になり、視覚パリティが壊れる。
+#[allow(clippy::too_many_arguments)]
 fn pack_render_data(
     clusters: &[Cluster],
     bg: [u8; 4],

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -596,7 +596,8 @@ export default function Studio() {
   };
 
   // #122: ローカル時刻ベースの YYYYMMDD-HHMMSS。連続 DL で上書き確認が
-  // 出ないよう毎回ユニークなファイル名にする。machigai-salad と揃える。
+  // 出ないよう毎回ユニークなファイル名にする。zip 内のエントリ名にも
+  // 同じ ts を埋めて、複数 zip を同じフォルダに展開しても衝突しないようにする。
   const downloadTimestamp = (d = new Date()) => {
     const p = (n: number) => String(n).padStart(2, '0');
     return (
@@ -683,7 +684,7 @@ export default function Studio() {
       const { default: JSZip } = await import('jszip');
       const zip = new JSZip();
       sorted.forEach(([, { blob, ext }], n) => {
-        zip.file(`orber_${String(n + 1).padStart(2, '0')}.${ext}`, blob);
+        zip.file(`orber-${ts}_${String(n + 1).padStart(2, '0')}.${ext}`, blob);
       });
       const zipBlob = await zip.generateAsync({ type: 'blob' });
       triggerDownload(zipBlob, `orber-${ts}.zip`);

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -595,6 +595,16 @@ export default function Studio() {
     URL.revokeObjectURL(url);
   };
 
+  // #122: ローカル時刻ベースの YYYYMMDD-HHMMSS。連続 DL で上書き確認が
+  // 出ないよう毎回ユニークなファイル名にする。machigai-salad と揃える。
+  const downloadTimestamp = (d = new Date()) => {
+    const p = (n: number) => String(n).padStart(2, '0');
+    return (
+      `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}` +
+      `-${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`
+    );
+  };
+
   // #73: DL 時の hi-res 再描画。プレビュー（#99 で 360×640）とは別に、同じ
   // baseSeed + (total, index) で `generate_one_at_index` / `start_animation_for_batch_spec`
   // を呼び、1080×1920 の PNG / mp4 を作る。プレビューと同じバリエーションが
@@ -665,8 +675,9 @@ export default function Studio() {
       const rendered = await renderHiResForIndices(indices);
       // index 順を保ってファイル名を 01, 02, ... に振る。
       const sorted = Array.from(rendered.entries()).sort((a, b) => a[0] - b[0]);
+      const ts = downloadTimestamp();
       if (sorted.length === 1) {
-        triggerDownload(sorted[0][1].blob, `orber.${sorted[0][1].ext}`);
+        triggerDownload(sorted[0][1].blob, `orber-${ts}.${sorted[0][1].ext}`);
         return;
       }
       const { default: JSZip } = await import('jszip');
@@ -675,7 +686,7 @@ export default function Studio() {
         zip.file(`orber_${String(n + 1).padStart(2, '0')}.${ext}`, blob);
       });
       const zipBlob = await zip.generateAsync({ type: 'blob' });
-      triggerDownload(zipBlob, 'orber.zip');
+      triggerDownload(zipBlob, `orber-${ts}.zip`);
     } catch (e) {
       console.error('hi-res download failed', e);
       setErrorMsg(`${t('downloadFailed')}: ${String(e)}`);

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -922,14 +922,27 @@ export default function Studio() {
         </div>
       </Show>
 
-      <Show when={phase() === 'decoding'}>
-        <p class="fade-in text-sm text-fgMuted">{t('decoding')}</p>
-      </Show>
-      <Show when={phase() === 'generating'}>
-        <p class="fade-in text-sm text-fgMuted">{t('generating')} {progress()} / {batchN()}</p>
-      </Show>
-      <Show when={phase() === 'animating'}>
-        <p class="fade-in text-sm text-fgMuted">{t('animating')}</p>
+      {/* #121: 進捗行は常に同じ高さを確保し、phase 完了後も消さない（消すと
+          下のサムネイルグリッドがガクッと上に詰まる）。done/idle/error では
+          中身を空にして高さだけ残し、テキストはセンタリングする。 */}
+      <Show
+        when={
+          phase() === 'decoding' ||
+          phase() === 'generating' ||
+          phase() === 'animating' ||
+          tiles().length > 0
+        }
+      >
+        <p
+          class="fade-in text-center text-sm text-fgMuted h-5 leading-5"
+          aria-live="polite"
+        >
+          <Show when={phase() === 'decoding'}>{t('decoding')}</Show>
+          <Show when={phase() === 'generating'}>
+            {t('generating')} {progress()} / {batchN()}
+          </Show>
+          <Show when={phase() === 'animating'}>{t('animating')}</Show>
+        </p>
       </Show>
 
       <Show when={errorMsg() && phase() === 'error'}>

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -301,7 +301,7 @@ export default function Studio() {
         if (myGen !== runGen) return;
         const png = await workerGenerateOne(params, total, i);
         if (myGen !== runGen) return;
-        const blob = new Blob([png], { type: 'image/png' });
+        const blob = new Blob([new Uint8Array(png)], { type: 'image/png' });
         const blobUrl = URL.createObjectURL(blob);
         const kind: Tile['kind'] = i < stillCount ? 'still' : 'video';
         setTiles((prev) =>
@@ -642,7 +642,7 @@ export default function Studio() {
         // 静止タイル、または WebCodecs 非対応環境では hi-res の t=0 PNG。
         const png = await workerGenerateOne(hiParams, total, i);
         out.set(i, {
-          blob: new Blob([png], { type: 'image/png' }),
+          blob: new Blob([new Uint8Array(png)], { type: 'image/png' }),
           ext: 'png',
         });
       } else {
@@ -1075,8 +1075,8 @@ export default function Studio() {
                               fill="none"
                               stroke="currentColor"
                               stroke-width="1.5"
-                              stroke-dasharray={c}
-                              stroke-dashoffset={c * (1 - pct())}
+                              stroke-dasharray={String(c)}
+                              stroke-dashoffset={String(c * (1 - pct()))}
                               stroke-linecap="round"
                               transform="rotate(-90 12 12)"
                             />

--- a/web/src/lib/orberClient.ts
+++ b/web/src/lib/orberClient.ts
@@ -83,9 +83,9 @@ function ensureWorker(): Worker {
     //   - 本体応答: `kind` プロパティなし。`{ id, ok, data?, error? }`
     //   - 進捗通知: `{ kind: 'animateProgress', id, frame, total }`
     // 将来 kind が増えるなら明示分岐を追加すること。
-    type Resp =
-      | { id: number; ok: boolean; data?: unknown; error?: string }
-      | { kind: 'animateProgress'; id: number; frame: number; total: number };
+    type RespResult = { id: number; ok: boolean; data?: unknown; error?: string };
+    type RespProgress = { kind: 'animateProgress'; id: number; frame: number; total: number };
+    type Resp = RespResult | RespProgress;
     const msg = e.data as Resp;
     if ('kind' in msg && msg.kind === 'animateProgress') {
       const pp = pending.get(msg.id);
@@ -98,7 +98,7 @@ function ensureWorker(): Worker {
       }
       return;
     }
-    const { id, ok, data, error } = msg;
+    const { id, ok, data, error } = msg as RespResult;
     const p = pending.get(id);
     if (!p) return;
     pending.delete(id);


### PR DESCRIPTION
## 関連 Issue

- closes #121
- closes #122

## 変更内容

### #122 — ダウンロードファイル名にタイムスタンプを付与
- `orber.{png,mp4,zip}` → `orber-YYYYMMDD-HHMMSS.{png,mp4,zip}`
- 連続 DL で上書き確認ダイアログが出なくなる
- `machigai-salad` と挙動を揃えた

### #121 — 進捗行のレイアウトジャンプを防止
- decoding / generating / animating で個別に出していた `<p>` を、常に高さを確保する 1 つのコンテナに統合
- phase 完了後もテキストを空にして高さだけ残す（下のサムネイルグリッドが上に詰まらない）
- テキストはセンタリング、`aria-live="polite"` を付与（コメントで指示があった点）

### chore — 既存の TS 型エラーを修正
- `Blob([Uint8Array])` の型不一致を `new Uint8Array(...)` で吸収
- SVG `stroke-dasharray` / `stroke-dashoffset` を string キャスト
- worker 応答型を判別ユニオンとして narrow できるよう分割

## 動作確認
- `npx tsc --noEmit` — 通る
- `npm run build` — 成功