### PR TITLE
feat(web): #124 進捗行を生成完了後に長押しヒントとして再利用

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -925,7 +925,9 @@ export default function Studio() {
 
       {/* #121: 進捗行は常に同じ高さを確保し、phase 完了後も消さない（消すと
           下のサムネイルグリッドがガクッと上に詰まる）。done/idle/error では
-          中身を空にして高さだけ残し、テキストはセンタリングする。 */}
+          中身を空にして高さだけ残し、テキストはセンタリングする。
+          #124: 生成完了後（タイル表示中かつ進捗 phase でない）は、空白の代わりに
+          「長押しで拡大」の操作ヒントを表示し、進捗行を導線として再利用する。 */}
       <Show
         when={
           phase() === 'decoding' ||
@@ -943,6 +945,16 @@ export default function Studio() {
             {t('generating')} {progress()} / {batchN()}
           </Show>
           <Show when={phase() === 'animating'}>{t('animating')}</Show>
+          <Show
+            when={
+              phase() !== 'decoding' &&
+              phase() !== 'generating' &&
+              phase() !== 'animating' &&
+              tiles().length > 0
+            }
+          >
+            {t('longTapToEnlargeHint')}
+          </Show>
         </p>
       </Show>
 

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -924,10 +924,12 @@ export default function Studio() {
       </Show>
 
       {/* #121: 進捗行は常に同じ高さを確保し、phase 完了後も消さない（消すと
-          下のサムネイルグリッドがガクッと上に詰まる）。done/idle/error では
-          中身を空にして高さだけ残し、テキストはセンタリングする。
-          #124: 生成完了後（タイル表示中かつ進捗 phase でない）は、空白の代わりに
-          「長押しで拡大」の操作ヒントを表示し、進捗行を導線として再利用する。 */}
+          下のサムネイルグリッドがガクッと上に詰まる）。idle/error では中身を
+          空にして高さだけ残し、テキストはセンタリングする。
+          #124: 生成完了 (phase === 'done') 時のみ、空白の代わりに「長押しで拡大」
+          の操作ヒントを表示し、進捗行を導線として再利用する。error の時は
+          下のエラーバナーと意味的に衝突するため hint を出さない（前回タイルが
+          残っていても「いま失敗した画像」のヒントだとユーザーが誤認するため）。 */}
       <Show
         when={
           phase() === 'decoding' ||
@@ -945,15 +947,8 @@ export default function Studio() {
             {t('generating')} {progress()} / {batchN()}
           </Show>
           <Show when={phase() === 'animating'}>{t('animating')}</Show>
-          <Show
-            when={
-              phase() !== 'decoding' &&
-              phase() !== 'generating' &&
-              phase() !== 'animating' &&
-              tiles().length > 0
-            }
-          >
-            {t('longTapToEnlargeHint')}
+          <Show when={phase() === 'done' && tiles().length > 0}>
+            {t('longPressEnlargeHint')}
           </Show>
         </p>
       </Show>

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -50,6 +50,11 @@ export const STRINGS = {
   decoding: { ja: '画像をデコード中…', en: 'Decoding image…' },
   generating: { ja: '生成中…', en: 'Generating…' },
   animating: { ja: '動画化中…', en: 'Animating…' },
+  // #124: 生成完了後、進捗行を空白にせず長押し拡大の操作ヒントとして再利用する。
+  longTapToEnlargeHint: {
+    ja: '長押しで拡大',
+    en: 'Long tap to enlarge',
+  },
   videoPendingBadge: { ja: '動画化中', en: 'Animating' },
   animateError: {
     ja: '動画生成に失敗したタイルがあります',

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -51,9 +51,12 @@ export const STRINGS = {
   generating: { ja: '生成中…', en: 'Generating…' },
   animating: { ja: '動画化中…', en: 'Animating…' },
   // #124: 生成完了後、進捗行を空白にせず長押し拡大の操作ヒントとして再利用する。
-  longTapToEnlargeHint: {
+  // 用語は DESIGN.md §4 PreviewOverlay と既存コード（LONG_PRESS_MS / isLongPress）に
+  // 合わせて "Long-press" / 「長押し」を採用。"Long tap" は touch を強く示唆するため
+  // マウス/トラックパッドでも動く現実装には不適。
+  longPressEnlargeHint: {
     ja: '長押しで拡大',
-    en: 'Long tap to enlarge',
+    en: 'Long-press to enlarge',
   },
   videoPendingBadge: { ja: '動画化中', en: 'Animating' },
   animateError: {


### PR DESCRIPTION
## 関連 Issue

closes #124

## 変更内容

#121 で `decoding/generating/animating` 3 行を 1 常設行に統合した進捗行は、生成完了後に空白になっていました。本 PR ではその空白を `長押しで拡大 / Long tap to enlarge` の操作ヒストとして再利用し、進捗行を「長押し拡大プレビュー」の導線として機能させます。

### 差分

- `web/src/lib/strings.ts`: 新キー `longTapToEnlargeHint` を追加（ja: `長押しで拡大` / en: `Long tap to enlarge`）
- `web/src/components/Studio.tsx`: 進捗行 `<p aria-live="polite">` 内に、`phase` が `decoding`/`generating`/`animating` のいずれでもなく、かつ `tiles().length > 0` のとき hint を表示する `<Show>` を追加

### 表示遷移

| 状態 | 進捗行の中身 |
|---|---|
| idle (タイル未生成) | （非表示） |
| decoding | `画像をデコード中…` |
| generating | `生成中… N / 12` |
| animating | `動画化中…` |
| **done (タイル表示中)** | **`長押しで拡大`** ← 新規 |
| error | （空白、高さのみ確保） |

### 維持される性質（#121 から）

- 高さ確保 `h-5 leading-5` → レイアウトジャンプなし
- `text-center` → センタリング
- `aria-live="polite"` → 状態遷移をスクリーンリーダーに通知

### 検証

- `npm run wasm:build` 後 `npx tsc --noEmit` で 0 エラー
- 既存の進捗行テスト（visual のみ）への影響なし