### PR TITLE
chore: #131 Phase B 後の残ギャップ整理（doc コメント統一）

### DIFF
--- a/crates/cli/src/video.rs
+++ b/crates/cli/src/video.rs
@@ -89,7 +89,7 @@ pub struct VideoOptions {
     pub background: [u8; 4],
     /// orb の描画形式。
     pub shape: OrbShape,
-    /// コントラスト preset (#55)。Mid なら既存挙動と完全同値。
+    /// ぼかし (Softness) preset (#55, #131 で改名)。Mid なら既存挙動と完全同値。
     pub softness: SoftnessPreset,
 }
 

--- a/crates/core/src/animate.rs
+++ b/crates/core/src/animate.rs
@@ -126,7 +126,7 @@ pub struct AnimateOptions {
     pub background: [u8; 4],
     /// orb の描画形式。
     pub shape: OrbShape,
-    /// コントラスト preset（#55）。Mid で既存挙動と完全同値。
+    /// ぼかし (Softness) preset（#55, #131 で改名）。Mid で既存挙動と完全同値。
     pub softness: SoftnessPreset,
 }
 

--- a/crates/core/src/orb.rs
+++ b/crates/core/src/orb.rs
@@ -91,7 +91,7 @@ pub struct RenderOptions {
     pub background: [u8; 4],
     /// orb の描画形式。Circle なら現状互換、Aquarelle ならセル画夜景の質感セット。
     pub shape: OrbShape,
-    /// コントラスト preset（#55）。Mid で既存挙動と完全同値。
+    /// ぼかし (Softness) preset（#55, #131 で改名）。Mid で既存挙動と完全同値。
     pub softness: SoftnessPreset,
 }
 


### PR DESCRIPTION
## 関連 Issue
closes #131

## 経緯
Issue #131 の本文 + 6 件の追記コメントで挙がった全 30 項目を audit したところ、累積コミット (b597aec, 0501bae 系列) で受け入れ条件はすべて満たされていた。残っていたのは内部 doc コメントの「コントラスト preset」表記のみ。

## 変更内容
- `crates/core/src/animate.rs` / `orb.rs` / `crates/cli/src/video.rs` の `softness` フィールド doc コメント 3 箇所を「ぼかし (Softness) preset」に統一

## 受け入れ条件（30 項目すべて確認済）
- 全ボタン即生成 (aspect/shape/count/speed/softness/glyphChar) ✓
- ガチャ大ボタン撤去 → 🔄 最下部最小サイズ ✓
- アドバンスト折りたたみ撤去 → フラット展開 ✓
- count high=30, speed: ゆっくり=VerySlow/標準=Slow/速め=Mid ✓
- ContrastPreset → SoftnessPreset / `--softness` rename ✓
- 4 軸ラベル右詰め + ボタン群中央配置 ✓
- 🔄 スピンアニメ (decoding/generating/animating phase) + reduced-motion 対応 ✓
- Glyph 入力欄が形状ボタン右側同行 ✓
- IME composition ガード (compositionstart/end + maxLength=16) ✓
- シンボルピッカー 23 個 + has_glyph フィルタ + 自由入力併用 ✓

## 検証
- `cargo test --workspace`: 138 件パス
- `npm run build`: 成功