### PR TITLE
feat(web): #133 segmented controls 連結ピル化 + active 白寄り + glyph monochrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [Unreleased]
 
 ### Added
+- feat(web): #133 — segmented buttons を連結ピル化、active state を白寄り強化、glyph picker を Noto Sans Symbols 2 で monochrome 化、glyph input を datalist combobox 化
 - feat(core,wasm,web): #136 — glyph rotation toggle (per-glyph defaults: ⚡/☀ default OFF). New `AnimateOptions.glyph_rotate: bool` (default `true`) and a matching `WasmParams.glyph_rotate` field thread the switch through wasm and into the WebGL fragment shader (header word 11, `u_glyph_rotate`). When `false`, glyph orbs hold their per-orb `base_angle` for all `t`, so loop closure (`t=0 ≡ t=1`) is trivially preserved. Studio adds a reusable glass checkbox component (`GLASS_CHECKBOX_LABEL` / `GLASS_CHECKBOX_INPUT`) used for the new "Animate rotation / 回転させる" toggle; this same component will be reused by the upcoming transparent-DL checkbox (#56).
 - feat(web): #135 — disable Studio controls until an image is loaded; move reroll above progress row
 - Web GUI control rows (#131). The old collapsible Advanced section is removed; the Studio surface now shows flat always-visible rows for Shape / Count / Speed / Softness directly under the aspect toggles. Every control immediately reruns the batch. Glyph mode now includes an inline IME-safe single-character input plus a symbol picker filtered through `glyph_supported()`. The old large "Roll / ガチャを引く" chip is gone; only a small reload icon remains at the bottom, and it spins while decoding / generating / animating. (#131)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -141,6 +141,8 @@ The implementation lives in `Studio.tsx` as the constants `SEG_GROUP` (wrapper c
 
 When the segmented control's adjacent input is the Glyph picker (`Studio` shape row), the input, the picker buttons, and the `<datalist>` options are all tagged with `glyph-symbol-text`. That class loads `Noto Sans Symbols 2` from Google Fonts and sets `font-variant-emoji: text`, so `⚡` / `☀` / `★` / `←` are drawn as white symbols (matching the rest of the chrome) instead of the OS color-emoji rasters. The font load lives in `Base.astro`; the class is scoped — body text and other UI strings continue using the system sans stack.
 
+For Safari/iOS the picker buttons additionally append `U+FE0E` (text variation selector) after each displayed symbol — `font-variant-emoji: text` is Chromium-only, and Safari can still resolve dual-presentation codepoints like `U+26A1` to the OS color emoji font even when Symbols 2 is listed first. The variation selector is display-only; the underlying signal value (`glyphChar()`) stays as the bare codepoint so state and wasm RPCs are unaffected.
+
 ### Tile
 
 - Flat. **No glass, no ring, no rounded corners beyond `0.125rem` (2px) for sub-pixel cleanup**

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -123,7 +123,23 @@ The component is exposed in `Studio.tsx` as the constants `GLASS_CHECKBOX_LABEL`
 
 ### SegmentedControl
 
-Not used in this iteration; reserved. The aspect Portrait / Landscape pair is intentionally implemented as **two independent glass Toggles** rather than a SegmentedControl: only two states, each carries a distinct silhouette icon, and visual independence reads better against the black canvas. If a future control needs three or more mutually-exclusive states, introduce a SegmentedControl here using the same glass tokens — a group of buttons with shared border-radius on the outer edges.
+Connected pill — used by every mutually-exclusive control row in Studio (#133). Aspect / Shape are 2-segment, Count / Speed / Softness are 3-segment. All five rows share the same outer container, the same per-cell sizing rule, and the same active-state token, so a 2-pick row and a 3-pick row read as the same primitive at different cardinalities.
+
+- Outer wrapper: `inline-flex w-full max-w-md mx-auto rounded-md overflow-hidden border border-glassBorder` — `overflow-hidden` clips the children's square corners against the wrapper radius so the whole row reads as one pill
+- Cells: `flex-1 h-9 px-2 text-sm` (equal-width, fixed 36px height)
+- Outer corners: only the first cell gets `rounded-l-md`, only the last cell gets `rounded-r-md`; intermediate cells are `rounded-none`
+- Inner separator: every cell after the first gets `border-l border-glassBorder` — a single hairline, not a gap
+- Default state: `bg-glassBg text-fgMuted hover:text-fg hover:bg-glassBgHover`
+- **Active state**: `bg-fg/15 text-fg` (white at 15% over the surface). This is **stronger than the legacy Toggle's `glass-bg-hover` (10%)** so a 3-segment row reads its selection at a glance. The Toggle (`§4 Toggle`) keeps the older 10% value because its 2-state silhouette icons already communicate state via shape; the segmented control needs more chroma since cells are text-only and adjacent
+- Focus: matches the rest of the glass system (`focus-visible:ring-1 focus-visible:ring-focusRing`)
+- Disabled: `opacity-40 cursor-not-allowed`, applied per-cell so individual cells can independently dim if a future row needs that (today every row dims as a unit via the parent grid's `disabled` propagation)
+- Row alignment: every row lives inside one shared `max-w-md` grid (`grid-cols-[auto_minmax(0,1fr)]`). Aspect spans both columns (`col-span-2`) so its segmented control fills the full grid width; the four labeled rows put the segmented control in the right column. The segmented control's `w-full` plus the grid's fixed `max-w-md` means **2-pick and 3-pick rows always end at the same right edge**
+
+The implementation lives in `Studio.tsx` as the constants `SEG_GROUP` (wrapper class string) and the helper `SEG_BTN(i, total, active)` (per-cell class string). Future segmented rows should reuse those rather than open-coding the radius / separator / state logic.
+
+#### Glyph monochrome rendering
+
+When the segmented control's adjacent input is the Glyph picker (`Studio` shape row), the input, the picker buttons, and the `<datalist>` options are all tagged with `glyph-symbol-text`. That class loads `Noto Sans Symbols 2` from Google Fonts and sets `font-variant-emoji: text`, so `⚡` / `☀` / `★` / `←` are drawn as white symbols (matching the rest of the chrome) instead of the OS color-emoji rasters. The font load lives in `Base.astro`; the class is scoped — body text and other UI strings continue using the system sans stack.
 
 ### Tile
 

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -920,7 +920,7 @@ export default function Studio() {
     return [
       'flex-1 h-9 px-2 text-sm flex items-center justify-center transition-colors duration-200 ease-out',
       'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing',
-      'disabled:opacity-40 disabled:cursor-not-allowed',
+      'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-glassBg disabled:hover:text-fgMuted',
       radius,
       sep,
       state,
@@ -1201,7 +1201,12 @@ export default function Studio() {
                     }
                     title={sym}
                   >
-                    {sym}
+                    {/* #133 review Q2: U+FE0E (text variation selector) を付けて
+                        Safari/iOS で ⚡ などが OS 絵文字フォントに resolve されるのを防ぎ、
+                        Noto Sans Symbols 2 のモノクロ描画を強制する。Chromium は
+                        font-variant-emoji: text で対応済み。selector は display 用で、
+                        value (sym) には付けないので状態管理は影響を受けない。 */}
+                    {sym + '︎'}
                   </button>
                 )}
               </For>

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -894,10 +894,44 @@ export default function Studio() {
     'active:opacity-80 disabled:opacity-40 disabled:cursor-not-allowed';
   // toggled (アスペクト ON 等) で重ねる class — DESIGN.md §4 Toggle.
   const GLASS_BTN_TOGGLED = 'bg-glassBgHover';
-  const GLASS_INPUT =
-    'h-9 w-20 rounded border border-glassBorder bg-glassBg px-2 text-center text-sm text-fg ' +
-    'backdrop-blur-glass placeholder:text-fgSubtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing ' +
-    'disabled:opacity-40 disabled:cursor-not-allowed';
+  // #133: Segmented control の各セルが使う class を index と total から組み立てる。
+  // - 連結ピル化: 中間 cell は角丸を消し、左右端のみ rounded-l / rounded-r-md を付ける
+  // - 等幅: flex-1 で row 全体を占有し、2 択 row でも 3 択 row でも左右端が揃う
+  // - 区切り: 2 個目以降は left hairline (border-l border-glassBorder) で隣接 cell と分ける
+  // - active: bg-fg/15 (白 15%) + text-fg、非選択 (text-fgMuted) と差を明確化
+  //   (現状の glass-bg-toggled = 10% より白寄りで、選択中が一目で判る)
+  // SEG_GROUP は <div> wrapper 側に付けるトークン。row の最大幅は max-w-md で
+  // aspect / shape / count / speed / softness すべて揃え、左右端を一致させる。
+  const SEG_GROUP =
+    'inline-flex w-full max-w-md mx-auto rounded-md overflow-hidden border border-glassBorder';
+  const SEG_BTN = (i: number, total: number, active: boolean) => {
+    const radius =
+      total === 1
+        ? 'rounded-md'
+        : i === 0
+          ? 'rounded-l-md'
+          : i === total - 1
+            ? 'rounded-r-md'
+            : 'rounded-none';
+    const sep = i > 0 ? 'border-l border-glassBorder' : '';
+    const state = active
+      ? 'bg-fg/15 text-fg'
+      : 'bg-glassBg text-fgMuted hover:text-fg hover:bg-glassBgHover';
+    return [
+      'flex-1 h-9 px-2 text-sm flex items-center justify-center transition-colors duration-200 ease-out',
+      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing',
+      'disabled:opacity-40 disabled:cursor-not-allowed',
+      radius,
+      sep,
+      state,
+    ]
+      .filter(Boolean)
+      .join(' ');
+  };
+  // #133: 旧 GLASS_INPUT (h-9 w-20 ...) は glyph 入力欄の専用品だったが、
+  // segmented row 化で w-full + glyph-symbol-text を持たせて inline 展開
+  // したため不要になった。将来 width 違いの input が増えたら token として
+  // 復活させる。
   // #136: 再利用可能な glass checkbox ラベル + input スタイル。
   // 後の #56（透過DL checkbox）が同じトークンを踏襲する想定。
   // - GLASS_CHECKBOX_LABEL: <label> 全体のクリック領域・disabled 連動を担う
@@ -1026,63 +1060,74 @@ export default function Studio() {
         </Show>
       </label>
 
-      <div class="flex items-center justify-center gap-2">
-        <button
-          type="button"
-          aria-pressed={aspect() === 'portrait'}
-          aria-label={t('aspectPortrait')}
-          title={t('aspectPortraitTitle')}
-          onClick={() => onAspectClick('portrait')}
-          disabled={!decoded() || downloading()}
-          class={GLASS_BTN + (aspect() === 'portrait' ? ' ' + GLASS_BTN_TOGGLED : '')}
-        >
-          {/* 縦長を示すシルエット (角丸縦長方形) */}
-          <svg
-            viewBox="0 0 24 24"
-            width="20"
-            height="20"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <rect x="8" y="3" width="8" height="18" rx="1.5" />
-          </svg>
-        </button>
-        <button
-          type="button"
-          aria-pressed={aspect() === 'landscape'}
-          aria-label={t('aspectLandscape')}
-          title={t('aspectLandscapeTitle')}
-          onClick={() => onAspectClick('landscape')}
-          disabled={!decoded() || downloading()}
-          class={GLASS_BTN + (aspect() === 'landscape' ? ' ' + GLASS_BTN_TOGGLED : '')}
-        >
-          {/* 横長を示すシルエット (角丸横長方形) */}
-          <svg
-            viewBox="0 0 24 24"
-            width="20"
-            height="20"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <rect x="3" y="8" width="18" height="8" rx="1.5" />
-          </svg>
-        </button>
-      </div>
-      <div class="mx-auto grid max-w-2xl grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2">
+      {/* #133: aspect / shape / count / speed / softness すべてを 1 つの grid に
+          載せて、各 row の左右端が完全に揃うようにする。
+          - 列定義: 左 = label (auto)、右 = segmented control (1fr)
+          - aspect は label のない 2 列 span (左右端が他 row より少し広く張り出す)
+          - 各 segmented control は SEG_GROUP の `w-full` で右列いっぱいに広がる
+          - SEG_BTN の `flex-1` で 2 択でも 3 択でも cell 幅が揃う */}
+      <div class="mx-auto grid max-w-md grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2">
+        {/* aspect: label なしで 2 列を span。other row と同じグリッド内なので
+            左右端が grid 幅 (max-w-md) で一致する。 */}
+        <div class="col-span-2">
+          <div class={SEG_GROUP}>
+            <button
+              type="button"
+              aria-pressed={aspect() === 'portrait'}
+              aria-label={t('aspectPortrait')}
+              title={t('aspectPortraitTitle')}
+              onClick={() => onAspectClick('portrait')}
+              disabled={!decoded() || downloading()}
+              class={SEG_BTN(0, 2, aspect() === 'portrait')}
+            >
+              {/* 縦長を示すシルエット (角丸縦長方形) */}
+              <svg
+                viewBox="0 0 24 24"
+                width="20"
+                height="20"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <rect x="8" y="3" width="8" height="18" rx="1.5" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              aria-pressed={aspect() === 'landscape'}
+              aria-label={t('aspectLandscape')}
+              title={t('aspectLandscapeTitle')}
+              onClick={() => onAspectClick('landscape')}
+              disabled={!decoded() || downloading()}
+              class={SEG_BTN(1, 2, aspect() === 'landscape')}
+            >
+              {/* 横長を示すシルエット (角丸横長方形) */}
+              <svg
+                viewBox="0 0 24 24"
+                width="20"
+                height="20"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <rect x="3" y="8" width="18" height="8" rx="1.5" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
         <label class="justify-self-end text-sm text-fgMuted">{t('shapeLabel')}:</label>
-        <div class="flex flex-wrap items-center gap-1">
+        <div class={SEG_GROUP}>
           <button
             type="button"
             aria-pressed={shape() === 'circle'}
             onClick={() => onShapeClick('circle')}
             disabled={!decoded() || downloading()}
-            class={GLASS_BTN + ' text-sm ' + (shape() === 'circle' ? GLASS_BTN_TOGGLED : '')}
+            class={SEG_BTN(0, 2, shape() === 'circle')}
           >
             {t('shapeOptionCircle')}
           </button>
@@ -1091,13 +1136,23 @@ export default function Studio() {
             aria-pressed={shape() === 'glyph'}
             onClick={() => onShapeClick('glyph')}
             disabled={!decoded() || downloading()}
-            class={GLASS_BTN + ' text-sm ' + (shape() === 'glyph' ? GLASS_BTN_TOGGLED : '')}
+            class={SEG_BTN(1, 2, shape() === 'glyph')}
           >
             {t('shapeOptionGlyph')}
           </button>
-          <Show when={shape() === 'glyph'}>
+        </div>
+
+        {/* #133: glyph 入力欄は datalist combobox 化。
+            候補は supportedGlyphChoices() (Noto Sans Symbols 2 同梱記号)、
+            自由入力は IME 経由で emoji なども受け付ける。
+            glyph-symbol-text class で picker / input 表示を Noto Sans Symbols 2
+            に揃え、⚡ などの白ベタ描画を実現する (Base.astro)。 */}
+        <Show when={shape() === 'glyph'}>
+          <>
+            <span />
             <input
               type="text"
+              list="glyph-suggestions"
               aria-label={t('glyphCharLabel')}
               value={glyphChar()}
               placeholder={t('glyphCharPlaceholder')}
@@ -1115,15 +1170,21 @@ export default function Studio() {
                 if (e.currentTarget.value !== first) e.currentTarget.value = first;
               }}
               class={
-                GLASS_INPUT +
+                // glass token を踏襲しつつ、segmented row 内では w-full にして
+                // 右列いっぱいに広げる。glyph-symbol-text で Noto Sans Symbols 2
+                // を当て、⚡ などをモノクロ描画する (Base.astro)。
+                // GLASS_INPUT は固定幅 (w-20) なのでここでは展開して再利用しない。
+                'glyph-symbol-text h-9 w-full rounded border border-glassBorder bg-glassBg px-2 text-center text-sm text-fg ' +
+                'backdrop-blur-glass placeholder:text-fgSubtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing ' +
+                'disabled:opacity-40 disabled:cursor-not-allowed' +
                 (glyphCharSupported() ? '' : ' border-fgMuted')
               }
             />
-          </Show>
-        </div>
-
-        <Show when={shape() === 'glyph'}>
-          <>
+            <datalist id="glyph-suggestions">
+              <For each={supportedGlyphChoices()}>
+                {(sym) => <option value={sym} />}
+              </For>
+            </datalist>
             <span />
             <div class="flex flex-wrap items-center gap-1">
               <For each={supportedGlyphChoices()}>
@@ -1135,7 +1196,7 @@ export default function Studio() {
                     disabled={!decoded() || downloading()}
                     class={
                       GLASS_BTN +
-                      ' h-9 w-9 px-0 text-base ' +
+                      ' glyph-symbol-text h-9 w-9 px-0 text-base ' +
                       (glyphChar() === sym ? GLASS_BTN_TOGGLED : '')
                     }
                     title={sym}
@@ -1164,13 +1225,13 @@ export default function Studio() {
         </Show>
 
         <label class="justify-self-end text-sm text-fgMuted">{t('countLabel')}:</label>
-        <div class="flex flex-wrap items-center gap-1">
+        <div class={SEG_GROUP}>
           <button
             type="button"
             aria-pressed={countPreset() === 'low'}
             onClick={() => onCountPresetClick('low')}
             disabled={!decoded() || downloading()}
-            class={GLASS_BTN + ' text-sm ' + (countPreset() === 'low' ? GLASS_BTN_TOGGLED : '')}
+            class={SEG_BTN(0, 3, countPreset() === 'low')}
           >
             {t('countOptionLow')}
           </button>
@@ -1179,10 +1240,7 @@ export default function Studio() {
             aria-pressed={countPreset() === '' || countPreset() === 'mid'}
             onClick={() => onCountPresetClick('mid')}
             disabled={!decoded() || downloading()}
-            class={
-              GLASS_BTN + ' text-sm ' +
-              (countPreset() === '' || countPreset() === 'mid' ? GLASS_BTN_TOGGLED : '')
-            }
+            class={SEG_BTN(1, 3, countPreset() === '' || countPreset() === 'mid')}
           >
             {t('countOptionMid')}
           </button>
@@ -1191,20 +1249,20 @@ export default function Studio() {
             aria-pressed={countPreset() === 'high'}
             onClick={() => onCountPresetClick('high')}
             disabled={!decoded() || downloading()}
-            class={GLASS_BTN + ' text-sm ' + (countPreset() === 'high' ? GLASS_BTN_TOGGLED : '')}
+            class={SEG_BTN(2, 3, countPreset() === 'high')}
           >
             {t('countOptionHigh')}
           </button>
         </div>
 
         <label class="justify-self-end text-sm text-fgMuted">{t('speedLabel')}:</label>
-        <div class="flex flex-wrap items-center gap-1">
+        <div class={SEG_GROUP}>
           <button
             type="button"
             aria-pressed={speedPreset() === 'slow'}
             onClick={() => onSpeedPresetClick('slow')}
             disabled={!decoded() || downloading()}
-            class={GLASS_BTN + ' text-sm ' + (speedPreset() === 'slow' ? GLASS_BTN_TOGGLED : '')}
+            class={SEG_BTN(0, 3, speedPreset() === 'slow')}
           >
             {t('speedOptionSlow')}
           </button>
@@ -1213,10 +1271,7 @@ export default function Studio() {
             aria-pressed={speedPreset() === '' || speedPreset() === 'mid'}
             onClick={() => onSpeedPresetClick('mid')}
             disabled={!decoded() || downloading()}
-            class={
-              GLASS_BTN + ' text-sm ' +
-              (speedPreset() === '' || speedPreset() === 'mid' ? GLASS_BTN_TOGGLED : '')
-            }
+            class={SEG_BTN(1, 3, speedPreset() === '' || speedPreset() === 'mid')}
           >
             {t('speedOptionMid')}
           </button>
@@ -1225,22 +1280,20 @@ export default function Studio() {
             aria-pressed={speedPreset() === 'fast'}
             onClick={() => onSpeedPresetClick('fast')}
             disabled={!decoded() || downloading()}
-            class={GLASS_BTN + ' text-sm ' + (speedPreset() === 'fast' ? GLASS_BTN_TOGGLED : '')}
+            class={SEG_BTN(2, 3, speedPreset() === 'fast')}
           >
             {t('speedOptionFast')}
           </button>
         </div>
 
         <label class="justify-self-end text-sm text-fgMuted">{t('softnessLabel')}:</label>
-        <div class="flex flex-wrap items-center gap-1">
+        <div class={SEG_GROUP}>
           <button
             type="button"
             aria-pressed={softnessPreset() === 'low'}
             onClick={() => onSoftnessPresetClick('low')}
             disabled={!decoded() || downloading()}
-            class={
-              GLASS_BTN + ' text-sm ' + (softnessPreset() === 'low' ? GLASS_BTN_TOGGLED : '')
-            }
+            class={SEG_BTN(0, 3, softnessPreset() === 'low')}
           >
             {t('softnessOptionLow')}
           </button>
@@ -1249,12 +1302,7 @@ export default function Studio() {
             aria-pressed={softnessPreset() === '' || softnessPreset() === 'mid'}
             onClick={() => onSoftnessPresetClick('mid')}
             disabled={!decoded() || downloading()}
-            class={
-              GLASS_BTN + ' text-sm ' +
-              (softnessPreset() === '' || softnessPreset() === 'mid'
-                ? GLASS_BTN_TOGGLED
-                : '')
-            }
+            class={SEG_BTN(1, 3, softnessPreset() === '' || softnessPreset() === 'mid')}
           >
             {t('softnessOptionMid')}
           </button>
@@ -1263,9 +1311,7 @@ export default function Studio() {
             aria-pressed={softnessPreset() === 'high'}
             onClick={() => onSoftnessPresetClick('high')}
             disabled={!decoded() || downloading()}
-            class={
-              GLASS_BTN + ' text-sm ' + (softnessPreset() === 'high' ? GLASS_BTN_TOGGLED : '')
-            }
+            class={SEG_BTN(2, 3, softnessPreset() === 'high')}
           >
             {t('softnessOptionHigh')}
           </button>

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -83,6 +83,19 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500&display=swap"
     />
     <!--
+      orber#133 — Noto Sans Symbols 2 を読み込んで、Studio の glyph picker /
+      glyph 入力欄 / datalist combobox の文字を白ベタ (monochrome) で描画する。
+      OS の絵文字フォントだと ⚡ や ☀ がカラー絵文字でレンダリングされて
+      モノトーンの UI から浮くため、`.glyph-symbol-text` を介して
+      Symbols 2 を優先フォントに指定する (font-variant-emoji: text を併用)。
+      Studio.tsx 側で picker / input / datalist にしか付かない class なので、
+      他のテキスト要素には影響しない。
+    -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+Symbols+2&display=swap"
+    />
+    <!--
       orber#62 — 言語自動切替。
       hydration を待たずに <html lang> を navigator.language に合わせて書き換える
       ことで、スクリーンリーダー / 翻訳ツールが最初から正しい言語で読み上げる。
@@ -130,6 +143,15 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
       @keyframes orb-skeleton-shimmer {
         0% { background-position: 200% 0; }
         100% { background-position: -200% 0; }
+      }
+      /* orber#133 — Studio の glyph picker / glyph 入力欄 / datalist option
+         専用フォント class。OS のカラー絵文字経路を回避し、Noto Sans Symbols 2
+         (上の <link> で読み込み) でモノクロ描画する。
+         font-variant-emoji: text は Chromium で対応 (Safari は部分対応)、
+         Symbols 2 の glyph があるコードポイントは確実にそちらが優先される。 */
+      .glyph-symbol-text {
+        font-family: 'Noto Sans Symbols 2', system-ui, sans-serif;
+        font-variant-emoji: text;
       }
       .skeleton {
         background-color: rgba(255, 255, 255, 0.04);


### PR DESCRIPTION
## 関連 Issue
closes #133

## 変更内容
- **Segmented controls**: aspect / shape / count / speed / softness の 5 row を連結ピル化。`SEG_GROUP` / `SEG_BTN` helper で gap-0、左右端のみ角丸、中間は border-l 1 本、`flex-1` 等幅
- **Active state 強調**: `bg-fg/15 text-fg`（旧 `bg-glassBgHover` 10% → 15%）で非選択 (`text-fgMuted`) との差を明確化
- **Row 左右端整列**: 全 row を `max-w-md` grid 内で統一、2択 cell も 3択 cell も右端が揃う
- **Glyph combobox 化**: `<input list="glyph-suggestions">` + `<datalist>` で候補選択 + 自由入力併用。既存 picker grid も並存。IME composition 経路は維持
- **シンボル monochrome 化**: Base.astro で Noto Sans Symbols 2 を CDN から読み込み + `.glyph-symbol-text` CSS class を picker / datalist / input に適用。`⚡` `☀` 等が黄色絵文字でなく白ベタで描画される
- DESIGN.md §4 に SegmentedControl 仕様 + Glyph monochrome 運用を明記
- CHANGELOG unreleased に 1 行追加

## 受け入れ条件
- [x] Shape / Aspect / Count / Speed / Softness の各 row が連結 segmented controls
- [x] 2択 row でも 3択 row でも row の左右端が揃う
- [x] 選択中ボタンが現状より明確に判別できる
- [x] Glyph は combobox から候補選択でき、必要なら自由入力も可能

## 検証
- `npm run build`: 成功
- 視覚チェック (kako-jun 実機確認依頼):
  - Chromium / WebKit / Firefox で `⚡` `☀` が白で描画されるか
  - datalist + IME (日本語) の干渉なし確認
  - segmented row 左右端が 2択/3択で揃って見えるか