### PR TITLE
fix(web): #147 glyph shader に GLYPH_SDF_CONTENT_SPAN を宣言

### DIFF
--- a/web/src/lib/orberGl.ts
+++ b/web/src/lib/orberGl.ts
@@ -66,6 +66,11 @@ out vec4 outColor;
 
 const float TAU = 6.28318530718;
 const float BREATH_RADIUS_MAX_FACTOR = 1.10;
+// #147: glyph SDF の content span を GLSL 側にも宣言する。
+// この値は TS 定数 GLYPH_SDF_CONTENT_SPAN と Rust 側
+// crates/core/src/glyph.rs の GLYPH_SDF_CONTENT_SPAN (= 1/√2) に同期させること。
+// 未宣言だと shader compile が "GLYPH_SDF_CONTENT_SPAN: undeclared identifier" で落ちる。
+const float GLYPH_SDF_CONTENT_SPAN = ${GLYPH_SDF_CONTENT_SPAN};
 
 uniform vec2 u_resolution;
 uniform float u_t;             // [0, 1)


### PR DESCRIPTION
## 関連 Issue
closes #147

## 症状
画像を選んで生成を始めようとすると、以下のエラーで止まることがあった。

```
Error: shader compile failed: ERROR: 0:136: 'GLYPH_SDF_CONTENT_SPAN' : undeclared identifier
```

## 原因
`web/src/lib/orberGl.ts` の fragment shader 文字列 `FS` 内で
`GLYPH_SDF_CONTENT_SPAN` を参照しているのに、GLSL 側に `const float` 宣言が無かった。
TS 側 / Rust 側 (`crates/core/src/glyph.rs`) には同名定数があるが、それらは
GLSL ソースには伝播しないため compile 時に未宣言で落ちる。

## 修正
- FS の冒頭定数群（`TAU` / `BREATH_RADIUS_MAX_FACTOR`）の隣に
  `const float GLYPH_SDF_CONTENT_SPAN = \${GLYPH_SDF_CONTENT_SPAN};` を template 補間で埋め込み、
  TS 定数と必ず同じ値が入るようにした
- TS / Rust / GLSL の三者で同じ値を共有していることを明記した同期コメントを追加

## 受け入れ条件
- [x] `GLYPH_SDF_CONTENT_SPAN` 未宣言エラーが消える
- [x] TS / Rust / GLSL で値が一致（`1/√2 = 0.70710678`）