### PR TITLE
fix(web): UI 4 件修正 — checkbox 位置 / QR 不可視 / orb モチーフ縮小 / Nostalgic Counter ID 投入

### DIFF
--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -25,10 +25,10 @@ import { onMount } from 'solid-js';
 import { t } from '../lib/strings';
 import AffiliateGrid from './AffiliateGrid';
 
-// #128: Nostalgic Counter の実 ID は kako-jun が
-// https://nostalgic.llll-ll.com/ のダッシュボードで取得後に置換する。
-// TODO(kako-jun): 実 ID に置換 (例 "orber-xxxxxxxx")。
-const NOSTALGIC_COUNTER_ID = 'orber-PLACEHOLDER';
+// #128 / #148: Nostalgic Counter ID。
+// `https://api.nostalgic.llll-ll.com/visit?action=create` POST で発行済み。
+// URL: https://orber.llll-ll.com、token は kako-jun 統一値 (`ekumetoteroesu`)。
+const NOSTALGIC_COUNTER_ID = 'orber-11532f39';
 
 // placeholder の間は Counter 部分を非表示にする。embed.js が "Counter not found"
 // 等のテキストを表示しないように完全 mount しない。
@@ -75,11 +75,11 @@ function formatCounterAfterMount(root: HTMLElement): void {
 // 中央 (3 つ目) を最大にし、上下に向かって縮ませることで奥行きを出す。
 // fg トークンを使い、opacity だけで濃淡を作る (色トークン外しない)。
 const ORB_DOTS: { size: number; opacity: number }[] = [
-  { size: 6, opacity: 0.35 },
-  { size: 12, opacity: 0.55 },
-  { size: 22, opacity: 0.85 },
-  { size: 12, opacity: 0.55 },
-  { size: 6, opacity: 0.35 },
+  { size: 3, opacity: 0.35 },
+  { size: 6, opacity: 0.55 },
+  { size: 10, opacity: 0.85 },
+  { size: 6, opacity: 0.55 },
+  { size: 3, opacity: 0.35 },
 ];
 
 export default function Footer() {
@@ -149,13 +149,15 @@ export default function Footer() {
             他 PWA にコピペで横展開できる pattern にしている。 */}
         <AffiliateGrid />
 
-        {/* C. QR — 別途指定する PNG (`/orber-qr.png`) を使う。補助コピーは置かない。 */}
+        {/* C. QR — 別途指定する PNG (`/orber-qr.png`) を使う。補助コピーは置かない。
+            元 PNG は黒モジュール / 白背景なので、orber の dark テーマで見えるよう
+            `invert` でモジュールを白にする (他アプリと同じスタイル: テーマカラーに揃える)。 */}
         <img
           src="/orber-qr.png"
           alt={t('qrAlt')}
           width="120"
           height="120"
-          class="block rounded-sm border border-hairline bg-bg"
+          class="block rounded-sm border border-hairline bg-bg invert"
         />
 
         {/* Privacy — orber の境界条件 (画像はブラウザ内処理) はここに残す。 */}

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -1255,28 +1255,6 @@ export default function Studio() {
           </div>
         </div>
 
-        {/* #56: 透過版を ZIP DL に同梱する checkbox。aspect の直下 (= DL に影響する
-            設定の最上段) に置き、4 軸 segmented row 群とは視覚的に分けるため
-            col-span-2 で row 全体を使い、中央寄せで一行に収める。OFF 既定で
-            既存挙動と byte-exact identity を保つ (#56 受け入れ条件)。VP9 alpha
-            非対応 (Safari) では disabled + tooltip を出す。glass checkbox 共通
-            tokens (#136 で確立) を踏襲。 */}
-        <div class="col-span-2 flex justify-center">
-          <label
-            class={GLASS_CHECKBOX_LABEL}
-            title={!vp9AlphaSupported() ? t('includeAlphaDisabledTitle') : ''}
-          >
-            <input
-              type="checkbox"
-              class={GLASS_CHECKBOX_INPUT}
-              checked={includeAlpha()}
-              onChange={(e) => setIncludeAlpha(e.currentTarget.checked)}
-              disabled={!decoded() || downloading() || !vp9AlphaSupported()}
-            />
-            <span>{t('includeAlphaLabel')}</span>
-          </label>
-        </div>
-
         <label class="justify-self-end text-sm text-fgMuted">{t('shapeLabel')}:</label>
         <div class={SEG_GROUP}>
           <button
@@ -1786,7 +1764,28 @@ export default function Studio() {
           </For>
         </div>
 
-        <div class="flex flex-wrap items-center justify-center gap-2 pt-2">
+        {/* #56 / 配置調整: 透過版同梱 checkbox は DL ボタン行の直上に置き、
+            DL に影響する設定であることを近接で示す。OFF 既定で既存挙動と
+            byte-exact identity を保つ (#56 受け入れ条件)。VP9 alpha 非対応
+            (Safari) では disabled + tooltip を出す。glass checkbox 共通
+            tokens (#136 で確立) を踏襲。 */}
+        <div class="flex justify-center pt-2">
+          <label
+            class={GLASS_CHECKBOX_LABEL}
+            title={!vp9AlphaSupported() ? t('includeAlphaDisabledTitle') : ''}
+          >
+            <input
+              type="checkbox"
+              class={GLASS_CHECKBOX_INPUT}
+              checked={includeAlpha()}
+              onChange={(e) => setIncludeAlpha(e.currentTarget.checked)}
+              disabled={!decoded() || downloading() || !vp9AlphaSupported()}
+            />
+            <span>{t('includeAlphaLabel')}</span>
+          </label>
+        </div>
+
+        <div class="flex flex-wrap items-center justify-center gap-2">
           <button
             type="button"
             onClick={downloadSelected}


### PR DESCRIPTION
## 変更内容

### 1. Studio の \"Include transparent versions\" checkbox を DL ボタン行の直上に移動
旧: aspect の直下（segmented controls 群の中、`col-span-2` で row 全体）
新: DL ボタン行 (`downloadSelected` / `downloadAll`) の直上
DL に影響する設定であることを近接で示す。

### 2. Footer の QR 画像に \`invert\` filter
元 PNG (黒モジュール / 白背景) は orber の dark テーマで見えなかった。Tailwind \`invert\` クラス 1 個で白モジュール / 黒背景化してテーマカラーに揃える（他アプリと同じ流儀）。

### 3. Footer 入口の orb モチーフ ●×5 を縮小
6 / 12 / 22 / 12 / 6 px → 3 / 6 / 10 / 6 / 3 px。中央が太すぎたのを抑え、引き算寄りに。

### 4. Nostalgic Counter ID 投入
\`orber-PLACEHOLDER\` → \`orber-11532f39\`

\`\`\`bash
curl -X POST 'https://api.nostalgic.llll-ll.com/visit?action=create' \\
  -H 'Content-Type: application/json' \\
  -d '{\"url\":\"https://orber.llll-ll.com\",\"token\":\"ekumetoteroesu\"}'
# → { \"success\": true, \"id\": \"orber-11532f39\", ... }
\`\`\`

これにより `NOSTALGIC_COUNTER_ENABLED = true` となり、Footer の閲覧数表示が実カウントで動き出す。

## ビルド確認
- \`npm run build\` 成功