### PR TITLE
feat(web): フォント統一 (Space Grotesk) + GH Sponsors 重複削除 + 🐱 等未対応 glyph 警告強調

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -35,11 +35,21 @@ Deliberately no red / amber / yellow. Error and warning surfaces share the glass
 
 ### Font Families
 
+UI 全体で Space Grotesk に統一する (Latin)。CJK 文字 (日本語) は Space Grotesk
+に収録されていないので、OS の日本語フォントへ自動フォールバックさせる。
+
 ```
-display: "Space Grotesk", system-ui, sans-serif   # logo only
-body:    system-ui, -apple-system, "Segoe UI", "Hiragino Sans",
-         "Yu Gothic", Meiryo, sans-serif           # everything else
+sans (default for body / labels / buttons / status):
+  "Space Grotesk", system-ui, -apple-system, "Segoe UI",
+  "Hiragino Sans", "Yu Gothic", Meiryo, sans-serif
+
+display (h1 ロゴ・大型表示専用):
+  "Space Grotesk", system-ui, sans-serif
 ```
+
+`tailwind.config.mjs` で `fontFamily.sans` を上記に上書きしているので、
+特に何も class を付けない要素 (`text-sm` 等) も自動で Space Grotesk を
+拾う。`font-display` はロゴ等の意味的に「大型表示」な場面でのみ使う。
 
 Space Grotesk is loaded from Google Fonts CDN with `preconnect` to `fonts.googleapis.com` and `fonts.gstatic.com`. Weights pulled: 300, 400, 500.
 
@@ -48,10 +58,10 @@ Space Grotesk is loaded from Google Fonts CDN with `preconnect` to `fonts.google
 | Element       | Size            | Weight | Tracking  | Notes                                       |
 | ------------- | --------------- | ------ | --------- | ------------------------------------------- |
 | Logo (h1)     | 3rem (48px)     | 300    | `0.4em`   | `font-display`, lowercase, color `fg`. Compensate the trailing tracking with `pl-[0.4em]` so the visual center aligns with the page axis. |
-| Subtitle      | 0.875rem (14px) | 400    | normal    | `font-display`, color `fg-muted`, 1 line     |
-| Status        | 0.875rem (14px) | 400    | normal    | system sans, color `fg-muted`               |
-| Button label  | 0.875rem (14px) | 400    | normal    | system sans, color `fg` / `fg-muted`        |
-| Placeholder   | 0.875rem (14px) | 400    | normal    | color `fg-subtle`                           |
+| Subtitle      | 0.875rem (14px) | 400    | normal    | `font-display` 明示、color `fg-muted`、1 line |
+| Status        | 0.875rem (14px) | 400    | normal    | sans (Space Grotesk)、color `fg-muted`      |
+| Button label  | 0.875rem (14px) | 400    | normal    | sans (Space Grotesk)、color `fg` / `fg-muted` |
+| Placeholder   | 0.875rem (14px) | 400    | normal    | sans (Space Grotesk)、color `fg-subtle`     |
 
 No bold anywhere. Headers are deliberately light.
 

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -123,29 +123,9 @@ export default function Footer() {
           ))}
         </div>
 
-        {/* A. GH Sponsors */}
-        <a
-          href="https://github.com/sponsors/kako-jun"
-          target="_blank"
-          rel="noopener noreferrer"
-          title={t('sponsorTitle')}
-          class="inline-flex items-center gap-2 rounded-md border border-glassBorder bg-glassBg hover:bg-glassBgHover px-3 py-2 text-sm text-fg transition-colors duration-200 ease-out focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
-          </svg>
-          <span>{t('sponsorLabel')}</span>
-        </a>
+        {/* A. GH Sponsors の大きな glass button は削除 (User: GH Sponsors が
+            Footer 末尾の link 行と二重になるため)。寄付導線は最終行の
+            text link [GitHub Sponsors] に集約する (machigai-salad と同パターン)。 */}
 
         {/* B. Amazon affiliate × 3 — #152 で AffiliateGrid に切り出し。
             データ層 (web/src/data/affiliateProducts.ts) と UI 層を分離し、

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -135,13 +135,14 @@ export default function Footer() {
         {/* C. QR — 別途指定する PNG (`/orber-qr.png`) を使う。補助コピーは置かない。
             PNG は事前に `magick -negate` 済みで、白モジュール + 透明背景。
             bg-bg (#040404) 上で白モジュールが見える形 (orber テーマカラーに合わせ済み)。
-            CSS の invert 指定は使わない (二重反転で全面白塗りになるため)。 */}
+            border / bg-bg は削除済み: 透明背景ごと bg をそのまま透かすため不要。
+            User: 「うっすらと白い四角い枠」がモジュール領域以外に見えるのを解消。 */}
         <img
           src="/orber-qr.png"
           alt={t('qrAlt')}
           width="120"
           height="120"
-          class="block rounded-sm border border-hairline bg-bg"
+          class="block"
         />
 
         {/* Privacy — orber の境界条件 (画像はブラウザ内処理) はここに残す。 */}

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -1461,7 +1461,13 @@ export default function Studio() {
       </div>
 
       <Show when={!glyphCharSupported() && shape() === 'glyph' && glyphChar().length > 0}>
-        <p class="text-center text-xs text-fgMuted">{t('glyphCharUnsupported')}</p>
+        {/* 警告は text-fg + glass 枠で目立たせる (User: 🐱 を入力しても何も表示
+            されない、と気付かれない問題)。typed char をそのまま見せて何が
+            unsupported かを明示。 */}
+        <p class="mx-auto inline-flex items-center gap-2 rounded-md border border-glassBorder bg-glassBg px-3 py-2 text-center text-sm text-fg">
+          <span class="glyph-symbol-text leading-none">{glyphChar()}</span>
+          <span>{t('glyphCharUnsupported')}</span>
+        </p>
       </Show>
 
       <Show when={wasmStatus() === 'error'}>

--- a/web/tailwind.config.mjs
+++ b/web/tailwind.config.mjs
@@ -20,6 +20,19 @@ export default {
       },
       fontFamily: {
         display: ['"Space Grotesk"', 'system-ui', 'sans-serif'],
+        // Latin は Space Grotesk に統一 (DESIGN.md §3 改訂、ロゴ専用ではなく
+        // UI 全体に拡張)。CJK 文字は Space Grotesk に収録されていないので
+        // OS の日本語フォントへ自動フォールバックさせる。
+        sans: [
+          '"Space Grotesk"',
+          'system-ui',
+          '-apple-system',
+          '"Segoe UI"',
+          '"Hiragino Sans"',
+          '"Yu Gothic"',
+          'Meiryo',
+          'sans-serif',
+        ],
       },
       letterSpacing: {
         // ロゴ用 — DESIGN.md §3 (0.4em)


### PR DESCRIPTION
ユーザー指示の3点を反映。

## 1. フォント統一 (Shape などのラベルもタイトル/副題と同じ Space Grotesk に)

- `tailwind.config.mjs` の \`fontFamily.sans\` を `["Space Grotesk", system-ui, ..., "Hiragino Sans", "Yu Gothic", Meiryo, sans-serif]` に上書き
- Latin は Space Grotesk、CJK (日本語) は OS の日本語フォントに自動フォールバック
- 特に \`font-display\` class を付けていない要素 (\`text-sm\` 等) も自動で Space Grotesk を拾う → Shape / Speed / Softness 等のラベル全てが統一される
- DESIGN.md §3 を改訂 (sans の定義を変更、Status / Button label / Placeholder の Notes を「sans (Space Grotesk)」に書き換え)

## 2. GH Sponsors 重複削除

- Footer 上部の大きな glass button (旧 A 項) を削除
- 寄付導線は Footer 末尾の text link \`[GitHub Sponsors]\` に集約 (machigai-salad と同パターン)
- 主要 CTA は AffiliateGrid 側に集中させ、Sponsor は静かな text link に

## 3. 🐱 等の未対応グリフ警告を強調

🐱 のように Noto Sans Symbols 2 に収録されていない文字を入力すると、現状は \`text-fgMuted text-xs\` の小さい注釈で「同梱フォントに収録されていません」と出ていた。User がこれを見落とし「何も表示されない」と誤解する報告があったため、以下に変更:
- text-fg + glass 枠 + text-sm に格上げ
- 入力された char (例: 🐱) そのものを並べて何が unsupported かを明示

## ビルド確認
\`npm run build\` 成功。

## マージ前後
- マージ前: AffiliateGrid と Sponsor 大ボタンの重複、ラベルが system font
- マージ後: Sponsor 1箇所、フォント統一、未対応グリフ警告が見える