### PR TITLE
fix(web): glyph placeholder 可視化 / picker 上下センター強制 / 選択マーカー強化

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -1713,66 +1713,70 @@ export default function Studio() {
                 </Show>
                 {/* 4-corner L marker — DESIGN.md §4 SelectionMarker
                     skeleton 中は disabled なので hover も発火しない。
-                    白い orb 画像でも見えるよう drop-shadow で黒い影を付け、
-                    selected 時はぼんやり呼吸アニメ (orb-selected-pulse) を当てる。 */}
+                    User: マークが小さすぎ / 影が薄すぎ / アニメ見えない、を反映:
+                      - サイズ 14 → 24 (約 1.7x 拡大)
+                      - stroke 1.5 → 2.5 (太く)
+                      - drop-shadow を 6px + 2px の二重影で濃く (黒 100%)
+                      - orb-selected-pulse の opacity 振幅を 100%↔65% → 100%↔30% に強化 */}
                 <span
                   class={
                     'pointer-events-none absolute inset-0 text-fg transition-opacity duration-200 ease-out ' +
                     (tile.selected ? 'opacity-100 orb-selected-pulse' : 'opacity-0 group-hover:opacity-30')
                   }
                   style={{
-                    filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.85))',
+                    filter:
+                      'drop-shadow(0 0 6px rgba(0,0,0,1)) drop-shadow(0 0 2px rgba(0,0,0,1))',
                   }}
                   aria-hidden="true"
                 >
                   {/* top-left */}
                   <svg
-                    class="absolute top-1 left-1"
-                    width="14"
-                    height="14"
+                    class="absolute top-1.5 left-1.5"
+                    width="24"
+                    height="24"
                     viewBox="0 0 14 14"
                     fill="none"
                     stroke="currentColor"
-                    stroke-width="1.5"
+                    stroke-width="2.5"
                     stroke-linecap="round"
                   >
                     <path d="M2 5 V2 H5" />
                   </svg>
                   {/* top-right */}
                   <svg
-                    class="absolute top-1 right-1"
-                    width="14"
-                    height="14"
+                    class="absolute top-1.5 right-1.5"
+                    width="24"
+                    height="24"
                     viewBox="0 0 14 14"
                     fill="none"
                     stroke="currentColor"
-                    stroke-width="1.5"
+                    stroke-width="2.5"
                     stroke-linecap="round"
                   >
                     <path d="M9 2 H12 V5" />
                   </svg>
                   {/* bottom-left */}
                   <svg
-                    class="absolute bottom-1 left-1"
-                    width="14"
-                    height="14"
+                    class="absolute bottom-1.5 left-1.5"
+                    width="24"
+                    height="24"
                     viewBox="0 0 14 14"
                     fill="none"
                     stroke="currentColor"
-                    stroke-width="1.5"
+                    stroke-width="2.5"
                     stroke-linecap="round"
                   >
                     <path d="M2 9 V12 H5" />
                   </svg>
                   {/* bottom-right */}
                   <svg
-                    class="absolute bottom-1 right-1"
-                    width="14"
-                    height="14"
+                    class="absolute bottom-1.5 right-1.5"
+                    width="24"
+                    height="24"
                     viewBox="0 0 14 14"
                     fill="none"
                     stroke="currentColor"
-                    stroke-width="1.5"
+                    stroke-width="2.5"
                     stroke-linecap="round"
                   >
                     <path d="M9 12 H12 V9" />

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -1344,10 +1344,12 @@ export default function Studio() {
                         Noto Sans Symbols 2 のモノクロ描画を強制する。Chromium は
                         font-variant-emoji: text で対応済み。selector は display 用で、
                         value (sym) には付けないので状態管理は影響を受けない。
-                        ボタン高さ h-9 に対してフォント独自メトリクスでズレるため、
-                        leading-none + inline-block span でグリフ中心を上下センターに
-                        揃える (review)。 */}
-                    <span class="inline-block leading-none">{sym + '︎'}</span>
+                        Noto Sans Symbols 2 はフォント独自の baseline でボタン中央
+                        からズレるので、span を flex で h-full 化して再度
+                        items-center / justify-center を当てて強制センタリングする。 */}
+                    <span class="flex h-full w-full items-center justify-center leading-none">
+                      {sym + '︎'}
+                    </span>
                   </button>
                 )}
               </For>

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -112,7 +112,11 @@ export default function Studio() {
   // #131: 4 軸は常時展開で、どのボタンも押した瞬間に runBatch を起動する。
   // 初期値は empty identity を維持し、既存 output regression を防ぐ。
   const [shape, setShape] = createSignal<ShapeChoice>('circle');
-  const [glyphChar, setGlyphChar] = createSignal<string>('☆');
+  // 初期値は空文字。User: 「最初から ☆ が入力されてるせいでプレイスホルダ
+  // を見られない」。空にすればプレイスホルダ (例: emoji) が見え、ユーザーが
+  // 自由入力欄であることに気付ける。glyph shape を選んでも何も入れなければ
+  // line 700 の guard で runBatch が走らないので落ちない。
+  const [glyphChar, setGlyphChar] = createSignal<string>('');
   // #136: Glyph 回転 ON/OFF。glyph_char 切替時に GLYPH_DEFAULT_ROTATE で上書き。
   // ユーザーが checkbox を切替えるとその session 中は尊重し、次の glyph 切替で
   // 再度 default が適用される。既定 true（既存挙動互換）。

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -154,13 +154,14 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
         animation: orb-spin 1.1s linear infinite;
       }
       /* タイル選択中の corner L マーカーのぼんやり呼吸アニメ。
-         opacity を 100% ↔ 65% で 1.6s ループ。reduced-motion では下で停止。 */
+         User: アニメが見えない、を反映して opacity 振幅を 65% → 30% に拡大、
+         サイクルも 1.6s → 1.4s に短縮で「呼吸している」感を強める。 */
       @keyframes orb-selected-pulse {
         0%, 100% { opacity: 1; }
-        50% { opacity: 0.65; }
+        50% { opacity: 0.3; }
       }
       .orb-selected-pulse {
-        animation: orb-selected-pulse 1.6s ease-in-out infinite;
+        animation: orb-selected-pulse 1.4s ease-in-out infinite;
       }
       /* orber#? — タイル生成中の skeleton shimmer。runBatch 開始と同時に
          12 個のプレースホルダを置いてグリッド形状を確定させ、wasm の

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -47,10 +47,10 @@ export const STRINGS = {
   shapeOptionCircle: { ja: '円', en: 'Circle' },
   shapeOptionGlyph: { ja: '文字', en: 'Glyph' },
   glyphCharLabel: { ja: '文字', en: 'Character' },
-  // 例示は ☆ だけだとユーザーが「☆ しか入らない」と誤解するため、
-  // 記号 / アルファベット / 矢印 / 雷 / 花 と幅広く例示する。Noto Sans Symbols 2
-  // に収録されている文字なら ASCII / 記号 / 一部絵文字も入る (収録外は警告表示)。
-  glyphCharPlaceholder: { ja: '例: ☆ A → ⚡ ✿', en: 'e.g., ☆ A → ⚡ ✿' },
+  // 自由入力欄であることを示すため "emoji" 1 単語。下のボタン群と同じ記号を
+  // 例示しても重複情報になるだけなので、ユーザーが「ボタンに無い文字も
+  // 入れられる」と気付けるよう emoji 表記にする (収録外なら警告表示)。
+  glyphCharPlaceholder: { ja: 'emoji', en: 'emoji' },
   glyphCharUnsupported: {
     ja: '同梱フォントに収録されていません',
     en: 'Not in bundled font',


### PR DESCRIPTION
ユーザー報告 4 件をまとめて修正。

## 1. Glyph 入力に最初から '☆' が入っていてプレイスホルダが見えない
- `glyphChar` の初期値を `'☆'` → `''` に
- `runBatch` は line 700 で empty char をガードしているので落ちない
- glyph shape を選んだ後に placeholder が見える

## 2. Placeholder の例示が下のボタンと重複していて意味不明
- `'例: ☆ A → ⚡ ✿'` → `'emoji'` (ja/en 共通)
- 下のボタンに同じ記号が並んでいるので例示は無意味
- 「ボタンに無い文字も自由入力できる」と気付かせる短い hint に

## 3. Glyph picker のグリフが上下センタリングされていない
- 前回 leading-none + inline-block では Noto Sans Symbols 2 の独自 baseline が解消しなかった
- span を `flex h-full w-full items-center justify-center` でボタン全面に広げて強制センタリング

## 4. 選択 corner L マーカーが小さい / 影が薄い / アニメが見えない
- SVG サイズ: 14 → 24 (約 1.7x 拡大)
- stroke-width: 1.5 → 2.5 (太く)
- inset: top-1 → top-1.5 (拡大に合わせて余白)
- drop-shadow: 1 重 0.85 → 二重 (6px + 2px) で黒 100%
- `orb-selected-pulse`: 100%↔65%/1.6s → 100%↔30%/1.4s で呼吸感を強める

## ビルド確認
\`npm run build\` 成功。