### PR TITLE
fix(web): 透過版 PNG/WebP を全ブラウザで含める + affiliate 文言修正 + 未使用キー削除

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -1713,66 +1713,70 @@ export default function Studio() {
                 </Show>
                 {/* 4-corner L marker — DESIGN.md §4 SelectionMarker
                     skeleton 中は disabled なので hover も発火しない。
-                    白い orb 画像でも見えるよう drop-shadow で黒い影を付け、
-                    selected 時はぼんやり呼吸アニメ (orb-selected-pulse) を当てる。 */}
+                    User: マークが小さすぎ / 影が薄すぎ / アニメ見えない、を反映:
+                      - サイズ 14 → 24 (約 1.7x 拡大)
+                      - stroke 1.5 → 2.5 (太く)
+                      - drop-shadow を 6px + 2px の二重影で濃く (黒 100%)
+                      - orb-selected-pulse の opacity 振幅を 100%↔65% → 100%↔30% に強化 */}
                 <span
                   class={
                     'pointer-events-none absolute inset-0 text-fg transition-opacity duration-200 ease-out ' +
                     (tile.selected ? 'opacity-100 orb-selected-pulse' : 'opacity-0 group-hover:opacity-30')
                   }
                   style={{
-                    filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.85))',
+                    filter:
+                      'drop-shadow(0 0 6px rgba(0,0,0,1)) drop-shadow(0 0 2px rgba(0,0,0,1))',
                   }}
                   aria-hidden="true"
                 >
                   {/* top-left */}
                   <svg
-                    class="absolute top-1 left-1"
-                    width="14"
-                    height="14"
+                    class="absolute top-1.5 left-1.5"
+                    width="24"
+                    height="24"
                     viewBox="0 0 14 14"
                     fill="none"
                     stroke="currentColor"
-                    stroke-width="1.5"
+                    stroke-width="2.5"
                     stroke-linecap="round"
                   >
                     <path d="M2 5 V2 H5" />
                   </svg>
                   {/* top-right */}
                   <svg
-                    class="absolute top-1 right-1"
-                    width="14"
-                    height="14"
+                    class="absolute top-1.5 right-1.5"
+                    width="24"
+                    height="24"
                     viewBox="0 0 14 14"
                     fill="none"
                     stroke="currentColor"
-                    stroke-width="1.5"
+                    stroke-width="2.5"
                     stroke-linecap="round"
                   >
                     <path d="M9 2 H12 V5" />
                   </svg>
                   {/* bottom-left */}
                   <svg
-                    class="absolute bottom-1 left-1"
-                    width="14"
-                    height="14"
+                    class="absolute bottom-1.5 left-1.5"
+                    width="24"
+                    height="24"
                     viewBox="0 0 14 14"
                     fill="none"
                     stroke="currentColor"
-                    stroke-width="1.5"
+                    stroke-width="2.5"
                     stroke-linecap="round"
                   >
                     <path d="M2 9 V12 H5" />
                   </svg>
                   {/* bottom-right */}
                   <svg
-                    class="absolute bottom-1 right-1"
-                    width="14"
-                    height="14"
+                    class="absolute bottom-1.5 right-1.5"
+                    width="24"
+                    height="24"
                     viewBox="0 0 14 14"
                     fill="none"
                     stroke="currentColor"
-                    stroke-width="1.5"
+                    stroke-width="2.5"
                     stroke-linecap="round"
                   >
                     <path d="M9 12 H12 V9" />

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -1344,10 +1344,12 @@ export default function Studio() {
                         Noto Sans Symbols 2 のモノクロ描画を強制する。Chromium は
                         font-variant-emoji: text で対応済み。selector は display 用で、
                         value (sym) には付けないので状態管理は影響を受けない。
-                        ボタン高さ h-9 に対してフォント独自メトリクスでズレるため、
-                        leading-none + inline-block span でグリフ中心を上下センターに
-                        揃える (review)。 */}
-                    <span class="inline-block leading-none">{sym + '︎'}</span>
+                        Noto Sans Symbols 2 はフォント独自の baseline でボタン中央
+                        からズレるので、span を flex で h-full 化して再度
+                        items-center / justify-center を当てて強制センタリングする。 */}
+                    <span class="flex h-full w-full items-center justify-center leading-none">
+                      {sym + '︎'}
+                    </span>
                   </button>
                 )}
               </For>

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -112,7 +112,11 @@ export default function Studio() {
   // #131: 4 軸は常時展開で、どのボタンも押した瞬間に runBatch を起動する。
   // 初期値は empty identity を維持し、既存 output regression を防ぐ。
   const [shape, setShape] = createSignal<ShapeChoice>('circle');
-  const [glyphChar, setGlyphChar] = createSignal<string>('☆');
+  // 初期値は空文字。User: 「最初から ☆ が入力されてるせいでプレイスホルダ
+  // を見られない」。空にすればプレイスホルダ (例: emoji) が見え、ユーザーが
+  // 自由入力欄であることに気付ける。glyph shape を選んでも何も入れなければ
+  // line 700 の guard で runBatch が走らないので落ちない。
+  const [glyphChar, setGlyphChar] = createSignal<string>('');
   // #136: Glyph 回転 ON/OFF。glyph_char 切替時に GLYPH_DEFAULT_ROTATE で上書き。
   // ユーザーが checkbox を切替えるとその session 中は尊重し、次の glyph 切替で
   // 再度 default が適用される。既定 true（既存挙動互換）。

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -938,7 +938,12 @@ export default function Studio() {
       // #56: alpha 同梱時は hi-res 経路を 2 周走らせるので、進捗 total は 2x。
       // renderHiResForIndices 冒頭で setDlProgress({done:0, total:indices.length})
       // していたのを上書きするため、ここで先に正しい total を立てる。
-      const wantAlpha = includeAlpha() && vp9AlphaSupported();
+      // User: 「透過版を含めるチェックを入れたのに含まれていなかった」を反映。
+      // 旧 `wantAlpha = includeAlpha() && vp9AlphaSupported()` は VP9 alpha
+      // 非対応ブラウザ (Safari 等) で alpha 経路が一切走らない状態だった。
+      // PNG / WebP 透過は VP9 と無関係なのでチェックされたら必ず走らせ、
+      // WebM 透過は renderAlphaForIndices 内 (line 915) で個別に VP9 ガードする。
+      const wantAlpha = includeAlpha();
       setDlProgress({
         done: 0,
         total: wantAlpha ? indices.length * 2 : indices.length,

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -154,13 +154,14 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
         animation: orb-spin 1.1s linear infinite;
       }
       /* タイル選択中の corner L マーカーのぼんやり呼吸アニメ。
-         opacity を 100% ↔ 65% で 1.6s ループ。reduced-motion では下で停止。 */
+         User: アニメが見えない、を反映して opacity 振幅を 65% → 30% に拡大、
+         サイクルも 1.6s → 1.4s に短縮で「呼吸している」感を強める。 */
       @keyframes orb-selected-pulse {
         0%, 100% { opacity: 1; }
-        50% { opacity: 0.65; }
+        50% { opacity: 0.3; }
       }
       .orb-selected-pulse {
-        animation: orb-selected-pulse 1.6s ease-in-out infinite;
+        animation: orb-selected-pulse 1.4s ease-in-out infinite;
       }
       /* orber#? — タイル生成中の skeleton shimmer。runBatch 開始と同時に
          12 個のプレースホルダを置いてグリッド形状を確定させ、wasm の

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -47,10 +47,10 @@ export const STRINGS = {
   shapeOptionCircle: { ja: '円', en: 'Circle' },
   shapeOptionGlyph: { ja: '文字', en: 'Glyph' },
   glyphCharLabel: { ja: '文字', en: 'Character' },
-  // 例示は ☆ だけだとユーザーが「☆ しか入らない」と誤解するため、
-  // 記号 / アルファベット / 矢印 / 雷 / 花 と幅広く例示する。Noto Sans Symbols 2
-  // に収録されている文字なら ASCII / 記号 / 一部絵文字も入る (収録外は警告表示)。
-  glyphCharPlaceholder: { ja: '例: ☆ A → ⚡ ✿', en: 'e.g., ☆ A → ⚡ ✿' },
+  // 自由入力欄であることを示すため "emoji" 1 単語。下のボタン群と同じ記号を
+  // 例示しても重複情報になるだけなので、ユーザーが「ボタンに無い文字も
+  // 入れられる」と気付けるよう emoji 表記にする (収録外なら警告表示)。
+  glyphCharPlaceholder: { ja: 'emoji', en: 'emoji' },
   glyphCharUnsupported: {
     ja: '同梱フォントに収録されていません',
     en: 'Not in bundled font',

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -126,23 +126,23 @@ export const STRINGS = {
     ja: 'バリエーション {n} (動画)',
     en: 'Variation {n} (animated)',
   },
-  // #128: Footer (GH Sponsors / Amazon affiliate / QR / Copyright / Counter)
-  sponsorLabel: { ja: 'GitHub で寄付', en: 'Sponsor on GitHub' },
-  sponsorTitle: {
-    ja: 'GitHub Sponsors で kako-jun を支援する',
-    en: 'Support kako-jun on GitHub Sponsors',
-  },
-  // User: 「Amazon と 2 回言う必要はない」「サイト維持のため購入を検討くださいみたいな
-  // 表現に」を反映。heading から (Amazon) を外し、disclosure を「サイト維持の支援」
-  // 前向き表現に。en は FTC 推奨テンプレ "As an Amazon Associate..." を残しつつ
-  // 「support orber」を頭に出す。
+  // #128 / #156: Footer (Amazon affiliate / QR / Copyright / Counter)。
+  // sponsorLabel / sponsorTitle は #156 で大きい GH Sponsors button を削除して
+  // 以来未使用 (テキストリンクは sponsorTextLabel 側) なので削除済み。
+  //
+  // affiliate 文言:
+  //   - User 「本やゲームは機材じゃない」「Amazon と 2 回言う必要はない」
+  //     「サイト維持のため、購入を検討くださいみたいな表現に」「文章が長くて改行されてしまう」
+  //   - heading: 「機材」だと書籍 / ゲームに合わないので「kako-jun のおすすめ」に
+  //   - disclosure: 1 行に収まる短さに圧縮。Amazon Associate の開示は維持
+  //     (en は FTC 推奨テンプレ、ja は短文 + Associate キーワードを残す)
   affiliateHeading: {
-    ja: 'おすすめ機材',
-    en: 'Recommended gear',
+    ja: 'kako-jun のおすすめ',
+    en: "kako-jun's picks",
   },
   affiliateDisclosure: {
-    ja: 'サイト維持のため、よければ購入をご検討ください。Amazon アソシエイトとして orber に還元されます。',
-    en: 'Buy via these links to support orber. As an Amazon Associate I earn from qualifying purchases.',
+    ja: '購入が orber 維持の支援になります (Amazon アソシエイト)',
+    en: 'As an Amazon Associate I earn from qualifying purchases.',
   },
   // #146: QR の補助コピー (qrLabel / "Open on phone") は廃止。alt のみ残す。
   qrAlt: {

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -132,13 +132,17 @@ export const STRINGS = {
     ja: 'GitHub Sponsors で kako-jun を支援する',
     en: 'Support kako-jun on GitHub Sponsors',
   },
+  // User: 「Amazon と 2 回言う必要はない」「サイト維持のため購入を検討くださいみたいな
+  // 表現に」を反映。heading から (Amazon) を外し、disclosure を「サイト維持の支援」
+  // 前向き表現に。en は FTC 推奨テンプレ "As an Amazon Associate..." を残しつつ
+  // 「support orber」を頭に出す。
   affiliateHeading: {
-    ja: 'おすすめ機材 (Amazon)',
-    en: 'Recommended gear (Amazon)',
+    ja: 'おすすめ機材',
+    en: 'Recommended gear',
   },
   affiliateDisclosure: {
-    ja: '※ Amazon アソシエイト・プログラムに参加しています。',
-    en: 'As an Amazon Associate this site earns from qualifying purchases.',
+    ja: 'サイト維持のため、よければ購入をご検討ください。Amazon アソシエイトとして orber に還元されます。',
+    en: 'Buy via these links to support orber. As an Amazon Associate I earn from qualifying purchases.',
   },
   // #146: QR の補助コピー (qrLabel / "Open on phone") は廃止。alt のみ残す。
   qrAlt: {


### PR DESCRIPTION
## 1. 透過版 alpha 経路を VP9 ガードから解放
**バグ**: 「透過版を含める」を ON にしても ZIP に透過版が含まれない (Safari / Edge 等で発生)

**原因**: `wantAlpha = includeAlpha() && vp9AlphaSupported()` で alpha 経路全体を VP9 alpha 対応ブラウザでだけ走らせていた。PNG / WebP 透過は VP9 と無関係なのに、VP9 検出が false な環境では一切出なかった。

**修正**: `wantAlpha = includeAlpha()` に変更。PNG/WebP 透過は checkbox ON で必ず走る。WebM 透過は `renderAlphaForIndices` 内 (line 915) で per-tile に `useWebCodecs && vp9AlphaSupported()` ガード継続。

## 2. Affiliate 文言修正
- heading: 「おすすめ機材」「Recommended gear」→ 「kako-jun のおすすめ」「kako-jun's picks」(書籍 / ゲームを含むラインアップに「機材」が合わないため)
- disclosure: 1 行に収まる短さに圧縮 (旧文は折り返されていた)
  - ja: 「購入が orber 維持の支援になります (Amazon アソシエイト)」
  - en: 「As an Amazon Associate I earn from qualifying purchases.」(FTC 推奨テンプレ)

## 3. 未使用キー削除
`sponsorLabel` / `sponsorTitle` は #156 で大きい GH Sponsors button を削除して以降、Footer のテキストリンクは `sponsorTextLabel` を使用しており dead code。削除。

## ビルド確認
`npm run build` 成功。