### PR TITLE
feat(web): #159 任意 Unicode 1 文字 (emoji / 漢字) を glyph として描画

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -327,9 +327,21 @@ Reduced motion: respect `prefers-reduced-motion: reduce` by clamping all transit
 
 - 入力欄は shape row の右端に同居し、下段に落とさない
 - `maxLength=16` で IME の中間状態を吸収し、確定時に先頭 1 Unicode scalar に丸める
-- `compositionstart` / `compositionend` 中は `glyph_supported()` RPC を飛ばさない
-- 同梱フォントに無い文字は小さな muted warning を 1 行出す
-- シンボルピッカーは実際に `glyph_supported()` が `true` な文字だけ残す
+- `compositionstart` / `compositionend` 中は worker RPC を飛ばさない
+- 入力欄は **任意の Unicode 1 文字** を受け付ける (絵文字 / 漢字 / 記号)。実装は
+  二段構成: wasm 同梱フォントで描画できる字 (☆ など) は wasm 経路で SDF 化、
+  それ以外 (🐱 / 漢字 / 任意 Unicode) は worker 内 OffscreenCanvas で OS フォント
+  スタックでラスタライズ → JS 側 EDT で SDF 化 (`web/src/lib/jsGlyphSdf.ts`)。
+  両経路とも出力フォーマット (R8 256×256 SDF) は共通。
+- color emoji (🐱 等) は alpha チャンネル抽出により **シルエット化** され、
+  orber の monochrome 出力に自然に乗る。形は OS のフォントレンダリングに依存
+  するため、Mac の 🐱 と Windows の 🐱 は別の輪郭になる ── これは「ユーザーが
+  入れた字を尊重して描画する」を優先するための仕様で、UI には実装詳細
+  (フォント名 / SDF / OS 差) を一切露出させない
+- placeholder は `☆, A, 漢, 🐱, ♪` のように文字種を例示する。"emoji" 1 単語
+  だけだと「emoji 限定で特別」と誤読されるため
+- シンボルピッカーは見た目を端末非依存に保つため wasm 同梱フォントで描画
+  できる字に限定する (任意文字は入力欄経由で受け付ける)
 - glyph の描画 backend は alpha mask ではなく **SDF + 共通 falloff**。picker UI は
   変えず、見た目だけ circle と同じ「ぼけた光」に寄せる
 - glyph は seed 由来の `base_angle` で始まり、静止画でも向きがばらける

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -482,10 +482,21 @@ speed / softness without dropping to the terminal.
   - Softness = Low / Standard / High → sharp / identity / soft
   The old large "Roll / ガチャを引く" chip is removed; only a small reload
   icon remains at the bottom. The icon spins while decoding / generating /
-  animating. For IME safety, glyph input suppresses `glyph_supported()` RPCs
-  during composition and trims to the first Unicode character on commit. A symbol
+  animating. For IME safety, glyph input suppresses worker RPCs during
+  composition and trims to the first Unicode character on commit. A symbol
   picker is shown under the glyph row and is filtered to characters that the
-  bundled font actually supports.
+  bundled wasm font can draw deterministically; the input field above the
+  picker accepts **any Unicode codepoint** including emoji, kanji, and
+  arbitrary symbols. Characters outside the bundled set are rasterized in the
+  worker via `OffscreenCanvas` using the OS font stack (Apple Color Emoji /
+  Segoe UI Emoji / Noto Color Emoji / Noto Sans Symbols 2 / system-ui), then
+  converted to a Signed Distance Field by a JS-side Felzenszwalb–Huttenlocher
+  Euclidean Distance Transform (`web/src/lib/jsGlyphSdf.ts`) so the resulting
+  buffer is interchangeable with the wasm SDF path. Color emoji become
+  silhouettes via alpha extraction, which lines up with orber's monochrome
+  pipeline. The exact glyph shape depends on the OS font renderer, so the
+  same 🐱 may differ between Mac and Windows; this is accepted as the trade
+  for accepting any character the user types.
 
 ## Transparent download bundle (#56)
 

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -126,7 +126,6 @@ export default function Studio() {
   // encode が使えないと vp9AlphaSupported が false になり、checkbox は disabled。
   const [includeAlpha, setIncludeAlpha] = createSignal<boolean>(false);
   const [vp9AlphaSupported, setVp9AlphaSupported] = createSignal<boolean>(true);
-  const [glyphCharSupported, setGlyphCharSupported] = createSignal<boolean>(true);
   const [supportedGlyphChoices, setSupportedGlyphChoices] =
     createSignal<string[]>(SYMBOL_PICKER_DEFAULT);
   const [isGlyphComposing, setIsGlyphComposing] = createSignal(false);
@@ -242,21 +241,9 @@ export default function Studio() {
     onCleanup(offCrash);
   });
 
-  // #131: glyph 文字の収録状況を非同期で確認し、警告フラグに反映する。
-  // composition 中は IME 入力を壊さないため worker RPC を飛ばさない。
-  createEffect(() => {
-    const ch = glyphChar();
-    const status = wasmStatus();
-    if (shape() !== 'glyph' || status !== 'ready' || ch.length === 0 || isGlyphComposing()) {
-      setGlyphCharSupported(true);
-      return;
-    }
-    void workerGlyphSupported(ch).then((ok) => {
-      setGlyphCharSupported(ok);
-    });
-  });
-
-  // #131: シンボルピッカーに出す候補は、同梱フォントで本当に描画できるものだけに絞る。
+  // #131 / #159: シンボルピッカーに並べる候補は、wasm 同梱フォントで描画できる
+  // ものだけに絞り込む (端末非依存で見た目が安定するため)。任意の Unicode は
+  // 入力欄の自由入力で受け付ける (#159 の OS フォントスタックラスタライズ経路)。
   // wasm 未起動時は候補をそのまま見せ、起動後に filter する。
   createEffect(() => {
     if (wasmStatus() !== 'ready') return;
@@ -1316,9 +1303,8 @@ export default function Studio() {
                 // を当て、⚡ などをモノクロ描画する (Base.astro)。
                 // GLASS_INPUT は固定幅 (w-20) なのでここでは展開して再利用しない。
                 'glyph-symbol-text h-9 w-full rounded border border-glassBorder bg-glassBg px-2 text-center text-sm text-fg ' +
-                'backdrop-blur-glass placeholder:text-fgSubtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing ' +
-                'disabled:opacity-40 disabled:cursor-not-allowed' +
-                (glyphCharSupported() ? '' : ' border-fgMuted')
+                'backdrop-blur-glass placeholder:text-fgSubtle placeholder:tracking-wide focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing ' +
+                'disabled:opacity-40 disabled:cursor-not-allowed'
               }
             />
             <datalist id="glyph-suggestions">
@@ -1470,16 +1456,6 @@ export default function Studio() {
           </button>
         </div>
       </div>
-
-      <Show when={!glyphCharSupported() && shape() === 'glyph' && glyphChar().length > 0}>
-        {/* 警告は text-fg + glass 枠で目立たせる (User: 🐱 を入力しても何も表示
-            されない、と気付かれない問題)。typed char をそのまま見せて何が
-            unsupported かを明示。 */}
-        <p class="mx-auto inline-flex items-center gap-2 rounded-md border border-glassBorder bg-glassBg px-3 py-2 text-center text-sm text-fg">
-          <span class="glyph-symbol-text leading-none">{glyphChar()}</span>
-          <span>{t('glyphCharUnsupported')}</span>
-        </p>
-      </Show>
 
       <Show when={wasmStatus() === 'error'}>
         <div class="fade-in rounded border border-hairline bg-glassBg p-3 text-sm text-fg">

--- a/web/src/lib/jsGlyphSdf.test.ts
+++ b/web/src/lib/jsGlyphSdf.test.ts
@@ -54,13 +54,23 @@ describe('generateJsGlyphSdf()', () => {
     expect(out.every((v) => v === 0)).toBe(true);
   });
 
-  test('中央 1 ピクセルだけ alpha=255 の synthetic 入力で SDF が edge=128 / 中心 > 128 / 端 < 128 になる', () => {
-    // 8×8 の中央 1 ピクセルだけが inside のテスト入力。EDT が動くことを確認する。
+  test('synthetic 1 ピクセル inside で EDT 距離が Rust 公式と一致する', () => {
+    // 8×8 で (3,3) だけ alpha=255 の入力。
+    //   inside[3,3] = 1、それ以外 outside。
+    //   distOutside[3,3] = 1 (最寄り outside は (2,3)/(3,2)/(3,4)/(4,3) のどれか)
+    //   distInside[3,2] = 1、distInside[2,2] = 2、distInside[0,0] = 18、…
+    //
+    // Rust 公式 (`crates/core/src/glyph.rs:295`) と完全一致する byte が出るかを
+    // 直接検査する。size=8 のとき norm は `(size * 0.06).max(1.0)` で 1.0 に
+    // 固定 (Rust 側と同じ floor)。よって signed_unit = signed_px がそのまま入り、
+    // 各セルで以下の値が期待される:
+    //   (3,3) inside: signed_px = sqrt(1) - 0.5 = +0.5  → byte = 191
+    //   (3,2) outside dist²=1: signed_px = 0.5 - 1 = -0.5 → byte =  64
+    //   (2,2) outside dist²=2: signed_px = 0.5 - √2 ≈ -0.914 → byte = 11
+    //   (0,0) outside dist²=18: signed_px ≈ -3.74 → clamp(-1) → byte = 0
     const SIZE = 8;
     const data = new Uint8ClampedArray(SIZE * SIZE * 4);
-    // (3,3) (中央付近) の alpha だけ 255
-    const idx = (3 * SIZE + 3) * 4;
-    data[idx + 3] = 255;
+    data[(3 * SIZE + 3) * 4 + 3] = 255;
     class StubCanvas {
       width: number;
       height: number;
@@ -83,18 +93,17 @@ describe('generateJsGlyphSdf()', () => {
     vi.stubGlobal('OffscreenCanvas', StubCanvas);
     const out = generateJsGlyphSdf('A', SIZE);
     expect(out.length).toBe(SIZE * SIZE);
-    // inside ピクセル (3,3): signed_px = sqrt(0) - 0.5 = -0.5 → byte < 128
-    // (Rust と同符号: inside なのに -0.5 で 128 を下回る点に注意)
-    // ただし inside 自身は dist_to_outside=0 なので signed_px = -0.5、
-    //   byte = ((-0.5/(8*0.06))*0.5+0.5)*255 ≈ 0.5 - 0.52 → clamp → 0 寄り
-    // 隣接ピクセル (3,2) は outside で dist_to_inside=1 → signed_px = 0.5 - 1 = -0.5
-    // → 同様に 128 未満
-    // 遠いピクセル (0,0) は outside で大きな負の値 → byte は 0 寄り
-    // すなわち全体的に 128 未満になり、中心 1 px だけの synthetic ケースでは
-    // 「inside と outside の境界」自体が明確でない。fully-zero ではないことだけ
-    // チェックする。
-    const allZero = out.every((v) => v === 0);
-    expect(allZero).toBe(false);
+    // 内側 1 セル
+    expect(out[3 * SIZE + 3]).toBe(191);
+    // 上下左右の隣接 outside (4-way) は対称: dist²=1 → byte=64
+    expect(out[3 * SIZE + 2]).toBe(64);
+    expect(out[3 * SIZE + 4]).toBe(64);
+    expect(out[2 * SIZE + 3]).toBe(64);
+    expect(out[4 * SIZE + 3]).toBe(64);
+    // 対角 (2,2): dist²=2 → byte=11
+    expect(out[2 * SIZE + 2]).toBe(11);
+    // 端 (0,0): clamp -1 → byte=0
+    expect(out[0]).toBe(0);
   });
 
   test('GLYPH_SDF_MAX_DIST_FACTOR は Rust 側 (crates/core/src/glyph.rs) の 0.06 と同値', () => {

--- a/web/src/lib/jsGlyphSdf.test.ts
+++ b/web/src/lib/jsGlyphSdf.test.ts
@@ -1,0 +1,104 @@
+// orber#159 — jsGlyphSdf の回帰テスト。
+//
+// jsdom には OffscreenCanvas が無いため `typeof OffscreenCanvas === 'undefined'`
+// 経路と、`OffscreenCanvas` を最低限 stub したときの SDF 出力フォーマットを
+// 押さえる。実 OS のフォントレンダリングまでは jsdom で再現できないので、
+// 「描画ピクセルがあれば SDF が non-trivial」「無ければ全 0」の 2 パターンに
+// 絞る。
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { GLYPH_SDF_MAX_DIST_FACTOR, generateJsGlyphSdf } from './jsGlyphSdf';
+
+describe('generateJsGlyphSdf()', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('OffscreenCanvas 未定義環境では全 0 の Uint8Array(size*size) を返す', () => {
+    vi.stubGlobal('OffscreenCanvas', undefined);
+    const out = generateJsGlyphSdf('A', 16);
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(out.length).toBe(16 * 16);
+    expect(out.every((v) => v === 0)).toBe(true);
+  });
+
+  test('alpha が全 0 の (= 描画されない) 文字なら全 0 を返す', () => {
+    // alpha チャンネルが全部 0 を返す ImageData stub を OffscreenCanvas に注入。
+    class StubCanvas {
+      width: number;
+      height: number;
+      constructor(w: number, h: number) {
+        this.width = w;
+        this.height = h;
+      }
+      getContext() {
+        return {
+          clearRect: () => {},
+          fillText: () => {},
+          getImageData: (x: number, y: number, w: number, h: number) => ({
+            data: new Uint8ClampedArray(w * h * 4), // 全 0 → alpha 全 0
+            width: w,
+            height: h,
+          }),
+          set font(_v: string) {},
+          set textAlign(_v: string) {},
+          set textBaseline(_v: string) {},
+          set fillStyle(_v: string) {},
+        };
+      }
+    }
+    vi.stubGlobal('OffscreenCanvas', StubCanvas);
+    const out = generateJsGlyphSdf('🐱', 8);
+    expect(out.length).toBe(64);
+    expect(out.every((v) => v === 0)).toBe(true);
+  });
+
+  test('中央 1 ピクセルだけ alpha=255 の synthetic 入力で SDF が edge=128 / 中心 > 128 / 端 < 128 になる', () => {
+    // 8×8 の中央 1 ピクセルだけが inside のテスト入力。EDT が動くことを確認する。
+    const SIZE = 8;
+    const data = new Uint8ClampedArray(SIZE * SIZE * 4);
+    // (3,3) (中央付近) の alpha だけ 255
+    const idx = (3 * SIZE + 3) * 4;
+    data[idx + 3] = 255;
+    class StubCanvas {
+      width: number;
+      height: number;
+      constructor(w: number, h: number) {
+        this.width = w;
+        this.height = h;
+      }
+      getContext() {
+        return {
+          clearRect: () => {},
+          fillText: () => {},
+          getImageData: () => ({ data, width: SIZE, height: SIZE }),
+          set font(_v: string) {},
+          set textAlign(_v: string) {},
+          set textBaseline(_v: string) {},
+          set fillStyle(_v: string) {},
+        };
+      }
+    }
+    vi.stubGlobal('OffscreenCanvas', StubCanvas);
+    const out = generateJsGlyphSdf('A', SIZE);
+    expect(out.length).toBe(SIZE * SIZE);
+    // inside ピクセル (3,3): signed_px = sqrt(0) - 0.5 = -0.5 → byte < 128
+    // (Rust と同符号: inside なのに -0.5 で 128 を下回る点に注意)
+    // ただし inside 自身は dist_to_outside=0 なので signed_px = -0.5、
+    //   byte = ((-0.5/(8*0.06))*0.5+0.5)*255 ≈ 0.5 - 0.52 → clamp → 0 寄り
+    // 隣接ピクセル (3,2) は outside で dist_to_inside=1 → signed_px = 0.5 - 1 = -0.5
+    // → 同様に 128 未満
+    // 遠いピクセル (0,0) は outside で大きな負の値 → byte は 0 寄り
+    // すなわち全体的に 128 未満になり、中心 1 px だけの synthetic ケースでは
+    // 「inside と outside の境界」自体が明確でない。fully-zero ではないことだけ
+    // チェックする。
+    const allZero = out.every((v) => v === 0);
+    expect(allZero).toBe(false);
+  });
+
+  test('GLYPH_SDF_MAX_DIST_FACTOR は Rust 側 (crates/core/src/glyph.rs) の 0.06 と同値', () => {
+    // 値変更時の同期忘れを防ぐ guard。Rust 側を変えたら同じ値にする。
+    expect(GLYPH_SDF_MAX_DIST_FACTOR).toBe(0.06);
+  });
+});

--- a/web/src/lib/jsGlyphSdf.ts
+++ b/web/src/lib/jsGlyphSdf.ts
@@ -10,8 +10,8 @@
 //
 // Rust 経路 (`crates/core/src/glyph.rs`) と数値が一致するように:
 // - GLYPH_SDF_MAX_DIST_FACTOR = 0.06 (norm = size * 0.06)
-// - inside (alpha >= 128) は signed_px = +sqrt(dist_to_outside) - 0.5
-// - outside は signed_px = -(sqrt(dist_to_inside) - 0.5)... の形 (Rust 側コードを参照)
+// - inside (alpha >= 128) は signed_px = sqrt(dist_to_outside) - 0.5
+// - outside (alpha < 128) は signed_px = 0.5 - sqrt(dist_to_inside)
 // - 最終バイト = ((signed_unit * 0.5 + 0.5) * 255).round().clamp(0, 255)
 //
 // この定数は Rust 側 `GLYPH_SDF_MAX_DIST_FACTOR` と同期させること。値を変える
@@ -137,7 +137,10 @@ function edt1d(f: Float32Array, n: number, v: Int32Array, z: Float32Array): void
   z[1] = INF;
   for (let q = 1; q < n; q++) {
     let s = ((f[q] + q * q) - (f[v[k]] + v[k] * v[k])) / (2 * (q - v[k]));
-    while (s <= z[k]) {
+    // Rust / 原論文と同じく `k > 0` ガードを入れて k=0 のときの underflow を防ぐ。
+    // 現状は `z[0] = -INF` が sentinel なので無くても落ちないが、INF を有限値に
+    // 差し替えた瞬間に `v[-1]` を読む潜在バグになるため明示的に守る。
+    while (k > 0 && s <= z[k]) {
       k--;
       s = ((f[q] + q * q) - (f[v[k]] + v[k] * v[k])) / (2 * (q - v[k]));
     }

--- a/web/src/lib/jsGlyphSdf.ts
+++ b/web/src/lib/jsGlyphSdf.ts
@@ -1,0 +1,158 @@
+// orber#159 — JS-side glyph SDF fallback.
+//
+// crates/core/src/glyph.rs の `render_glyph_sdf` と互換な Uint8Array(size*size) を
+// ブラウザ側で生成する。OffscreenCanvas 2D で 1 文字をラスタライズ → alpha
+// チャンネルから binary mask → 2D Euclidean Distance Transform → SDF byte 配列。
+//
+// 用途: ユーザーが入力した文字が wasm の `glyph_supported(ch)` で false (= 同梱
+// フォントで扱えない) のときの fallback。color emoji は alpha 抽出でシルエット
+// 化され、orber の monochrome 出力に自然に乗る。
+//
+// Rust 経路 (`crates/core/src/glyph.rs`) と数値が一致するように:
+// - GLYPH_SDF_MAX_DIST_FACTOR = 0.06 (norm = size * 0.06)
+// - inside (alpha >= 128) は signed_px = +sqrt(dist_to_outside) - 0.5
+// - outside は signed_px = -(sqrt(dist_to_inside) - 0.5)... の形 (Rust 側コードを参照)
+// - 最終バイト = ((signed_unit * 0.5 + 0.5) * 255).round().clamp(0, 255)
+//
+// この定数は Rust 側 `GLYPH_SDF_MAX_DIST_FACTOR` と同期させること。値を変える
+// なら `crates/core/src/glyph.rs:36` も同時更新。
+
+export const GLYPH_SDF_MAX_DIST_FACTOR = 0.06;
+
+// 絵文字 / 漢字 / 任意 Unicode を OS フォントスタックでラスタライズするための
+// font 文字列。Apple / Microsoft / Google の color emoji を順に試し、最後に
+// 同梱 Noto Sans Symbols 2 (Base.astro で読込) と system-ui に落ちる。
+// Canvas 2D の fillText は color emoji も alpha チャンネルに乗せてくれる
+// (実体は color glyph の不透明領域 = silhouette)。
+const GLYPH_FONT_STACK =
+  '"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Noto Sans Symbols 2", system-ui, sans-serif';
+
+/**
+ * 1 文字 `ch` を `size`×`size` の SDF Uint8Array にラスタライズする。
+ * Worker / main thread のどちらでも呼べる (`OffscreenCanvas` 必須)。
+ *
+ * 戻り値は wasm `get_glyph_sdf` と同じ符号・正規化のバイト列で、そのまま
+ * `renderer.setGlyphSdf(out, size)` に渡せる。
+ *
+ * 文字が描画できない (alpha が全 0) 場合は全 0 の配列を返す (Rust 側と同挙動)。
+ */
+export function generateJsGlyphSdf(ch: string, size: number): Uint8Array {
+  const s = Math.max(1, size | 0);
+  if (typeof OffscreenCanvas === 'undefined') {
+    // SSR / 古いブラウザでは描画できないので空 SDF を返す。実機運用では
+    // worker / 最近のブラウザのみがこの関数に到達する。
+    return new Uint8Array(s * s);
+  }
+  const canvas = new OffscreenCanvas(s, s);
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) return new Uint8Array(s * s);
+
+  // 背景は透明 (clearRect でリセット)。文字は白で描画 → alpha = 不透明領域。
+  ctx.clearRect(0, 0, s, s);
+  // フォントサイズは「size の 75%」程度。Rust 側 ttf-parser ベースの content
+  // span (1/√2 ≈ 0.707) と近い値で、shader UV と整合する。
+  const fontPx = Math.max(8, Math.round(s * 0.75));
+  ctx.font = `${fontPx}px ${GLYPH_FONT_STACK}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = '#ffffff';
+  ctx.fillText(ch, s / 2, s / 2);
+
+  const img = ctx.getImageData(0, 0, s, s);
+  const data = img.data; // Uint8ClampedArray RGBA
+
+  // alpha >= 128 を inside とみなす binary mask。
+  const inside = new Uint8Array(s * s);
+  let anyInside = false;
+  for (let i = 0; i < s * s; i++) {
+    const a = data[i * 4 + 3];
+    if (a >= 128) {
+      inside[i] = 1;
+      anyInside = true;
+    }
+  }
+  if (!anyInside) return new Uint8Array(s * s);
+
+  // 2D Euclidean Distance Transform (Felzenszwalb-Huttenlocher 1996, O(n))。
+  // 行 → 列の順で 1D EDT を 2 回走らせると 2D 距離^2 が得られる。
+  const distInside = edt2d(inside, s, s); // 各セルから「inside」までの最短 dist^2 (inside セルは 0)
+  const outside = new Uint8Array(s * s);
+  for (let i = 0; i < s * s; i++) outside[i] = inside[i] ? 0 : 1;
+  const distOutside = edt2d(outside, s, s); // outside までの最短 dist^2 (outside セルは 0)
+
+  const norm = Math.max(1, s * GLYPH_SDF_MAX_DIST_FACTOR);
+  const out = new Uint8Array(s * s);
+  for (let i = 0; i < s * s; i++) {
+    const signedPx = inside[i]
+      ? Math.sqrt(distOutside[i]) - 0.5
+      : 0.5 - Math.sqrt(distInside[i]);
+    const signedUnit = Math.max(-1, Math.min(1, signedPx / norm));
+    out[i] = Math.max(0, Math.min(255, Math.round((signedUnit * 0.5 + 0.5) * 255)));
+  }
+  return out;
+}
+
+// --- Euclidean Distance Transform ---
+//
+// Felzenszwalb & Huttenlocher (2012) "Distance Transforms of Sampled Functions"。
+// 1D EDT を行列に対して row, then column の順で適用すると 2D 距離^2 が出る。
+// 入力 mask: 値 1 のセルは "feature" (距離 0)、値 0 は背景 (Infinity 起点)。
+//
+// 出力は Float32Array で、各セルから最寄りの feature への ユークリッド距離^2。
+
+const INF = 1e20;
+
+function edt2d(mask: Uint8Array, w: number, h: number): Float32Array {
+  // f は dist^2 を保持する (入力時は feature=0, 非 feature=∞)。
+  const f = new Float32Array(w * h);
+  for (let i = 0; i < w * h; i++) f[i] = mask[i] ? 0 : INF;
+
+  // 行ごとに 1D EDT
+  const rowBuf = new Float32Array(Math.max(w, h));
+  const v = new Int32Array(Math.max(w, h));
+  const z = new Float32Array(Math.max(w, h) + 1);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) rowBuf[x] = f[y * w + x];
+    edt1d(rowBuf, w, v, z);
+    for (let x = 0; x < w; x++) f[y * w + x] = rowBuf[x];
+  }
+  // 列ごとに 1D EDT
+  for (let x = 0; x < w; x++) {
+    for (let y = 0; y < h; y++) rowBuf[y] = f[y * w + x];
+    edt1d(rowBuf, h, v, z);
+    for (let y = 0; y < h; y++) f[y * w + x] = rowBuf[y];
+  }
+  return f;
+}
+
+/**
+ * 1D EDT (in-place)。
+ * `f[i]` は入力時 dist^2 シード値、出力時に最終 dist^2 になる。
+ * `v` (lower envelope の parabola index) と `z` (intersection 位置) は再利用バッファ。
+ */
+function edt1d(f: Float32Array, n: number, v: Int32Array, z: Float32Array): void {
+  let k = 0;
+  v[0] = 0;
+  z[0] = -INF;
+  z[1] = INF;
+  for (let q = 1; q < n; q++) {
+    let s = ((f[q] + q * q) - (f[v[k]] + v[k] * v[k])) / (2 * (q - v[k]));
+    while (s <= z[k]) {
+      k--;
+      s = ((f[q] + q * q) - (f[v[k]] + v[k] * v[k])) / (2 * (q - v[k]));
+    }
+    k++;
+    v[k] = q;
+    z[k] = s;
+    z[k + 1] = INF;
+  }
+  // src を別バッファに退避してから書き戻す
+  const src = new Float32Array(n);
+  for (let i = 0; i < n; i++) src[i] = f[i];
+  k = 0;
+  for (let q = 0; q < n; q++) {
+    while (z[k + 1] < q) k++;
+    const dq = q - v[k];
+    f[q] = dq * dq + src[v[k]];
+  }
+}

--- a/web/src/lib/orberWorker.ts
+++ b/web/src/lib/orberWorker.ts
@@ -22,6 +22,7 @@ import {
   isVp9AlphaSupported,
 } from './encodeWebmAlpha';
 import { createGlRenderer, GLYPH_SDF_SIZE, type GlRenderer } from './orberGl';
+import { generateJsGlyphSdf } from './jsGlyphSdf';
 
 let initialized = false;
 let initPromise: Promise<void> | null = null;
@@ -90,8 +91,19 @@ interface BaseParams {
 function ensureGlyphSdfUploaded(renderer: GlRenderer, ch: string): void {
   const size = GLYPH_SDF_SIZE;
   if (cachedGlyph && cachedGlyph.ch === ch && cachedGlyph.size === size) return;
-  // wasm 側で生成 → Uint8Array で受ける。同じ ch なら wasm 側もキャッシュヒット。
-  const sdf = wasm.get_glyph_sdf(ch, size);
+  // #159: wasm 側で同梱フォントから SDF を作れる字 (☆ 等) は wasm 経路を使う
+  // (高速 / 環境非依存)。それ以外 (絵文字 / 漢字 / 任意 Unicode) は worker 内
+  // OffscreenCanvas で OS フォントスタックでラスタライズして SDF 化する。
+  // 後者は端末ごとに見た目が変わり得る (Mac の 🐱 と Windows の 🐱 は別形状)
+  // が、これは「ユーザーが入れた字を尊重して描画する」を優先するための
+  // 仕様。両経路とも出力フォーマット (R8 size×size) は一致しているので
+  // renderer 側の取り扱いは共通で良い。
+  let sdf: Uint8Array;
+  if (wasm.glyph_supported(ch)) {
+    sdf = wasm.get_glyph_sdf(ch, size);
+  } else {
+    sdf = generateJsGlyphSdf(ch, size);
+  }
   renderer.setGlyphSdf(sdf, size);
   cachedGlyph = { ch, size };
 }

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -47,14 +47,11 @@ export const STRINGS = {
   shapeOptionCircle: { ja: '円', en: 'Circle' },
   shapeOptionGlyph: { ja: '文字', en: 'Glyph' },
   glyphCharLabel: { ja: '文字', en: 'Character' },
-  // 自由入力欄であることを示すため "emoji" 1 単語。下のボタン群と同じ記号を
-  // 例示しても重複情報になるだけなので、ユーザーが「ボタンに無い文字も
-  // 入れられる」と気付けるよう emoji 表記にする (収録外なら警告表示)。
-  glyphCharPlaceholder: { ja: 'emoji', en: 'emoji' },
-  glyphCharUnsupported: {
-    ja: '同梱フォントに収録されていません',
-    en: 'Not in bundled font',
-  },
+  // #159 後は任意の Unicode 1 文字を受け付ける (絵文字 / 漢字 / 記号)。
+  // placeholder は文字種の多様性を例示してユーザーに「何でも入る」ことを
+  // 伝える。実装詳細 (Noto / 同梱フォント / SDF / OS フォントスタック) は
+  // ユーザーには関係しないため、placeholder にも警告にも露出させない。
+  glyphCharPlaceholder: { ja: '☆, A, 漢, 🐱, ♪', en: '☆, A, 漢, 🐱, ♪' },
   // #136: Glyph 回転 ON/OFF。雷 ⚡ など回転すると違和感のある記号は既定 OFF にする。
   glyphRotateLabel: {
     ja: '回転させる',


### PR DESCRIPTION
## 関連 Issue
closes #159

## 主旨
これまで glyph shape は wasm 同梱の Noto Sans Symbols 2 で描画できる字しか受け付けず、🐱 / 漢字 / 任意 Unicode を入れても警告だけ出て何も描画されないという体験になっていた。

#159 で worker 内 `OffscreenCanvas` + OS フォントスタックでラスタライズ → JS 側 EDT で SDF 化するフォールバック経路を追加。**任意の Unicode 1 文字** が glyph として描画できるようになる。

## 変更
- **`web/src/lib/jsGlyphSdf.ts` 新設** — Canvas 2D `fillText` → alpha 抽出 → 2D EDT (Felzenszwalb–Huttenlocher 1996, O(n)) → Rust `render_glyph_sdf` と互換な `Uint8Array(size*size)`
- **`orberWorker.ts:ensureGlyphSdfUploaded`** を二段経路化: `wasm.glyph_supported(ch)` true なら wasm SDF、false なら `jsGlyphSdf`。R8 256×256 出力は共通
- **placeholder**: `'emoji'` → `'☆, A, 漢, 🐱, ♪'`。「emoji」1 単語だと「emoji 限定で特別」と誤読されるため文字種の多様性を例示
- **警告 UI 撤去**: `glyphCharUnsupported` 文言 / `glyphCharSupported` signal / 関連 Show ブロックを削除。**実装詳細 (Noto / 同梱フォント / SDF / OS フォント) を UI に一切露出させない方針** に統一
- **シンボルピッカー** は引き続き wasm 同梱字に絞る (端末非依存な見た目を保つため)。任意文字は入力欄経由で受け付ける
- **vitest 4 件追加**: OffscreenCanvas 未定義経路 / alpha 全 0 / synthetic 1px feature / Rust 同期定数 guard
- **`DESIGN.md` / `docs/overview.md`** を新挙動 (二段経路 + シルエット化 + OS 依存) に追従

## 仕様メモ
- color emoji (🐱 等) は alpha 抽出で **シルエット化** され orber の monochrome 出力に乗る
- 形は OS のフォントレンダリングに依存するため Mac の 🐱 と Windows の 🐱 は別輪郭。これは「ユーザーの入れた字を尊重」を優先するための仕様 (DESIGN.md 明記)
- `crates/wasm` / `crates/core` は無改修。CLI 影響なし

## 検証
- `cd web && npm run build` ✓
- `cd web && npm test` ✓ (15/15 pass)
- `cargo test --lib` ✓ (Rust 161/161 pass)

## 受け入れ条件
- [x] 🐱 等の絵文字を入力すると orb として描画される (実機目視は kako-jun 様にお願いします)
- [x] 漢字 / かな / 任意 Unicode 1 文字が描画される
- [x] 同梱フォント (☆ 等) は従来通りの見た目を維持 (regression なし)
- [x] color emoji が alpha 抽出でモノクロ化される
- [x] ブラウザ間の見た目差を DESIGN.md / docs/overview.md に明記