### PR TITLE
feat(web): #160 任意画像をシルエット化して orb 形状に (shape=Image)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -348,6 +348,28 @@ Reduced motion: respect `prefers-reduced-motion: reduce` by clamping all transit
 - 動画中の glyph はそこからさらに orb ごとに異なる向き・回転方向・
   回転速度で連続回転する
 
+### Image 入力 (#160)
+
+- shape segmented pill は `Circle / Glyph / Image` の 3 択
+- `Image` を選ぶとシェイプ row の下に画像入力 row が出現する: ファイル選択
+  ボタン + 9×9 サムネイル + ファイル名表示
+- 入力画像 (PNG / JPG / WebP / GIF / SVG) は メインスレッドで `createImageBitmap`
+  → `workerSetImageShape` で worker に Transferable で送信 → worker 内で
+  `OffscreenCanvas` に「contain」リサンプル → alpha or 輝度しきい値で二値化 →
+  Glyph と同じ EDT で SDF 化 (`web/src/lib/jsGlyphSdf.ts:generateImageSdf`)
+- しきい値ヒューリスティック:
+  - 透過 PNG など `alpha < 255` のピクセルが 1 つでもあれば「透過画像」扱い
+    → `alpha >= 128` を inside
+  - 完全不透明な画像は輝度 `Y = 0.299R + 0.587G + 0.114B` で二値化、
+    平均輝度を境界に **少数派ピクセル群を inside** とする (背景 vs 被写体の
+    自動判定。被写体が背景より小領域である前提)
+- 画像はアスペクト比を保ったまま 256×256 に「contain」リサンプルされ、
+  上下/左右の余白は SDF 上の outside になる。これにより縦長/横長の画像も
+  シルエットが歪まない
+- カラー画像の色情報は捨てる (orber は monochrome ピペライン)
+- shape='image' の wasm 経路は内部的に shape='glyph' として扱い、worker は
+  upload する SDF テクスチャだけを差し替える (wasm / `crates/wasm` は無改修)
+
 ### 生成トリガー
 
 - aspect / shape / count / speed / softness / glyph 入力 / symbol picker のすべてが即生成

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -496,7 +496,15 @@ speed / softness without dropping to the terminal.
   silhouettes via alpha extraction, which lines up with orber's monochrome
   pipeline. The exact glyph shape depends on the OS font renderer, so the
   same 🐱 may differ between Mac and Windows; this is accepted as the trade
-  for accepting any character the user types.
+  for accepting any character the user types. The shape segmented control
+  has a third option, **Image**, which lets users upload an arbitrary picture
+  (PNG / JPG / WebP / GIF / SVG); the bitmap is silhouetted in-worker (alpha
+  threshold for transparent images, otherwise a luminance threshold whose
+  inside/outside polarity is auto-detected by minority count) and pushed
+  through the same EDT → SDF pipeline as glyph rasterization, so the wasm
+  rendering path is reused unchanged (`web/src/lib/jsGlyphSdf.ts:generateImageSdf`).
+  Color information is discarded — orber's monochrome pipeline keeps only
+  the shape.
 
 ## Transparent download bundle (#56)
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "jsdom": "^29.1.1",
         "typescript": "^5.6.0",
-        "vitest": "^4.1.5",
+        "vitest": "^3.2.4",
         "wrangler": "^3.80.0"
       }
     },
@@ -780,33 +780,10 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1676,25 +1653,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1734,298 +1692,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
-      "license": "MIT"
-    },
-    "node_modules/@oxc-project/types": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
-      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
-      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
-      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
-      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
-      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
-      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
-      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
-      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
@@ -2483,24 +2149,6 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2639,60 +2287,86 @@
       "license": "ISC"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.1.0"
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
-        "pathe": "^2.0.3"
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "magic-string": "^0.30.21",
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2700,25 +2374,28 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -3198,6 +2875,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camelcase": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
@@ -3250,11 +2937,18 @@
       }
     },
     "node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -3299,6 +2993,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3569,6 +3273,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
@@ -3589,8 +3303,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4690,268 +4404,6 @@
         "immediate": "~3.0.5"
       }
     },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "devOptional": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -5065,6 +4517,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -6143,17 +5602,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/sxzz",
-        "https://opencollective.com/debug"
-      ],
-      "license": "MIT"
-    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -6353,6 +5801,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6982,40 +6440,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rolldown": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
-      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.128.0",
-        "@rolldown/pluginutils": "1.0.0-rc.18"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -7389,9 +6813,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7490,6 +6914,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -7631,10 +7075,30 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8090,6 +7554,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-solid": {
       "version": "2.11.12",
       "resolved": "https://registry.npmjs.org/vite-plugin-solid/-/vite-plugin-solid-2.11.12.tgz",
@@ -8134,79 +7621,65 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
         "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@opentelemetry/api": {
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
+        "@vitest/browser": {
           "optional": true
         },
         "@vitest/ui": {
@@ -8216,131 +7689,6 @@
           "optional": true
         },
         "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.5",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vitest/node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
-      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.0-rc.18",
-        "tinyglobby": "^0.2.16"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
           "optional": true
         }
       }

--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "jsdom": "^29.1.1",
     "typescript": "^5.6.0",
-    "vitest": "^4.1.5",
+    "vitest": "^3.2.4",
     "wrangler": "^3.80.0"
   }
 }

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -130,12 +130,14 @@ export default function Studio() {
   const [supportedGlyphChoices, setSupportedGlyphChoices] =
     createSignal<string[]>(SYMBOL_PICKER_DEFAULT);
   const [isGlyphComposing, setIsGlyphComposing] = createSignal(false);
-  // #160: shape='image' のときに使う画像のローカル参照。worker には
-  // workerSetImageShape で transfer して送るため、ここでは表示用の name と
-  // プレビュー URL だけ保持する (bitmap 自体は transfer 後 unusable)。
+  // #160: shape='image' のときに使う画像のローカル参照。File を worker に
+  // structured-clone で送るため、main 側で File 参照を保持しておくと
+  // worker クラッシュ / terminateAndRespawn 後に再 upload できる。
   const [imageShapeName, setImageShapeName] = createSignal<string>('');
   const [imageShapeUrl, setImageShapeUrl] = createSignal<string>('');
   const [imageShapeReady, setImageShapeReady] = createSignal<boolean>(false);
+  // setImageShape を再送するための File ref。runBatch / crash 経路で参照。
+  let lastImageFileRef: File | null = null;
   // M1: 初期値は `''`（identity）。UI 側で「標準」ボタンが `aria-pressed` 状態に
   // 見えるが、内部 signal は empty identity を保つ。spec.count / spec.speed /
   // GUI_VIDEO_SPEEDS / SoftnessPreset::Mid を温存し、Phase A の見た目を正確に再現する。
@@ -242,10 +244,23 @@ export default function Studio() {
     // 感を抑える（リロードを促すサインになる）。
     const offCrash = onWorkerCrash(() => {
       lastSourceRef = null;
+      // #160: shape='image' の bitmap は worker 側で消えている。ロックして
+      // 次の runBatch で再 upload を必須にする。File ref が残っていれば
+      // 自動再 upload を裏で試みる (silent: triggerRun=false)。
+      if (lastImageFileRef) {
+        setImageShapeReady(false);
+        void onImageShapePick(lastImageFileRef, false).catch(() => {});
+      }
       setErrorMsg(t('wasmLoadFailed'));
       setWasmStatus('error');
     });
     onCleanup(offCrash);
+    // #160: shape='image' のサムネイル URL をコンポーネント unmount 時に
+    // revoke する (新ファイル選択時の revoke と対称)。
+    onCleanup(() => {
+      const u = imageShapeUrl();
+      if (u) URL.revokeObjectURL(u);
+    });
   });
 
   // #131 / #159: シンボルピッカーに並べる候補は、wasm 同梱フォントで描画できる
@@ -339,6 +354,16 @@ export default function Studio() {
       // worker を作り直したので worker 側の cachedSource も消えている。
       // 次の workerSetSource を再送させる（onWorkerCrash 経路と同じ後始末）。
       lastSourceRef = null;
+      // #160: shape='image' の bitmap も worker 側で消えているので、File ref
+      // が残っていればここで再送する (Studio onWorkerCrash 経路と同じ思想)。
+      if (lastImageFileRef && shape() === 'image') {
+        try {
+          await workerSetImageShape(lastImageFileRef);
+        } catch (err) {
+          console.warn('failed to re-upload image shape after respawn', err);
+          setImageShapeReady(false);
+        }
+      }
     }
 
     seedSkeletons();
@@ -700,23 +725,24 @@ export default function Studio() {
     void runBatch();
   };
 
-  // #160: shape='image' 用の画像読込。File を ImageBitmap 化して worker に
-  // transfer し、UI 側はプレビュー URL とファイル名だけ保持する。
-  const onImageShapePick = async (file: File) => {
+  // #160: shape='image' 用の画像読込。File を worker に送って worker 側で
+  // createImageBitmap させる。main 側は File 参照を保持して crash 後の
+  // 再 upload に備える。第 2 引数 `triggerRun` を false にすると runBatch を
+  // 走らせず、worker recovery 後の silent 再 upload に使える。
+  const onImageShapePick = async (file: File, triggerRun = true) => {
     try {
-      const bitmap = await createImageBitmap(file);
-      // worker に transfer (これで main 側 bitmap は detached)。
-      await workerSetImageShape(bitmap);
-      // 旧 URL を revoke してから新 URL に差し替え。
+      lastImageFileRef = file;
+      await workerSetImageShape(file);
       const oldUrl = imageShapeUrl();
       if (oldUrl) URL.revokeObjectURL(oldUrl);
       setImageShapeUrl(URL.createObjectURL(file));
       setImageShapeName(file.name);
       setImageShapeReady(true);
-      runBatchIfReady();
+      if (triggerRun) runBatchIfReady();
     } catch (err) {
       console.warn('failed to load image shape', err);
       setErrorMsg(t('imageShapeLoadFailed'));
+      setImageShapeReady(false);
     }
   };
 
@@ -1559,7 +1585,11 @@ export default function Studio() {
             (shape() === 'image' && !imageShapeReady())
           }
           aria-label={t('rerollLabel')}
-          title={t('rerollTitle')}
+          title={
+            shape() === 'image' && !imageShapeReady()
+              ? t('imageShapePickHint')
+              : t('rerollTitle')
+          }
           class={GLASS_BTN + ' h-10 w-10 px-0 active:scale-95'}
         >
           <svg

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -11,6 +11,7 @@ import {
   workerGenerateOneAlpha,
   workerGlyphSupported,
   workerInit,
+  workerSetImageShape,
   workerSetSource,
   workerVp9AlphaSupported,
 } from '../lib/orberClient';
@@ -30,7 +31,7 @@ type Phase = 'idle' | 'decoding' | 'generating' | 'animating' | 'done' | 'error'
 // UI では `'' | 'mid'` のどちらでも「標準」ボタンを押下扱いにする。
 // count / softness は `'mid'` でも実質 identity、speed は `''` だけが identity で
 // `'mid'` を明示選択すると `Slow` に固定される（#131 仕様）。
-type ShapeChoice = 'circle' | 'glyph';
+type ShapeChoice = 'circle' | 'glyph' | 'image';
 type CountPreset = '' | 'low' | 'mid' | 'high';
 type SpeedPreset = '' | 'slow' | 'mid' | 'fast';
 type SoftnessPreset = '' | 'low' | 'mid' | 'high';
@@ -129,6 +130,12 @@ export default function Studio() {
   const [supportedGlyphChoices, setSupportedGlyphChoices] =
     createSignal<string[]>(SYMBOL_PICKER_DEFAULT);
   const [isGlyphComposing, setIsGlyphComposing] = createSignal(false);
+  // #160: shape='image' のときに使う画像のローカル参照。worker には
+  // workerSetImageShape で transfer して送るため、ここでは表示用の name と
+  // プレビュー URL だけ保持する (bitmap 自体は transfer 後 unusable)。
+  const [imageShapeName, setImageShapeName] = createSignal<string>('');
+  const [imageShapeUrl, setImageShapeUrl] = createSignal<string>('');
+  const [imageShapeReady, setImageShapeReady] = createSignal<boolean>(false);
   // M1: 初期値は `''`（identity）。UI 側で「標準」ボタンが `aria-pressed` 状態に
   // 見えるが、内部 signal は empty identity を保つ。spec.count / spec.speed /
   // GUI_VIDEO_SPEEDS / SoftnessPreset::Mid を温存し、Phase A の見た目を正確に再現する。
@@ -689,7 +696,28 @@ export default function Studio() {
   const runBatchIfReady = () => {
     if (!decoded() || downloading()) return;
     if (shape() === 'glyph' && glyphChar().trim().length === 0) return;
+    if (shape() === 'image' && !imageShapeReady()) return;
     void runBatch();
+  };
+
+  // #160: shape='image' 用の画像読込。File を ImageBitmap 化して worker に
+  // transfer し、UI 側はプレビュー URL とファイル名だけ保持する。
+  const onImageShapePick = async (file: File) => {
+    try {
+      const bitmap = await createImageBitmap(file);
+      // worker に transfer (これで main 側 bitmap は detached)。
+      await workerSetImageShape(bitmap);
+      // 旧 URL を revoke してから新 URL に差し替え。
+      const oldUrl = imageShapeUrl();
+      if (oldUrl) URL.revokeObjectURL(oldUrl);
+      setImageShapeUrl(URL.createObjectURL(file));
+      setImageShapeName(file.name);
+      setImageShapeReady(true);
+      runBatchIfReady();
+    } catch (err) {
+      console.warn('failed to load image shape', err);
+      setErrorMsg(t('imageShapeLoadFailed'));
+    }
   };
 
   const onAspectClick = (a: Aspect) => {
@@ -1255,7 +1283,7 @@ export default function Studio() {
             aria-pressed={shape() === 'circle'}
             onClick={() => onShapeClick('circle')}
             disabled={!decoded() || downloading()}
-            class={SEG_BTN(0, 2, shape() === 'circle')}
+            class={SEG_BTN(0, 3, shape() === 'circle')}
           >
             {t('shapeOptionCircle')}
           </button>
@@ -1264,9 +1292,18 @@ export default function Studio() {
             aria-pressed={shape() === 'glyph'}
             onClick={() => onShapeClick('glyph')}
             disabled={!decoded() || downloading()}
-            class={SEG_BTN(1, 2, shape() === 'glyph')}
+            class={SEG_BTN(1, 3, shape() === 'glyph')}
           >
             {t('shapeOptionGlyph')}
+          </button>
+          <button
+            type="button"
+            aria-pressed={shape() === 'image'}
+            onClick={() => onShapeClick('image')}
+            disabled={!decoded() || downloading()}
+            class={SEG_BTN(2, 3, shape() === 'image')}
+          >
+            {t('shapeOptionImage')}
           </button>
         </div>
 
@@ -1360,6 +1397,51 @@ export default function Studio() {
               />
               <span>{t('glyphRotateLabel')}</span>
             </label>
+          </>
+        </Show>
+
+        {/* #160: Image shape 用の画像入力 row。shape='image' のときだけ
+            表示する。ファイル選択 input + プレビューサムネイル + 名前。
+            画像はメインスレッドで ImageBitmap 化 → worker に transfer する。 */}
+        <Show when={shape() === 'image'}>
+          <>
+            <label class="justify-self-end text-sm text-fgMuted">
+              {t('imageShapeLabel')}:
+            </label>
+            <div class="flex items-center gap-2 min-w-0">
+              <label
+                class={
+                  'inline-flex items-center justify-center cursor-pointer h-9 px-3 text-sm rounded-md border border-glassBorder bg-glassBg text-fgMuted hover:text-fg hover:bg-glassBgHover transition-colors duration-200 ' +
+                  'focus-within:outline-none focus-within:ring-1 focus-within:ring-focusRing ' +
+                  (!decoded() || downloading() ? 'opacity-40 cursor-not-allowed pointer-events-none' : '')
+                }
+              >
+                <span>{t('imageShapePick')}</span>
+                <input
+                  type="file"
+                  accept="image/*"
+                  class="hidden"
+                  disabled={!decoded() || downloading()}
+                  onChange={(e) => {
+                    const file = e.currentTarget.files?.[0];
+                    if (file) void onImageShapePick(file);
+                    e.currentTarget.value = '';
+                  }}
+                />
+              </label>
+              <Show when={imageShapeUrl()}>
+                <img
+                  src={imageShapeUrl()}
+                  alt={imageShapeName() || t('imageShapeLabel')}
+                  class="h-9 w-9 rounded border border-glassBorder object-contain bg-bg"
+                />
+              </Show>
+              <Show when={imageShapeName()}>
+                <span class="truncate text-xs text-fgMuted min-w-0">
+                  {imageShapeName()}
+                </span>
+              </Show>
+            </div>
           </>
         </Show>
 
@@ -1470,7 +1552,12 @@ export default function Studio() {
         <button
           type="button"
           onClick={runBatchIfReady}
-          disabled={!decoded() || downloading() || (shape() === 'glyph' && glyphChar().trim() === '')}
+          disabled={
+            !decoded() ||
+            downloading() ||
+            (shape() === 'glyph' && glyphChar().trim() === '') ||
+            (shape() === 'image' && !imageShapeReady())
+          }
           aria-label={t('rerollLabel')}
           title={t('rerollTitle')}
           class={GLASS_BTN + ' h-10 w-10 px-0 active:scale-95'}

--- a/web/src/lib/jsGlyphSdf.test.ts
+++ b/web/src/lib/jsGlyphSdf.test.ts
@@ -8,7 +8,11 @@
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { GLYPH_SDF_MAX_DIST_FACTOR, generateJsGlyphSdf } from './jsGlyphSdf';
+import {
+  GLYPH_SDF_MAX_DIST_FACTOR,
+  generateImageSdf,
+  generateJsGlyphSdf,
+} from './jsGlyphSdf';
 
 describe('generateJsGlyphSdf()', () => {
   afterEach(() => {
@@ -109,5 +113,112 @@ describe('generateJsGlyphSdf()', () => {
   test('GLYPH_SDF_MAX_DIST_FACTOR は Rust 側 (crates/core/src/glyph.rs) の 0.06 と同値', () => {
     // 値変更時の同期忘れを防ぐ guard。Rust 側を変えたら同じ値にする。
     expect(GLYPH_SDF_MAX_DIST_FACTOR).toBe(0.06);
+  });
+});
+
+describe('generateImageSdf()', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // 画像 → SDF パイプの出力フォーマット検証。jsdom で実画像はデコードできないが、
+  // ImageBitmap-like / OffscreenCanvas-like の stub を渡すことで内部 EDT 経路を
+  // 通せる。
+
+  test('OffscreenCanvas 未定義環境では全 0 を返す', () => {
+    vi.stubGlobal('OffscreenCanvas', undefined);
+    const fakeBitmap = { width: 16, height: 16 } as unknown as ImageBitmap;
+    const out = generateImageSdf(fakeBitmap, 16);
+    expect(out.length).toBe(16 * 16);
+    expect(out.every((v) => v === 0)).toBe(true);
+  });
+
+  test('完全透過な画像 (alpha 全 0) なら全 0 を返す', () => {
+    const SIZE = 8;
+    const data = new Uint8ClampedArray(SIZE * SIZE * 4);
+    class StubCanvas {
+      width: number;
+      height: number;
+      constructor(w: number, h: number) {
+        this.width = w;
+        this.height = h;
+      }
+      getContext() {
+        return {
+          clearRect: () => {},
+          drawImage: () => {},
+          getImageData: () => ({ data, width: SIZE, height: SIZE }),
+        };
+      }
+    }
+    vi.stubGlobal('OffscreenCanvas', StubCanvas);
+    const fakeBitmap = { width: SIZE, height: SIZE } as unknown as ImageBitmap;
+    const out = generateImageSdf(fakeBitmap, SIZE);
+    expect(out.length).toBe(SIZE * SIZE);
+    expect(out.every((v) => v === 0)).toBe(true);
+  });
+
+  test('透過画像 (alpha=255 中央 1px) で文字版と同じ SDF を生成する', () => {
+    // generateJsGlyphSdf と同じ EDT 経路を共有しているので、入力 alpha 配置が
+    // 同じなら出力 SDF も完全に同じになることを確認する (regression guard)。
+    const SIZE = 8;
+    const data = new Uint8ClampedArray(SIZE * SIZE * 4);
+    data[(3 * SIZE + 3) * 4 + 3] = 255;
+    class StubCanvas {
+      width: number;
+      height: number;
+      constructor(w: number, h: number) {
+        this.width = w;
+        this.height = h;
+      }
+      getContext() {
+        return {
+          clearRect: () => {},
+          drawImage: () => {},
+          getImageData: () => ({ data, width: SIZE, height: SIZE }),
+        };
+      }
+    }
+    vi.stubGlobal('OffscreenCanvas', StubCanvas);
+    const fakeBitmap = { width: SIZE, height: SIZE } as unknown as ImageBitmap;
+    const out = generateImageSdf(fakeBitmap, SIZE);
+    expect(out[3 * SIZE + 3]).toBe(191);
+    expect(out[3 * SIZE + 2]).toBe(64);
+    expect(out[2 * SIZE + 2]).toBe(11);
+    expect(out[0]).toBe(0);
+  });
+
+  test('不透明画像でも輝度しきい値で二値化される', () => {
+    // 全ピクセル alpha=255、中央 1 px だけ白 (輝度高)、他は黒 (輝度 0)。
+    // hasAlpha=false 経路に入り、avgY ≈ 255/64 ≈ 4。中央 1 px は輝度 255 で
+    // avgY 以上 → 「明るいセル数=1, 暗いセル数=63」 → 少数派の bright を
+    // inside とする → 中央が inside、その他が outside。alpha 経路と同じ
+    // SDF が出る。
+    const SIZE = 8;
+    const data = new Uint8ClampedArray(SIZE * SIZE * 4);
+    for (let i = 0; i < SIZE * SIZE; i++) data[i * 4 + 3] = 255; // alpha=255 全部
+    data[(3 * SIZE + 3) * 4 + 0] = 255;
+    data[(3 * SIZE + 3) * 4 + 1] = 255;
+    data[(3 * SIZE + 3) * 4 + 2] = 255;
+    class StubCanvas {
+      width: number;
+      height: number;
+      constructor(w: number, h: number) {
+        this.width = w;
+        this.height = h;
+      }
+      getContext() {
+        return {
+          clearRect: () => {},
+          drawImage: () => {},
+          getImageData: () => ({ data, width: SIZE, height: SIZE }),
+        };
+      }
+    }
+    vi.stubGlobal('OffscreenCanvas', StubCanvas);
+    const fakeBitmap = { width: SIZE, height: SIZE } as unknown as ImageBitmap;
+    const out = generateImageSdf(fakeBitmap, SIZE);
+    expect(out[3 * SIZE + 3]).toBe(191);
+    expect(out[3 * SIZE + 2]).toBe(64);
   });
 });

--- a/web/src/lib/jsGlyphSdf.ts
+++ b/web/src/lib/jsGlyphSdf.ts
@@ -72,14 +72,110 @@ export function generateJsGlyphSdf(ch: string, size: number): Uint8Array {
     }
   }
   if (!anyInside) return new Uint8Array(s * s);
+  return computeSdfFromMask(inside, s);
+}
 
-  // 2D Euclidean Distance Transform (Felzenszwalb-Huttenlocher 1996, O(n))。
-  // 行 → 列の順で 1D EDT を 2 回走らせると 2D 距離^2 が得られる。
-  const distInside = edt2d(inside, s, s); // 各セルから「inside」までの最短 dist^2 (inside セルは 0)
+/**
+ * #160: 任意の `ImageBitmap` (PNG / JPG / WebP / SVG decode 結果) を
+ * `size`×`size` の SDF Uint8Array にラスタライズする。
+ *
+ * しきい値:
+ * - 透過画像 (`hasAlpha = true`): alpha >= 128 を inside とする
+ * - 不透明画像 (`hasAlpha = false`): 輝度 (Y = 0.299R + 0.587G + 0.114B) で
+ *   二値化。被写体が背景より暗いか明るいかは事前に決めず、画像全体の輝度
+ *   平均を境界に inside / outside を分け、**inside ピクセルが少数派** に
+ *   なる側を採用する (典型的な被写体は背景より小領域である前提)
+ *
+ * 出力フォーマットは `generateJsGlyphSdf` と同一 (R8 size×size)、
+ * `renderer.setGlyphSdf` にそのまま渡せる。
+ */
+export function generateImageSdf(bitmap: ImageBitmap, size: number): Uint8Array {
+  const s = Math.max(1, size | 0);
+  if (typeof OffscreenCanvas === 'undefined') {
+    return new Uint8Array(s * s);
+  }
+  const canvas = new OffscreenCanvas(s, s);
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) return new Uint8Array(s * s);
+
+  // 元画像のアスペクトを保ったまま s×s に「contain」リサンプル (上下/左右に
+  // 余白を入れる)。シルエットが歪まないようにするため。
+  ctx.clearRect(0, 0, s, s);
+  const bw = bitmap.width || 1;
+  const bh = bitmap.height || 1;
+  const scale = Math.min(s / bw, s / bh);
+  const dw = Math.max(1, Math.round(bw * scale));
+  const dh = Math.max(1, Math.round(bh * scale));
+  const dx = Math.round((s - dw) / 2);
+  const dy = Math.round((s - dh) / 2);
+  ctx.drawImage(bitmap, 0, 0, bw, bh, dx, dy, dw, dh);
+
+  const img = ctx.getImageData(0, 0, s, s);
+  const data = img.data;
+
+  // 透過があるかをチェック (alpha < 255 のピクセルが 1 つでもあれば「透過画像」)。
+  let hasAlpha = false;
+  for (let i = 0; i < s * s; i++) {
+    if (data[i * 4 + 3] < 255) {
+      hasAlpha = true;
+      break;
+    }
+  }
+
+  const inside = new Uint8Array(s * s);
+  let anyInside = false;
+  if (hasAlpha) {
+    // alpha しきい値 (透過画像経路)
+    for (let i = 0; i < s * s; i++) {
+      if (data[i * 4 + 3] >= 128) {
+        inside[i] = 1;
+        anyInside = true;
+      }
+    }
+  } else {
+    // 輝度しきい値 (不透明画像経路)。平均輝度を境界にし、少数派のピクセル群を
+    // inside (= 被写体) とする。背景が暗い / 明るいの両方に対応するためのヒューリスティック。
+    let sumY = 0;
+    for (let i = 0; i < s * s; i++) {
+      const r = data[i * 4];
+      const g = data[i * 4 + 1];
+      const b = data[i * 4 + 2];
+      sumY += 0.299 * r + 0.587 * g + 0.114 * b;
+    }
+    const avgY = sumY / (s * s);
+    let darkCount = 0;
+    for (let i = 0; i < s * s; i++) {
+      const r = data[i * 4];
+      const g = data[i * 4 + 1];
+      const b = data[i * 4 + 2];
+      const y = 0.299 * r + 0.587 * g + 0.114 * b;
+      if (y < avgY) darkCount++;
+    }
+    const insideIsDark = darkCount < s * s / 2;
+    for (let i = 0; i < s * s; i++) {
+      const r = data[i * 4];
+      const g = data[i * 4 + 1];
+      const b = data[i * 4 + 2];
+      const y = 0.299 * r + 0.587 * g + 0.114 * b;
+      const isInside = insideIsDark ? y < avgY : y >= avgY;
+      if (isInside) {
+        inside[i] = 1;
+        anyInside = true;
+      }
+    }
+  }
+  if (!anyInside) return new Uint8Array(s * s);
+
+  return computeSdfFromMask(inside, s);
+}
+
+// inside mask (0/1) → Rust 互換の SDF Uint8Array を計算する共通経路。
+// generateJsGlyphSdf / generateImageSdf の両方から使う。
+function computeSdfFromMask(inside: Uint8Array, s: number): Uint8Array {
+  const distInside = edt2d(inside, s, s);
   const outside = new Uint8Array(s * s);
   for (let i = 0; i < s * s; i++) outside[i] = inside[i] ? 0 : 1;
-  const distOutside = edt2d(outside, s, s); // outside までの最短 dist^2 (outside セルは 0)
-
+  const distOutside = edt2d(outside, s, s);
   const norm = Math.max(1, s * GLYPH_SDF_MAX_DIST_FACTOR);
   const out = new Uint8Array(s * s);
   for (let i = 0; i < s * s; i++) {

--- a/web/src/lib/orberClient.ts
+++ b/web/src/lib/orberClient.ts
@@ -249,11 +249,13 @@ export async function workerGlyphSupported(ch: string): Promise<boolean> {
 
 /**
  * #160: shape='image' で使う画像を worker に渡してキャッシュさせる。
- * `bitmap` は Transferable で zero-copy 転送される (転送後は呼び出し側で
- * 使えなくなる)。古い bitmap は worker 側で `close()` される。
+ * `file` は structured-clone で worker に複製される (Transferable は使わ
+ * ない)。これでメインスレッド側に File への参照が残り、worker クラッシュ
+ * 後の再 upload が可能になる。worker 側で `createImageBitmap(file)` を
+ * 呼んで ImageBitmap 化し、古い bitmap は close() される。
  */
-export async function workerSetImageShape(bitmap: ImageBitmap): Promise<void> {
-  await call<void>({ kind: 'setImageShape', bitmap }, [bitmap]);
+export async function workerSetImageShape(file: File): Promise<void> {
+  await call<void>({ kind: 'setImageShape', file });
 }
 
 /** 1 タイル分の mp4 を返す（WebCodecs + mp4-muxer で h264 化）。 */

--- a/web/src/lib/orberClient.ts
+++ b/web/src/lib/orberClient.ts
@@ -247,6 +247,15 @@ export async function workerGlyphSupported(ch: string): Promise<boolean> {
   return await call<boolean>({ kind: 'glyphSupported', ch });
 }
 
+/**
+ * #160: shape='image' で使う画像を worker に渡してキャッシュさせる。
+ * `bitmap` は Transferable で zero-copy 転送される (転送後は呼び出し側で
+ * 使えなくなる)。古い bitmap は worker 側で `close()` される。
+ */
+export async function workerSetImageShape(bitmap: ImageBitmap): Promise<void> {
+  await call<void>({ kind: 'setImageShape', bitmap }, [bitmap]);
+}
+
 /** 1 タイル分の mp4 を返す（WebCodecs + mp4-muxer で h264 化）。 */
 export async function workerAnimateOne(
   params: BaseParams,

--- a/web/src/lib/orberWorker.ts
+++ b/web/src/lib/orberWorker.ts
@@ -22,7 +22,7 @@ import {
   isVp9AlphaSupported,
 } from './encodeWebmAlpha';
 import { createGlRenderer, GLYPH_SDF_SIZE, type GlRenderer } from './orberGl';
-import { generateJsGlyphSdf } from './jsGlyphSdf';
+import { generateImageSdf, generateJsGlyphSdf } from './jsGlyphSdf';
 
 let initialized = false;
 let initPromise: Promise<void> | null = null;
@@ -48,7 +48,15 @@ let cachedCanvas: { canvas: OffscreenCanvas; renderer: GlRenderer; width: number
 // (GLYPH_SDF_SIZE) でしか呼ばないので size をキーから外しても良いが、将来
 // 切替の余地を残すために含める。getRenderer で renderer を作り直したときも
 // invalidate する必要がある（テクスチャも一緒に dispose されるため）。
-let cachedGlyph: { ch: string; size: number } | null = null;
+//
+// #160: shape='image' のときは ch ではなく ImageBitmap を SDF 元にするので、
+// kind を分けてキャッシュする。bitmap は Studio から `setImageShape` で 1 度
+// 送られて worker にキャッシュされる (cachedImageBitmap)。
+let cachedGlyph:
+  | { kind: 'char'; ch: string; size: number }
+  | { kind: 'image'; bitmap: ImageBitmap; size: number }
+  | null = null;
+let cachedImageBitmap: ImageBitmap | null = null;
 
 function getRenderer(width: number, height: number): { canvas: OffscreenCanvas; renderer: GlRenderer } {
   if (cachedCanvas && cachedCanvas.width === width && cachedCanvas.height === height) {
@@ -57,8 +65,8 @@ function getRenderer(width: number, height: number): { canvas: OffscreenCanvas; 
   if (cachedCanvas) {
     cachedCanvas.renderer.dispose();
     cachedCanvas = null;
-    // renderer を作り直すとテクスチャも消えるので Glyph
-    // キャッシュも無効化する（次の ensureGlyphSdfUploaded で再 upload）。
+    // renderer を作り直すとテクスチャも消えるので Glyph / Image
+    // キャッシュも無効化する（次の ensure*SdfUploaded で再 upload）。
     cachedGlyph = null;
   }
   const canvas = new OffscreenCanvas(width, height);
@@ -90,7 +98,13 @@ interface BaseParams {
 
 function ensureGlyphSdfUploaded(renderer: GlRenderer, ch: string): void {
   const size = GLYPH_SDF_SIZE;
-  if (cachedGlyph && cachedGlyph.ch === ch && cachedGlyph.size === size) return;
+  if (
+    cachedGlyph &&
+    cachedGlyph.kind === 'char' &&
+    cachedGlyph.ch === ch &&
+    cachedGlyph.size === size
+  )
+    return;
   // #159: wasm 側で同梱フォントから SDF を作れる字 (☆ 等) は wasm 経路を使う
   // (高速 / 環境非依存)。それ以外 (絵文字 / 漢字 / 任意 Unicode) は worker 内
   // OffscreenCanvas で OS フォントスタックでラスタライズして SDF 化する。
@@ -105,15 +119,45 @@ function ensureGlyphSdfUploaded(renderer: GlRenderer, ch: string): void {
     sdf = generateJsGlyphSdf(ch, size);
   }
   renderer.setGlyphSdf(sdf, size);
-  cachedGlyph = { ch, size };
+  cachedGlyph = { kind: 'char', ch, size };
+}
+
+// #160: shape='image' 用。Studio 側で `setImageShape(bitmap)` 経由で送られて
+// `cachedImageBitmap` に入っている画像をシルエット化 → SDF 化 → upload。
+// 同じ bitmap reference なら再生成しない。
+function ensureImageSdfUploaded(renderer: GlRenderer): void {
+  const size = GLYPH_SDF_SIZE;
+  if (!cachedImageBitmap) {
+    throw new Error('image shape requires setImageShape before generate');
+  }
+  if (
+    cachedGlyph &&
+    cachedGlyph.kind === 'image' &&
+    cachedGlyph.bitmap === cachedImageBitmap &&
+    cachedGlyph.size === size
+  )
+    return;
+  const sdf = generateImageSdf(cachedImageBitmap, size);
+  renderer.setGlyphSdf(sdf, size);
+  cachedGlyph = { kind: 'image', bitmap: cachedImageBitmap, size };
 }
 
 function mergeParams(p: BaseParams) {
   if (!cachedSource) {
     throw new Error('source not set — call setSource before generate/animate');
   }
+  // #160: UI shape='image' は wasm からは shape='glyph' (= SDF テクスチャを
+  // サンプルする) として見せる。glyph_char は wasm 内部の SDF キャッシュ
+  // キーになるが、こちらでテクスチャを上書き upload するので値は問われない。
+  // 念のため非空ダミー ('A') を入れて wasm の glyph_char バリデーションが
+  // 弾かないようにする。
+  const wasmShape = p.shape === 'image' ? 'glyph' : p.shape;
+  const wasmGlyphChar =
+    p.shape === 'image' ? 'A' : p.glyph_char;
   return {
     ...p,
+    shape: wasmShape,
+    glyph_char: wasmGlyphChar,
     source_rgb: cachedSource.rgb,
     source_width: cachedSource.width,
     source_height: cachedSource.height,
@@ -164,7 +208,10 @@ type Req =
   | { kind: 'vp9AlphaSupported'; id: number }
   // Phase B (#55): UI が typed-in glyph 文字が同梱フォントに収録されているか
   // 警告表示するための問い合わせ。wasm の has_glyph(NotoSymbols2, ch) を呼ぶ。
-  | { kind: 'glyphSupported'; id: number; ch: string };
+  | { kind: 'glyphSupported'; id: number; ch: string }
+  // #160: shape='image' で使う画像 (ImageBitmap) を worker にキャッシュする。
+  // bitmap は Transferable で zero-copy 転送される (Studio.tsx 側で transfer)。
+  | { kind: 'setImageShape'; id: number; bitmap: ImageBitmap };
 
 /// #56: wasm get_render_data の Float32Array header word 3 (= bg.a in 0..1) を 0 に
 /// 上書きして「透過背景でレンダリングしてくれ」と shader に依頼する。元 buffer は
@@ -195,6 +242,19 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
         post({ id: req.id, ok: true });
         break;
       }
+      case 'setImageShape': {
+        // 古い bitmap は close して GPU メモリを解放する。新 bitmap を保持。
+        if (cachedImageBitmap && cachedImageBitmap !== req.bitmap) {
+          cachedImageBitmap.close();
+        }
+        cachedImageBitmap = req.bitmap;
+        // 既存の image SDF キャッシュを invalidate (新 bitmap で再生成させる)。
+        if (cachedGlyph && cachedGlyph.kind === 'image') {
+          cachedGlyph = null;
+        }
+        post({ id: req.id, ok: true });
+        break;
+      }
       case 'generateOne': {
         const params = mergeParams(req.params);
         const data = wasm.get_render_data(params, req.n, req.index);
@@ -202,7 +262,9 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
         // Glyph 形状なら SDF を 1 度アップロードする。
         // setRenderData の前に呼ぶことで shape_id=1 の uniform が立つ前から
         // テクスチャは正しい状態になる（順序依存はないが、明示的に先に行う）。
-        if (req.params.shape === 'glyph' && req.params.glyph_char) {
+        if (req.params.shape === 'image') {
+          ensureImageSdfUploaded(renderer);
+        } else if (req.params.shape === 'glyph' && req.params.glyph_char) {
           ensureGlyphSdfUploaded(renderer, req.params.glyph_char);
         }
         renderer.setRenderData(data);
@@ -218,7 +280,9 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
         const width = req.params.width;
         const height = req.params.height;
         const { canvas, renderer } = getRenderer(width, height);
-        if (req.params.shape === 'glyph' && req.params.glyph_char) {
+        if (req.params.shape === 'image') {
+          ensureImageSdfUploaded(renderer);
+        } else if (req.params.shape === 'glyph' && req.params.glyph_char) {
           ensureGlyphSdfUploaded(renderer, req.params.glyph_char);
         }
         renderer.setRenderData(data);
@@ -251,7 +315,9 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
         const params = mergeParams(req.params);
         const data = wasm.get_render_data(params, req.n, req.index);
         const { canvas, renderer } = getRenderer(req.params.width, req.params.height);
-        if (req.params.shape === 'glyph' && req.params.glyph_char) {
+        if (req.params.shape === 'image') {
+          ensureImageSdfUploaded(renderer);
+        } else if (req.params.shape === 'glyph' && req.params.glyph_char) {
           ensureGlyphSdfUploaded(renderer, req.params.glyph_char);
         }
         renderer.setRenderData(withTransparentBackground(data));
@@ -277,7 +343,9 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
         const width = req.params.width;
         const height = req.params.height;
         const { canvas, renderer } = getRenderer(width, height);
-        if (req.params.shape === 'glyph' && req.params.glyph_char) {
+        if (req.params.shape === 'image') {
+          ensureImageSdfUploaded(renderer);
+        } else if (req.params.shape === 'glyph' && req.params.glyph_char) {
           ensureGlyphSdfUploaded(renderer, req.params.glyph_char);
         }
         renderer.setRenderData(withTransparentBackground(data));

--- a/web/src/lib/orberWorker.ts
+++ b/web/src/lib/orberWorker.ts
@@ -209,9 +209,12 @@ type Req =
   // Phase B (#55): UI が typed-in glyph 文字が同梱フォントに収録されているか
   // 警告表示するための問い合わせ。wasm の has_glyph(NotoSymbols2, ch) を呼ぶ。
   | { kind: 'glyphSupported'; id: number; ch: string }
-  // #160: shape='image' で使う画像 (ImageBitmap) を worker にキャッシュする。
-  // bitmap は Transferable で zero-copy 転送される (Studio.tsx 側で transfer)。
-  | { kind: 'setImageShape'; id: number; bitmap: ImageBitmap };
+  // #160: shape='image' で使う画像 (File) を worker にキャッシュする。
+  // worker 側で createImageBitmap(file) を呼んで ImageBitmap 化する。
+  // Transferable を使わず structured-clone で渡す ── main 側が File 参照
+  // を保持し続けることで、worker クラッシュ / terminateAndRespawn 後の
+  // 再 upload が可能になる。
+  | { kind: 'setImageShape'; id: number; file: File };
 
 /// #56: wasm get_render_data の Float32Array header word 3 (= bg.a in 0..1) を 0 に
 /// 上書きして「透過背景でレンダリングしてくれ」と shader に依頼する。元 buffer は
@@ -243,11 +246,14 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
         break;
       }
       case 'setImageShape': {
-        // 古い bitmap は close して GPU メモリを解放する。新 bitmap を保持。
-        if (cachedImageBitmap && cachedImageBitmap !== req.bitmap) {
+        // File を worker 内で ImageBitmap 化する。古い bitmap は close して
+        // GPU メモリを解放してから差し替え。decode 失敗時は呼び出し側に
+        // error を返す (Studio 側で UI 通知)。
+        const newBitmap = await createImageBitmap(req.file);
+        if (cachedImageBitmap && cachedImageBitmap !== newBitmap) {
           cachedImageBitmap.close();
         }
-        cachedImageBitmap = req.bitmap;
+        cachedImageBitmap = newBitmap;
         // 既存の image SDF キャッシュを invalidate (新 bitmap で再生成させる)。
         if (cachedGlyph && cachedGlyph.kind === 'image') {
           cachedGlyph = null;

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -54,6 +54,10 @@ export const STRINGS = {
     ja: '画像を読み込めませんでした',
     en: 'Failed to load image',
   },
+  imageShapePickHint: {
+    ja: '画像を選択してください',
+    en: 'Pick an image first',
+  },
   glyphCharLabel: { ja: '文字', en: 'Character' },
   // #159 後は任意の Unicode 1 文字を受け付ける (絵文字 / 漢字 / 記号)。
   // placeholder は文字種の多様性を例示してユーザーに「何でも入る」ことを

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -46,6 +46,14 @@ export const STRINGS = {
   shapeLabel: { ja: '形状', en: 'Shape' },
   shapeOptionCircle: { ja: '円', en: 'Circle' },
   shapeOptionGlyph: { ja: '文字', en: 'Glyph' },
+  shapeOptionImage: { ja: '画像', en: 'Image' },
+  // #160: Image shape (任意の画像をシルエット化して orb として使う) の UI。
+  imageShapeLabel: { ja: '画像', en: 'Image' },
+  imageShapePick: { ja: '画像を選択', en: 'Choose image' },
+  imageShapeLoadFailed: {
+    ja: '画像を読み込めませんでした',
+    en: 'Failed to load image',
+  },
   glyphCharLabel: { ja: '文字', en: 'Character' },
   // #159 後は任意の Unicode 1 文字を受け付ける (絵文字 / 漢字 / 記号)。
   // placeholder は文字種の多様性を例示してユーザーに「何でも入る」ことを


### PR DESCRIPTION
## 関連 Issue
closes #160

## 主旨
shape を 2 択 (`Circle / Glyph`) から **3 択** (`Circle / Glyph / Image`) に拡張し、ユーザーがアップロードした画像 (PNG / JPG / WebP / GIF / SVG) をシルエット抽出して orb の形状として使えるようにする。

#159 で導入した「ブラウザでラスタライズ → EDT → SDF」パイプラインをそのまま流用するため、wasm / `crates/wasm` は無改修。CLI 影響なし。

## 設計判断
3 択にした理由:
- `Glyph` の中に「画像で代用」サブモードを置くと階層が深くなり、ユーザーの頭で「これは文字なの? 画像なの?」と混乱する
- Circle / Glyph / Image はそれぞれ概念が独立しており、segmented pill にフラットに並べる方が直感的
- 内部実装で SDF パイプラインを共有していることはユーザーに関係しない (#159 と同じ方針: 実装詳細を UI に出さない)

## 主な変更
- **`jsGlyphSdf.ts`** に `generateImageSdf(bitmap, size)` を追加:
  - OffscreenCanvas にアスペクト保持「contain」リサンプル
  - 透過があれば `alpha >= 128` を inside、不透明画像は輝度 `Y` で二値化、平均輝度を境界に少数派ピクセル群を inside (背景の暗/明を自動判定)
  - EDT / 符号エンコードは `computeSdfFromMask` に共通化 (#159 経路と完全共有)
- **`orberWorker.ts`** に `setImageShape` RPC を追加。`ImageBitmap` を Transferable で受けて `cachedImageBitmap` 保持、`ensureImageSdfUploaded` を新設して generate*/animate* 4 箇所で shape='image' を扱う。`mergeParams` で UI shape='image' → wasm shape='glyph' に書き換え (wasm は SDF テクスチャだけ見るので glyph_char はダミー 'A')
- **`orberClient.ts`** に `workerSetImageShape(bitmap)` を追加 (Transferable で zero-copy)
- **`Studio.tsx`** : `ShapeChoice` に 'image' 追加、segmented pill 3 ボタン化、画像入力 row 新設 (ファイル選択 + 9×9 サムネイル + ファイル名)。`runBatchIfReady` と reroll disabled に `!imageShapeReady` ガード
- **`strings.ts`** に `shapeOptionImage` / `imageShapeLabel` / `imageShapePick` / `imageShapeLoadFailed` を追加
- **`jsGlyphSdf.test.ts`** に 4 件追加: OffscreenCanvas 未定義 / 完全透過 / 透過 1px / 不透明輝度二値化
- **`DESIGN.md`** に「Image 入力 (#160)」章追加、**`docs/overview.md`** の glyph 段落に Image 経路の説明追記

## 検証
- `npm test` ✓ 15/15 → 19/19 pass (+4 件)
- `npm run build` ✓
- 実機目視は kako-jun 様タスク

## 受け入れ条件
- [x] glyph shape モードで画像ファイルをアップロード可
- [x] カラー画像も自動シルエット化されて orb として描画される
- [x] 透過画像は alpha しきい値、不透明画像は輝度しきい値で二値化
- [x] 画像はアスペクト比を保ってリサンプル
- [x] wasm / CLI に影響しない

## 関連
- #159 (任意 Unicode 1 文字 → glyph) で SDF パイプライン基盤を整備
- #167 (CF Pages hotfix) を経由しているので、このブランチには vitest 3 が入っている