### PR TITLE
feat(web): #169 #170 #171 #172 image shape ヒューリスティック改善 + 内部整理

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -353,22 +353,35 @@ Reduced motion: respect `prefers-reduced-motion: reduce` by clamping all transit
 - shape segmented pill は `Circle / Glyph / Image` の 3 択
 - `Image` を選ぶとシェイプ row の下に画像入力 row が出現する: ファイル選択
   ボタン + 9×9 サムネイル + ファイル名表示
-- 入力画像 (PNG / JPG / WebP / GIF / SVG) は メインスレッドで `createImageBitmap`
-  → `workerSetImageShape` で worker に Transferable で送信 → worker 内で
+- 入力画像 (PNG / JPG / WebP / GIF / SVG) は **`File` を worker に
+  structured-clone で送信** → worker 内で `createImageBitmap` →
   `OffscreenCanvas` に「contain」リサンプル → alpha or 輝度しきい値で二値化 →
-  Glyph と同じ EDT で SDF 化 (`web/src/lib/jsGlyphSdf.ts:generateImageSdf`)
-- しきい値ヒューリスティック:
-  - 透過 PNG など `alpha < 255` のピクセルが 1 つでもあれば「透過画像」扱い
-    → `alpha >= 128` を inside
-  - 完全不透明な画像は輝度 `Y = 0.299R + 0.587G + 0.114B` で二値化、
-    平均輝度を境界に **少数派ピクセル群を inside** とする (背景 vs 被写体の
-    自動判定。被写体が背景より小領域である前提)
+  Glyph と同じ EDT で SDF 化 (`web/src/lib/jsGlyphSdf.ts:generateImageSdf`)。
+  Transferable を使わない理由は worker クラッシュ / `terminateAndRespawn`
+  後にメインスレッドに残った `File` 参照から再 upload するため (#168 M1)
+- しきい値ヒューリスティック (#171 で改訂):
+  - **透過画像判定**: `alpha < 255` のピクセル数が画像全体の **1% 以上** の
+    ときだけ「透過画像」扱いとする。1 px 単位の混入 (JPEG → PNG 変換ロスや
+    ICC プロファイルの端ピクセル等) で alpha 経路に倒れる事故を防ぐ
+  - **透過画像経路**: `alpha >= 128` を inside
+  - **不透明画像経路**: 輝度 `Y = 0.299R + 0.587G + 0.114B` で二値化、
+    平均輝度を境界に **少数派ピクセル群を inside** とする (auto-polarity)
+- **コントラスト不足検出 (#169)**: シルエット抽出が成功しない (= inside 0 個、
+  または全画素 inside) 場合は worker が `image-shape-no-contrast` エラーを
+  投げ、UI に「この画像にはコントラストがありません」を表示する
+- **シルエット反転トグル (#170)**: 画像入力 row に `imageShapeInvert`
+  checkbox を置く。auto-polarity が外れる画像 (証明写真風など被写体が画面
+  半分以上を占める) の救済。トグル ON で inside / outside を強制反転、
+  worker 側 SDF が再生成される
 - 画像はアスペクト比を保ったまま 256×256 に「contain」リサンプルされ、
   上下/左右の余白は SDF 上の outside になる。これにより縦長/横長の画像も
   シルエットが歪まない
 - カラー画像の色情報は捨てる (orber は monochrome ピペライン)
 - shape='image' の wasm 経路は内部的に shape='glyph' として扱い、worker は
-  upload する SDF テクスチャだけを差し替える (wasm / `crates/wasm` は無改修)
+  upload する SDF テクスチャだけを差し替える (wasm / `crates/wasm` は無改修)。
+  wasm に渡すダミー `glyph_char` は `'☆'` (Noto Sans Symbols 2 同梱で必ず
+  glyph_supported になる字) を使い、将来 wasm 側で glyph_char バリデーション
+  が厳格化されても silent fail しないよう備える (#172 N2)
 
 ### 生成トリガー
 

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -330,6 +330,18 @@ export default function Studio() {
   // 1 frame ぶん描画を挟む（setTimeout(0) より意図が明確）。
   const yieldFrame = () => new Promise<void>((r) => requestAnimationFrame(() => r()));
 
+  // #169: runBatch から伝播してくる worker エラーを i18n 文言にマップする。
+  // image-shape-no-contrast は generateImageSdf でシルエット抽出に失敗した
+  // ことを示す内部 sentinel。`Error` インスタンスなら .message を見て、それ
+  // 以外は String(e) で文字列化する (N2)。
+  const formatRunBatchError = (e: unknown): string => {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('image-shape-no-contrast')) {
+      return t('imageShapeNoContrast');
+    }
+    return msg;
+  };
+
   const runBatch = async () => {
     const src = decoded();
     if (!src) return;
@@ -749,27 +761,20 @@ export default function Studio() {
     }
   };
 
-  // #169: runBatch から伝播してくる worker エラーを i18n 文言にマップする。
-  // image-shape-no-contrast は generateImageSdf でシルエット抽出に失敗した
-  // ことを示す内部コード。それ以外は生のまま表示する (デバッグ用)。
-  const formatRunBatchError = (e: unknown): string => {
-    const s = String(e);
-    if (s.includes('image-shape-no-contrast')) {
-      return t('imageShapeNoContrast');
-    }
-    return s;
-  };
-
   // #170: invert トグル切替時に worker 側 SDF を再生成する。File ref が
-  // 残っていれば自動で再 upload。
-  const onImageShapeInvertChange = (next: boolean) => {
+  // 残っていれば再 upload を試み、失敗時は signal をロールバックして UI
+  // と worker 状態の整合を保つ (S2)。スタイルは onImageShapePick の async
+  // /try-catch に揃える (N1)。
+  const onImageShapeInvertChange = async (next: boolean) => {
     setImageShapeInvert(next);
-    if (lastImageFileRef && shape() === 'image') {
-      void workerSetImageShape(lastImageFileRef, next).then(() => {
-        runBatchIfReady();
-      }).catch((err) => {
-        console.warn('failed to re-upload image shape on invert toggle', err);
-      });
+    if (!lastImageFileRef || shape() !== 'image') return;
+    try {
+      await workerSetImageShape(lastImageFileRef, next);
+      runBatchIfReady();
+    } catch (err) {
+      console.warn('failed to re-upload image shape on invert toggle', err);
+      setImageShapeInvert(!next);
+      setErrorMsg(formatRunBatchError(err));
     }
   };
 
@@ -1503,7 +1508,7 @@ export default function Studio() {
                 type="checkbox"
                 class={GLASS_CHECKBOX_INPUT}
                 checked={imageShapeInvert()}
-                onChange={(e) => onImageShapeInvertChange(e.currentTarget.checked)}
+                onChange={(e) => void onImageShapeInvertChange(e.currentTarget.checked)}
                 disabled={!decoded() || downloading() || !imageShapeReady()}
               />
               <span>{t('imageShapeInvert')}</span>

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -136,6 +136,9 @@ export default function Studio() {
   const [imageShapeName, setImageShapeName] = createSignal<string>('');
   const [imageShapeUrl, setImageShapeUrl] = createSignal<string>('');
   const [imageShapeReady, setImageShapeReady] = createSignal<boolean>(false);
+  // #170: シルエット反転トグル。auto-polarity (= 少数派 = 被写体) が外れる
+  // 画像 (証明写真など被写体が画面の半分以上) の救済。
+  const [imageShapeInvert, setImageShapeInvert] = createSignal<boolean>(false);
   // setImageShape を再送するための File ref。runBatch / crash 経路で参照。
   let lastImageFileRef: File | null = null;
   // M1: 初期値は `''`（identity）。UI 側で「標準」ボタンが `aria-pressed` 状態に
@@ -346,7 +349,7 @@ export default function Studio() {
       } catch (e) {
         if (myGen !== runGen) return;
         clearTiles();
-        setErrorMsg(String(e));
+        setErrorMsg(formatRunBatchError(e));
         setPhase('error');
         return;
       }
@@ -388,7 +391,7 @@ export default function Studio() {
       } catch (e) {
         if (myGen !== runGen) return;
         clearTiles();
-        setErrorMsg(String(e));
+        setErrorMsg(formatRunBatchError(e));
         setPhase('error');
         return;
       }
@@ -468,7 +471,7 @@ export default function Studio() {
       // setTimeout 等が動いていても抑止できるよう保守的に維持する。
       runGen += 1;
       clearTiles();
-      setErrorMsg(String(e));
+      setErrorMsg(formatRunBatchError(e));
       setPhase('error');
       return;
     }
@@ -597,7 +600,7 @@ export default function Studio() {
       await runBatch();
     } catch (e) {
       console.error('decode failed', e);
-      setErrorMsg(String(e));
+      setErrorMsg(formatRunBatchError(e));
       setPhase('error');
       // 失敗した画像を「成功扱い」のサムネとしてドロップエリアに残さない。
       const failedThumbUrl = pickedThumbUrl();
@@ -732,7 +735,7 @@ export default function Studio() {
   const onImageShapePick = async (file: File, triggerRun = true) => {
     try {
       lastImageFileRef = file;
-      await workerSetImageShape(file);
+      await workerSetImageShape(file, imageShapeInvert());
       const oldUrl = imageShapeUrl();
       if (oldUrl) URL.revokeObjectURL(oldUrl);
       setImageShapeUrl(URL.createObjectURL(file));
@@ -743,6 +746,30 @@ export default function Studio() {
       console.warn('failed to load image shape', err);
       setErrorMsg(t('imageShapeLoadFailed'));
       setImageShapeReady(false);
+    }
+  };
+
+  // #169: runBatch から伝播してくる worker エラーを i18n 文言にマップする。
+  // image-shape-no-contrast は generateImageSdf でシルエット抽出に失敗した
+  // ことを示す内部コード。それ以外は生のまま表示する (デバッグ用)。
+  const formatRunBatchError = (e: unknown): string => {
+    const s = String(e);
+    if (s.includes('image-shape-no-contrast')) {
+      return t('imageShapeNoContrast');
+    }
+    return s;
+  };
+
+  // #170: invert トグル切替時に worker 側 SDF を再生成する。File ref が
+  // 残っていれば自動で再 upload。
+  const onImageShapeInvertChange = (next: boolean) => {
+    setImageShapeInvert(next);
+    if (lastImageFileRef && shape() === 'image') {
+      void workerSetImageShape(lastImageFileRef, next).then(() => {
+        runBatchIfReady();
+      }).catch((err) => {
+        console.warn('failed to re-upload image shape on invert toggle', err);
+      });
     }
   };
 
@@ -1468,6 +1495,19 @@ export default function Studio() {
                 </span>
               </Show>
             </div>
+            {/* #170: シルエット反転トグル。auto-polarity が外れる画像
+                (被写体が画面の半分以上を占める証明写真風など) の救済。 */}
+            <span />
+            <label class={GLASS_CHECKBOX_LABEL}>
+              <input
+                type="checkbox"
+                class={GLASS_CHECKBOX_INPUT}
+                checked={imageShapeInvert()}
+                onChange={(e) => onImageShapeInvertChange(e.currentTarget.checked)}
+                disabled={!decoded() || downloading() || !imageShapeReady()}
+              />
+              <span>{t('imageShapeInvert')}</span>
+            </label>
           </>
         </Show>
 

--- a/web/src/lib/jsGlyphSdf.test.ts
+++ b/web/src/lib/jsGlyphSdf.test.ts
@@ -125,18 +125,9 @@ describe('generateImageSdf()', () => {
   // ImageBitmap-like / OffscreenCanvas-like の stub を渡すことで内部 EDT 経路を
   // 通せる。
 
-  test('OffscreenCanvas 未定義環境では全 0 を返す', () => {
-    vi.stubGlobal('OffscreenCanvas', undefined);
-    const fakeBitmap = { width: 16, height: 16 } as unknown as ImageBitmap;
-    const out = generateImageSdf(fakeBitmap, 16);
-    expect(out.length).toBe(16 * 16);
-    expect(out.every((v) => v === 0)).toBe(true);
-  });
-
-  test('完全透過な画像 (alpha 全 0) なら全 0 を返す', () => {
-    const SIZE = 8;
-    const data = new Uint8ClampedArray(SIZE * SIZE * 4);
-    class StubCanvas {
+  // 共通 stub
+  const makeStubCanvas = (data: Uint8ClampedArray, size: number) => {
+    return class StubCanvas {
       width: number;
       height: number;
       constructor(w: number, h: number) {
@@ -147,78 +138,123 @@ describe('generateImageSdf()', () => {
         return {
           clearRect: () => {},
           drawImage: () => {},
-          getImageData: () => ({ data, width: SIZE, height: SIZE }),
+          getImageData: () => ({ data, width: size, height: size }),
         };
       }
-    }
-    vi.stubGlobal('OffscreenCanvas', StubCanvas);
-    const fakeBitmap = { width: SIZE, height: SIZE } as unknown as ImageBitmap;
-    const out = generateImageSdf(fakeBitmap, SIZE);
-    expect(out.length).toBe(SIZE * SIZE);
-    expect(out.every((v) => v === 0)).toBe(true);
+    };
+  };
+
+  test('OffscreenCanvas 未定義環境では ok=false で全 0 を返す', () => {
+    vi.stubGlobal('OffscreenCanvas', undefined);
+    const fakeBitmap = { width: 16, height: 16 } as unknown as ImageBitmap;
+    const r = generateImageSdf(fakeBitmap, 16);
+    expect(r.ok).toBe(false);
+    expect(r.sdf.length).toBe(16 * 16);
+    expect(r.sdf.every((v) => v === 0)).toBe(true);
   });
 
-  test('透過画像 (alpha=255 中央 1px) で文字版と同じ SDF を生成する', () => {
-    // generateJsGlyphSdf と同じ EDT 経路を共有しているので、入力 alpha 配置が
-    // 同じなら出力 SDF も完全に同じになることを確認する (regression guard)。
+  test('完全透過な画像 (alpha 全 0) は ok=false', () => {
+    const SIZE = 8;
+    const data = new Uint8ClampedArray(SIZE * SIZE * 4);
+    vi.stubGlobal('OffscreenCanvas', makeStubCanvas(data, SIZE));
+    const fakeBitmap = { width: SIZE, height: SIZE } as unknown as ImageBitmap;
+    const r = generateImageSdf(fakeBitmap, SIZE);
+    expect(r.ok).toBe(false);
+    expect(r.sdf.every((v) => v === 0)).toBe(true);
+  });
+
+  test('透過画像 (alpha=255 中央 1px、他 alpha=0) は alpha 経路で文字版と同じ SDF を生成', () => {
+    // alpha<255 のピクセルが 63/64 = 98% > 1% → alpha 経路 (#171)。
+    // generateJsGlyphSdf と同じ EDT で同じ byte が出る (regression guard)。
     const SIZE = 8;
     const data = new Uint8ClampedArray(SIZE * SIZE * 4);
     data[(3 * SIZE + 3) * 4 + 3] = 255;
-    class StubCanvas {
-      width: number;
-      height: number;
-      constructor(w: number, h: number) {
-        this.width = w;
-        this.height = h;
-      }
-      getContext() {
-        return {
-          clearRect: () => {},
-          drawImage: () => {},
-          getImageData: () => ({ data, width: SIZE, height: SIZE }),
-        };
-      }
-    }
-    vi.stubGlobal('OffscreenCanvas', StubCanvas);
+    vi.stubGlobal('OffscreenCanvas', makeStubCanvas(data, SIZE));
     const fakeBitmap = { width: SIZE, height: SIZE } as unknown as ImageBitmap;
-    const out = generateImageSdf(fakeBitmap, SIZE);
-    expect(out[3 * SIZE + 3]).toBe(191);
-    expect(out[3 * SIZE + 2]).toBe(64);
-    expect(out[2 * SIZE + 2]).toBe(11);
-    expect(out[0]).toBe(0);
+    const r = generateImageSdf(fakeBitmap, SIZE);
+    expect(r.ok).toBe(true);
+    expect(r.sdf[3 * SIZE + 3]).toBe(191);
+    expect(r.sdf[3 * SIZE + 2]).toBe(64);
+    expect(r.sdf[2 * SIZE + 2]).toBe(11);
+    expect(r.sdf[0]).toBe(0);
   });
 
   test('不透明画像でも輝度しきい値で二値化される', () => {
-    // 全ピクセル alpha=255、中央 1 px だけ白 (輝度高)、他は黒 (輝度 0)。
-    // hasAlpha=false 経路に入り、avgY ≈ 255/64 ≈ 4。中央 1 px は輝度 255 で
-    // avgY 以上 → 「明るいセル数=1, 暗いセル数=63」 → 少数派の bright を
-    // inside とする → 中央が inside、その他が outside。alpha 経路と同じ
-    // SDF が出る。
+    // 全ピクセル alpha=255、中央 1 px だけ白 (輝度高)、他は黒。
+    // alphaPixelCount=0 → 不透明経路 → 少数派 (中央 1px) が inside。
     const SIZE = 8;
     const data = new Uint8ClampedArray(SIZE * SIZE * 4);
-    for (let i = 0; i < SIZE * SIZE; i++) data[i * 4 + 3] = 255; // alpha=255 全部
+    for (let i = 0; i < SIZE * SIZE; i++) data[i * 4 + 3] = 255;
     data[(3 * SIZE + 3) * 4 + 0] = 255;
     data[(3 * SIZE + 3) * 4 + 1] = 255;
     data[(3 * SIZE + 3) * 4 + 2] = 255;
-    class StubCanvas {
-      width: number;
-      height: number;
-      constructor(w: number, h: number) {
-        this.width = w;
-        this.height = h;
-      }
-      getContext() {
-        return {
-          clearRect: () => {},
-          drawImage: () => {},
-          getImageData: () => ({ data, width: SIZE, height: SIZE }),
-        };
-      }
-    }
-    vi.stubGlobal('OffscreenCanvas', StubCanvas);
+    vi.stubGlobal('OffscreenCanvas', makeStubCanvas(data, SIZE));
     const fakeBitmap = { width: SIZE, height: SIZE } as unknown as ImageBitmap;
-    const out = generateImageSdf(fakeBitmap, SIZE);
-    expect(out[3 * SIZE + 3]).toBe(191);
-    expect(out[3 * SIZE + 2]).toBe(64);
+    const r = generateImageSdf(fakeBitmap, SIZE);
+    expect(r.ok).toBe(true);
+    expect(r.sdf[3 * SIZE + 3]).toBe(191);
+    expect(r.sdf[3 * SIZE + 2]).toBe(64);
+  });
+
+  test('#169 単色塗り画像 (全画素同輝度) は ok=false でコントラスト不足を通知', () => {
+    // 全画素 RGB=(128,128,128), alpha=255 → 平均輝度=128、全画素が avgY と
+    // 同値で「未満」が 0 → insideIsDark=true、`y < avgY` は false 全部 →
+    // insideCount=0 → ok=false。
+    const SIZE = 8;
+    const data = new Uint8ClampedArray(SIZE * SIZE * 4);
+    for (let i = 0; i < SIZE * SIZE; i++) {
+      data[i * 4] = 128;
+      data[i * 4 + 1] = 128;
+      data[i * 4 + 2] = 128;
+      data[i * 4 + 3] = 255;
+    }
+    vi.stubGlobal('OffscreenCanvas', makeStubCanvas(data, SIZE));
+    const fakeBitmap = { width: SIZE, height: SIZE } as unknown as ImageBitmap;
+    const r = generateImageSdf(fakeBitmap, SIZE);
+    expect(r.ok).toBe(false);
+    expect(r.sdf.every((v) => v === 0)).toBe(true);
+  });
+
+  test('#170 invert=true で inside/outside が反転する', () => {
+    // 不透明・中央 1px 白 (= 自動判定で inside=中央)。invert=true で
+    // 中央以外が inside になり、SDF byte 値が大きく変わる。
+    const SIZE = 8;
+    const data = new Uint8ClampedArray(SIZE * SIZE * 4);
+    for (let i = 0; i < SIZE * SIZE; i++) data[i * 4 + 3] = 255;
+    data[(3 * SIZE + 3) * 4 + 0] = 255;
+    data[(3 * SIZE + 3) * 4 + 1] = 255;
+    data[(3 * SIZE + 3) * 4 + 2] = 255;
+    vi.stubGlobal('OffscreenCanvas', makeStubCanvas(data, SIZE));
+    const fakeBitmap = { width: SIZE, height: SIZE } as unknown as ImageBitmap;
+    const direct = generateImageSdf(fakeBitmap, SIZE, false);
+    const inverted = generateImageSdf(fakeBitmap, SIZE, true);
+    // 中央: direct は inside (signed_px=+0.5 → byte=191)、
+    //       invert は outside (signed_px=-0.5 → byte=64)。
+    expect(direct.sdf[3 * SIZE + 3]).toBe(191);
+    expect(inverted.sdf[3 * SIZE + 3]).toBe(64);
+  });
+
+  test('#171 alpha<255 が 1px だけの「実質不透明」画像は alpha 経路に入らない', () => {
+    // 8×8 の隅 1 px だけ alpha=128、他 alpha=255、輝度差は中央 1 px に持たせる。
+    // alphaPixelCount = 1、s*s = 64、1*100 = 100、64 と比べて 100 > 64 → true。
+    // つまり SIZE=8 の場合 1 px でも > 1% を超えてしまう。テストは輝度経路を
+    // ちゃんとピックアップする SIZE=32 で行う (1 px / 1024 = 0.097% < 1%)。
+    const SIZE = 32;
+    const data = new Uint8ClampedArray(SIZE * SIZE * 4);
+    for (let i = 0; i < SIZE * SIZE; i++) data[i * 4 + 3] = 255;
+    data[3] = 128; // (0,0) alpha=128 (1 px だけ alpha < 255)
+    // 中央 (16,16) を白く
+    const c = (16 * SIZE + 16) * 4;
+    data[c] = 255;
+    data[c + 1] = 255;
+    data[c + 2] = 255;
+    vi.stubGlobal('OffscreenCanvas', makeStubCanvas(data, SIZE));
+    const fakeBitmap = { width: SIZE, height: SIZE } as unknown as ImageBitmap;
+    const r = generateImageSdf(fakeBitmap, SIZE);
+    expect(r.ok).toBe(true);
+    // 輝度経路に入ったなら中央 (16,16) が inside で byte が高く、
+    // (0,0) は outside で 0 寄り。alpha 経路だと逆 (alpha=128 なら inside)。
+    expect(r.sdf[16 * SIZE + 16]).toBeGreaterThan(127);
+    expect(r.sdf[0]).toBeLessThan(127);
   });
 });

--- a/web/src/lib/jsGlyphSdf.ts
+++ b/web/src/lib/jsGlyphSdf.ts
@@ -142,7 +142,8 @@ export function generateImageSdf(
   for (let i = 0; i < s * s; i++) {
     if (data[i * 4 + 3] < 255) alphaPixelCount++;
   }
-  const hasMeaningfulAlpha = alphaPixelCount * 100 > s * s;
+  // ドキュメント上は「1% 以上」表記なので >= で揃える (boundary を inclusive)。
+  const hasMeaningfulAlpha = alphaPixelCount * 100 >= s * s;
 
   const inside = new Uint8Array(s * s);
   let insideCount = 0;

--- a/web/src/lib/jsGlyphSdf.ts
+++ b/web/src/lib/jsGlyphSdf.ts
@@ -76,27 +76,49 @@ export function generateJsGlyphSdf(ch: string, size: number): Uint8Array {
 }
 
 /**
+ * #160 結果型。`sdf` は SDF Uint8Array、`ok` は false ならシルエット抽出に
+ * 失敗したことを示す (#169: 単色塗りなどで inside / outside の分離が
+ * 取れない画像)。呼び出し側は `ok=false` のとき UI に「コントラスト不足」を
+ * 通知する。
+ */
+export interface ImageSdfResult {
+  sdf: Uint8Array;
+  ok: boolean;
+}
+
+/**
  * #160: 任意の `ImageBitmap` (PNG / JPG / WebP / SVG decode 結果) を
  * `size`×`size` の SDF Uint8Array にラスタライズする。
  *
  * しきい値:
- * - 透過画像 (`hasAlpha = true`): alpha >= 128 を inside とする
- * - 不透明画像 (`hasAlpha = false`): 輝度 (Y = 0.299R + 0.587G + 0.114B) で
- *   二値化。被写体が背景より暗いか明るいかは事前に決めず、画像全体の輝度
- *   平均を境界に inside / outside を分け、**inside ピクセルが少数派** に
- *   なる側を採用する (典型的な被写体は背景より小領域である前提)
+ * - 透過画像 (alpha < 255 のピクセルが画像全体の **1% 以上**): alpha >= 128
+ *   を inside とする (#171: 単発 stray 透過 1px で経路が暴れる問題を回避)
+ * - 不透明画像 (上記以外): 輝度 (Y = 0.299R + 0.587G + 0.114B) で二値化。
+ *   平均輝度を境界に **inside ピクセルが少数派** になる側を採用する (典型的
+ *   な被写体は背景より小領域である前提のヒューリスティック)
+ *
+ * #170: `invert` が true なら inside / outside を強制的に逆転させる
+ * (被写体が画面の半分以上を占める画像で自動判定が反転するときの救済)。
+ *
+ * #169: シルエットが抽出できない (= inside ピクセルが 0、または全画素が
+ * inside でコントラストが無い) 場合は `ok: false` を返し、呼び出し側で UI
+ * 通知を行う。`sdf` は念のため全 0 を入れる。
  *
  * 出力フォーマットは `generateJsGlyphSdf` と同一 (R8 size×size)、
  * `renderer.setGlyphSdf` にそのまま渡せる。
  */
-export function generateImageSdf(bitmap: ImageBitmap, size: number): Uint8Array {
+export function generateImageSdf(
+  bitmap: ImageBitmap,
+  size: number,
+  invert: boolean = false,
+): ImageSdfResult {
   const s = Math.max(1, size | 0);
   if (typeof OffscreenCanvas === 'undefined') {
-    return new Uint8Array(s * s);
+    return { sdf: new Uint8Array(s * s), ok: false };
   }
   const canvas = new OffscreenCanvas(s, s);
   const ctx = canvas.getContext('2d', { willReadFrequently: true });
-  if (!ctx) return new Uint8Array(s * s);
+  if (!ctx) return { sdf: new Uint8Array(s * s), ok: false };
 
   // 元画像のアスペクトを保ったまま s×s に「contain」リサンプル (上下/左右に
   // 余白を入れる)。シルエットが歪まないようにするため。
@@ -113,60 +135,65 @@ export function generateImageSdf(bitmap: ImageBitmap, size: number): Uint8Array 
   const img = ctx.getImageData(0, 0, s, s);
   const data = img.data;
 
-  // 透過があるかをチェック (alpha < 255 のピクセルが 1 つでもあれば「透過画像」)。
-  let hasAlpha = false;
+  // #171: 透過判定は「alpha < 255 のピクセルが画像全体の 1% 以上」で初めて
+  // 透過画像とみなす。1 px 単位の混入 (JPEG → PNG 変換のロス由来など) で
+  // alpha 経路に倒れて輝度ベースの被写体抽出が走らなくなる事故を防ぐ。
+  let alphaPixelCount = 0;
   for (let i = 0; i < s * s; i++) {
-    if (data[i * 4 + 3] < 255) {
-      hasAlpha = true;
-      break;
-    }
+    if (data[i * 4 + 3] < 255) alphaPixelCount++;
   }
+  const hasMeaningfulAlpha = alphaPixelCount * 100 > s * s;
 
   const inside = new Uint8Array(s * s);
-  let anyInside = false;
-  if (hasAlpha) {
-    // alpha しきい値 (透過画像経路)
+  let insideCount = 0;
+  if (hasMeaningfulAlpha) {
+    // alpha しきい値経路
     for (let i = 0; i < s * s; i++) {
       if (data[i * 4 + 3] >= 128) {
         inside[i] = 1;
-        anyInside = true;
+        insideCount++;
       }
     }
   } else {
-    // 輝度しきい値 (不透明画像経路)。平均輝度を境界にし、少数派のピクセル群を
-    // inside (= 被写体) とする。背景が暗い / 明るいの両方に対応するためのヒューリスティック。
+    // 輝度しきい値経路 (auto-polarity: 少数派 = 被写体)
     let sumY = 0;
+    const yBuf = new Float32Array(s * s);
     for (let i = 0; i < s * s; i++) {
       const r = data[i * 4];
       const g = data[i * 4 + 1];
       const b = data[i * 4 + 2];
-      sumY += 0.299 * r + 0.587 * g + 0.114 * b;
+      const y = 0.299 * r + 0.587 * g + 0.114 * b;
+      yBuf[i] = y;
+      sumY += y;
     }
     const avgY = sumY / (s * s);
     let darkCount = 0;
     for (let i = 0; i < s * s; i++) {
-      const r = data[i * 4];
-      const g = data[i * 4 + 1];
-      const b = data[i * 4 + 2];
-      const y = 0.299 * r + 0.587 * g + 0.114 * b;
-      if (y < avgY) darkCount++;
+      if (yBuf[i] < avgY) darkCount++;
     }
     const insideIsDark = darkCount < s * s / 2;
     for (let i = 0; i < s * s; i++) {
-      const r = data[i * 4];
-      const g = data[i * 4 + 1];
-      const b = data[i * 4 + 2];
-      const y = 0.299 * r + 0.587 * g + 0.114 * b;
-      const isInside = insideIsDark ? y < avgY : y >= avgY;
+      const isInside = insideIsDark ? yBuf[i] < avgY : yBuf[i] >= avgY;
       if (isInside) {
         inside[i] = 1;
-        anyInside = true;
+        insideCount++;
       }
     }
   }
-  if (!anyInside) return new Uint8Array(s * s);
 
-  return computeSdfFromMask(inside, s);
+  // #170: invert が true なら inside/outside を flip。auto-polarity で
+  // 反転誤判定された画像の救済。
+  if (invert) {
+    for (let i = 0; i < s * s; i++) inside[i] = inside[i] ? 0 : 1;
+    insideCount = s * s - insideCount;
+  }
+
+  // #169: 全 inside でも全 outside でもコントラスト 0 として扱う。
+  if (insideCount === 0 || insideCount === s * s) {
+    return { sdf: new Uint8Array(s * s), ok: false };
+  }
+
+  return { sdf: computeSdfFromMask(inside, s), ok: true };
 }
 
 // inside mask (0/1) → Rust 互換の SDF Uint8Array を計算する共通経路。

--- a/web/src/lib/orberClient.ts
+++ b/web/src/lib/orberClient.ts
@@ -253,9 +253,16 @@ export async function workerGlyphSupported(ch: string): Promise<boolean> {
  * ない)。これでメインスレッド側に File への参照が残り、worker クラッシュ
  * 後の再 upload が可能になる。worker 側で `createImageBitmap(file)` を
  * 呼んで ImageBitmap 化し、古い bitmap は close() される。
+ *
+ * #170: `invert` で inside/outside を強制反転する (auto-polarity が外れる
+ * 画像の救済)。worker 側で SDF キャッシュに含まれるため、トグル切替時は
+ * 必ず再 upload する必要がある。
  */
-export async function workerSetImageShape(file: File): Promise<void> {
-  await call<void>({ kind: 'setImageShape', file });
+export async function workerSetImageShape(
+  file: File,
+  invert: boolean = false,
+): Promise<void> {
+  await call<void>({ kind: 'setImageShape', file, invert });
 }
 
 /** 1 タイル分の mp4 を返す（WebCodecs + mp4-muxer で h264 化）。 */

--- a/web/src/lib/orberWorker.ts
+++ b/web/src/lib/orberWorker.ts
@@ -49,14 +49,18 @@ let cachedCanvas: { canvas: OffscreenCanvas; renderer: GlRenderer; width: number
 // 切替の余地を残すために含める。getRenderer で renderer を作り直したときも
 // invalidate する必要がある（テクスチャも一緒に dispose されるため）。
 //
-// #160: shape='image' のときは ch ではなく ImageBitmap を SDF 元にするので、
-// kind を分けてキャッシュする。bitmap は Studio から `setImageShape` で 1 度
-// 送られて worker にキャッシュされる (cachedImageBitmap)。
+// #160 / #172: shape='image' のときは ch ではなく ImageBitmap (cachedImageBitmap)
+// と invert flag (cachedImageInvert) を SDF の元にする。`cachedGlyph` の image
+// 分岐は SDF アップロード状態の identity (= どの (bitmap, invert, size) で
+// upload 済か) を表すフラグなので、bitmap reference を再保持する必要は無い:
+// setImageShape で cachedImageBitmap が差し替わるたびに cachedGlyph を null
+// にすれば、次の ensureImageSdfUploaded で必ず再 upload される (#172 N1)。
 let cachedGlyph:
   | { kind: 'char'; ch: string; size: number }
-  | { kind: 'image'; bitmap: ImageBitmap; size: number }
+  | { kind: 'image'; size: number; invert: boolean }
   | null = null;
 let cachedImageBitmap: ImageBitmap | null = null;
+let cachedImageInvert = false;
 
 function getRenderer(width: number, height: number): { canvas: OffscreenCanvas; renderer: GlRenderer } {
   if (cachedCanvas && cachedCanvas.width === width && cachedCanvas.height === height) {
@@ -122,9 +126,13 @@ function ensureGlyphSdfUploaded(renderer: GlRenderer, ch: string): void {
   cachedGlyph = { kind: 'char', ch, size };
 }
 
-// #160: shape='image' 用。Studio 側で `setImageShape(bitmap)` 経由で送られて
+// #160: shape='image' 用。Studio 側で `setImageShape` 経由で送られて
 // `cachedImageBitmap` に入っている画像をシルエット化 → SDF 化 → upload。
-// 同じ bitmap reference なら再生成しない。
+// 同じ (bitmap, invert) なら再生成しない (setImageShape が cachedGlyph を
+// null にするので reference が変われば必ず再 upload される)。
+//
+// #169: シルエット抽出に失敗 (コントラスト不足) したら専用 Error を投げる。
+// 呼び出し側 (Studio) で `imageShapeNoContrast` 文言の UI に使う。
 function ensureImageSdfUploaded(renderer: GlRenderer): void {
   const size = GLYPH_SDF_SIZE;
   if (!cachedImageBitmap) {
@@ -133,27 +141,38 @@ function ensureImageSdfUploaded(renderer: GlRenderer): void {
   if (
     cachedGlyph &&
     cachedGlyph.kind === 'image' &&
-    cachedGlyph.bitmap === cachedImageBitmap &&
-    cachedGlyph.size === size
+    cachedGlyph.size === size &&
+    cachedGlyph.invert === cachedImageInvert
   )
     return;
-  const sdf = generateImageSdf(cachedImageBitmap, size);
-  renderer.setGlyphSdf(sdf, size);
-  cachedGlyph = { kind: 'image', bitmap: cachedImageBitmap, size };
+  const result = generateImageSdf(cachedImageBitmap, size, cachedImageInvert);
+  if (!result.ok) {
+    throw new Error('image-shape-no-contrast');
+  }
+  renderer.setGlyphSdf(result.sdf, size);
+  cachedGlyph = { kind: 'image', size, invert: cachedImageInvert };
 }
+
+// #160 / #172 N2: shape='image' のとき wasm 側に渡すダミー glyph_char。
+// wasm は SDF テクスチャをそのまま使うので glyph_char の値は読まないが、
+// 内部バリデーションが「非空」を要求しているケースを想定して安全な記号を
+// 当てる。将来 wasm 側で glyph_char バリデーションが厳格化された場合
+// (例: 同梱フォントに収録されている字のみ受け付ける) でも、`☆` (Noto Sans
+// Symbols 2 同梱・glyph_supported(☆)=true) を選ぶことで silent fail しにくい。
+// 真の解決は crates/wasm 側で shape='image' を直接受け付ける API を生やす
+// ことだが、現状はテクスチャ上書きの仕組みで充分なため UI レイヤで吸収する。
+const IMAGE_SHAPE_DUMMY_GLYPH = '☆';
 
 function mergeParams(p: BaseParams) {
   if (!cachedSource) {
     throw new Error('source not set — call setSource before generate/animate');
   }
-  // #160: UI shape='image' は wasm からは shape='glyph' (= SDF テクスチャを
-  // サンプルする) として見せる。glyph_char は wasm 内部の SDF キャッシュ
-  // キーになるが、こちらでテクスチャを上書き upload するので値は問われない。
-  // 念のため非空ダミー ('A') を入れて wasm の glyph_char バリデーションが
-  // 弾かないようにする。
+  // UI shape='image' は wasm からは shape='glyph' (= SDF テクスチャを
+  // サンプルする) として見せる。`IMAGE_SHAPE_DUMMY_GLYPH` を渡す理由は
+  // 上の定数コメントを参照。
   const wasmShape = p.shape === 'image' ? 'glyph' : p.shape;
   const wasmGlyphChar =
-    p.shape === 'image' ? 'A' : p.glyph_char;
+    p.shape === 'image' ? IMAGE_SHAPE_DUMMY_GLYPH : p.glyph_char;
   return {
     ...p,
     shape: wasmShape,
@@ -214,7 +233,7 @@ type Req =
   // Transferable を使わず structured-clone で渡す ── main 側が File 参照
   // を保持し続けることで、worker クラッシュ / terminateAndRespawn 後の
   // 再 upload が可能になる。
-  | { kind: 'setImageShape'; id: number; file: File };
+  | { kind: 'setImageShape'; id: number; file: File; invert: boolean };
 
 /// #56: wasm get_render_data の Float32Array header word 3 (= bg.a in 0..1) を 0 に
 /// 上書きして「透過背景でレンダリングしてくれ」と shader に依頼する。元 buffer は
@@ -254,7 +273,10 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
           cachedImageBitmap.close();
         }
         cachedImageBitmap = newBitmap;
-        // 既存の image SDF キャッシュを invalidate (新 bitmap で再生成させる)。
+        cachedImageInvert = req.invert;
+        // 既存の image SDF キャッシュを invalidate (新 bitmap / invert で
+        // 再生成させる)。これによって ensureImageSdfUploaded 側は単純な
+        // (size, invert) 比較だけで済む (#172 N1)。
         if (cachedGlyph && cachedGlyph.kind === 'image') {
           cachedGlyph = null;
         }

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -58,6 +58,11 @@ export const STRINGS = {
     ja: '画像を選択してください',
     en: 'Pick an image first',
   },
+  imageShapeInvert: { ja: 'シルエット反転', en: 'Invert silhouette' },
+  imageShapeNoContrast: {
+    ja: 'この画像にはコントラストがありません',
+    en: 'This image has no contrast',
+  },
   glyphCharLabel: { ja: '文字', en: 'Character' },
   // #159 後は任意の Unicode 1 文字を受け付ける (絵文字 / 漢字 / 記号)。
   // placeholder は文字種の多様性を例示してユーザーに「何でも入る」ことを


### PR DESCRIPTION
## 関連 Issue
closes #169 #170 #171 #172

PR #168 (#160 Image shape) のセルフレビューで挙がった deferred 4 件をまとめて消化。

## 変更
### #169 コントラスト不足の明示エラー
- `generateImageSdf` を `{ sdf, ok }` 戻り値に変更
- inside ピクセル数が 0 or 全画素 inside (= シルエット抽出不可) で `ok: false` を返す
- `ensureImageSdfUploaded` は `image-shape-no-contrast` エラーを throw
- Studio 側 `formatRunBatchError` で `imageShapeNoContrast` 文言にマップ
- 単色塗り画像で「何も起きない」状態を「この画像にはコントラストがありません」エラーに

### #170 シルエット反転トグル
- 画像入力 row に \`imageShapeInvert\` checkbox 追加
- `workerSetImageShape(file, invert)` で worker に渡す
- `generateImageSdf(bitmap, size, invert)` で auto-polarity を flip
- トグル切替時は worker 側 SDF を即時再生成して runBatch を打つ
- 証明写真風 (被写体が画面の半分以上) の救済

### #171 alpha しきい値の強化
- `alpha < 255` のピクセル数が画像全体の **1% 以上** のときだけ透過画像扱い
- 1 px stray 透過 (JPEG → PNG 変換ロス等) で alpha 経路に倒れる事故を防止

### #172 内部状態の整理
- `cachedGlyph.kind === 'image'` から bitmap reference 保持を削除し \`{ size, invert }\` のみに (N1)
- `IMAGE_SHAPE_DUMMY_GLYPH` を `'A'` → `'☆'` (Noto Sans Symbols 2 同梱、glyph_supported 確実) に変更し将来の wasm バリデーション強化に備える (N2)

## 検証
- `npm test` ✓ 19/19 → 22/22 pass (+3 件、jsGlyphSdf テスト全面再構築)
- `npm run build` ✓

## ドキュメント
DESIGN.md の「Image 入力 (#160)」章を新挙動 (#169 / #170 / #171 / #172) に追従。

## 関連
- PR #168 (#160 Image shape 本体) のセルフレビュー指摘の deferred 全件