### PR TITLE
fix(web): kako-jun/orber#174 スマホ UI/UX 8 件まとめ修正

### DIFF
--- a/web/src/components/AffiliateGrid.tsx
+++ b/web/src/components/AffiliateGrid.tsx
@@ -25,10 +25,10 @@ export default function AffiliateGrid() {
       <h2 class="text-xs text-fgMuted mb-4 tracking-wide text-center">
         {t('affiliateHeading')}
       </h2>
-      {/* レビュー: max-w-sm (24rem) では caption が折り返されたため max-w-xl
-          (36rem) に拡大。3 列 × ~180px/cell でフリガナの長い caption も 1-2 行で
-          収まる。Footer のコンテナ (max-w-3xl) より小さい範囲で中央寄せを保つ。 */}
-      <ul class="grid grid-cols-3 gap-4 max-w-xl mx-auto">
+      {/* #174: max-w-xl (36rem) を外して Footer の max-w-3xl いっぱい
+          (= ドロップエリアと同じ幅) まで広げる。スマホ窮屈問題の解消。
+          gap はスマホ gap-3, sm 以上 gap-4 で caption の折り返しを抑える。 */}
+      <ul class="grid grid-cols-3 gap-3 sm:gap-4 w-full">
         {AFFILIATE_PRODUCTS.map((p) => (
           <li>
             <a

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -99,13 +99,13 @@ export default function Footer() {
 
   return (
     <footer
-      class="mt-16 border-t border-hairline"
+      class="mt-16"
       aria-label={t('footerAriaLabel')}
     >
-      {/* レビュー: 下のスペースは main の p-8 (32px) のみに頼り、footer 自体の
-          bottom padding は削る (pb-0)。これで © kako-jun の下のスペースが
-          ヘッダ「orber」の上のスペースと揃う。 */}
-      <div class="mx-auto max-w-3xl px-4 pt-10 pb-0 flex flex-col items-center text-center gap-8">
+      {/* #174: 旧 border-t border-hairline は削除。区切り線をやめてオーブ
+          モチーフ (●×5) の上下が同サイズの余白になるよう、py-10 を据える。
+          下端は main の p-8 を据え置き (旧 pb-0 と同じ意図)。 */}
+      <div class="mx-auto max-w-3xl px-4 py-10 pb-0 flex flex-col items-center text-center gap-8">
         {/* Orb motif — 縦 5 個のドット (DESIGN.md §14) */}
         <div
           class="flex flex-col items-center gap-2 py-2"
@@ -172,30 +172,74 @@ export default function Footer() {
           <span>v{buildDate}</span>
         </div>
 
-        {/* D. Copyright + 関連リンク (machigai-salad パターン)。
-            [llll-ll.com] · [GitHub Sponsors テキスト] · © kako-jun を 1 行で。
-            上の大きな Sponsor button は CTA として残しつつ、ここでも小さい
-            テキストリンクを再掲して machigai-salad の終端 UI と揃える。 */}
-        <div class="flex flex-wrap items-center justify-center gap-3 text-xs text-fgSubtle">
+        {/* #174: D. Copyright 行 — テキストリンク (`More by kako-jun` /
+            `GitHub Sponsors`) を SVG アイコン並びに置換。osaka-kenpo / sasso /
+            agasteer で使われる home / GitHub / Sponsors アイコンと同形式。
+            旧版は `GitHub Sponsors` の長さでスマホ幅に収まらず、`© kako-jun`
+            がハイフン直後で改行されて `kako-` のみ前行に残る不格好な崩れが
+            発生していた。アイコン化で行が短くなり、さらに `© kako-jun` 自体に
+            whitespace-nowrap を当てて折り返しを禁じる。 */}
+        <div class="flex flex-wrap items-center justify-center gap-4 text-xs text-fgSubtle">
           <a
             href="https://llll-ll.com"
             target="_blank"
             rel="noopener noreferrer"
-            class="underline decoration-hairline underline-offset-2 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            aria-label={t('authorSiteAriaLabel')}
+            title={t('authorSiteAriaLabel')}
+            class="hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing focus-visible:ring-offset-2 focus-visible:ring-offset-bg rounded"
           >
-            {t('authorSiteLabel')}
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+            </svg>
           </a>
-          <span aria-hidden="true">·</span>
+          <a
+            href="https://github.com/kako-jun/orber"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={t('repoLinkAriaLabel')}
+            title={t('repoLinkAriaLabel')}
+            class="hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing focus-visible:ring-offset-2 focus-visible:ring-offset-bg rounded"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.27-.01-1.01-.02-1.98-3.2.69-3.87-1.54-3.87-1.54-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18a11 11 0 015.79 0c2.21-1.5 3.18-1.18 3.18-1.18.62 1.58.23 2.75.11 3.04.74.8 1.18 1.83 1.18 3.09 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.06.78 2.13 0 1.54-.01 2.78-.01 3.16 0 .31.21.68.79.56C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z" />
+            </svg>
+          </a>
           <a
             href="https://github.com/sponsors/kako-jun"
             target="_blank"
             rel="noopener noreferrer"
-            class="underline decoration-hairline underline-offset-2 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            aria-label={t('sponsorAriaLabel')}
+            title={t('sponsorAriaLabel')}
+            class="hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing focus-visible:ring-offset-2 focus-visible:ring-offset-bg rounded"
           >
-            {t('sponsorTextLabel')}
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M12 21s-7-4.5-9.5-9C.5 8 3 4 7 4c2 0 3.5 1 5 3 1.5-2 3-3 5-3 4 0 6.5 4 4.5 8C19 16.5 12 21 12 21z" />
+            </svg>
           </a>
           <span aria-hidden="true">·</span>
-          <span class="font-display font-light">© kako-jun</span>
+          <span class="font-display font-light whitespace-nowrap">© kako-jun</span>
         </div>
       </div>
     </footer>

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -103,9 +103,10 @@ export default function Footer() {
       aria-label={t('footerAriaLabel')}
     >
       {/* #174: 旧 border-t border-hairline は削除。区切り線をやめてオーブ
-          モチーフ (●×5) の上下が同サイズの余白になるよう、py-10 を据える。
-          下端は main の p-8 を据え置き (旧 pb-0 と同じ意図)。 */}
-      <div class="mx-auto max-w-3xl px-4 py-10 pb-0 flex flex-col items-center text-center gap-8">
+          モチーフ (●×5) の上下が同サイズの余白になるよう、上端 pt-10 を据える。
+          下端は main の p-8 (32px) のみに頼り、footer 自体の bottom padding
+          は pb-0 で削る (旧実装と同じ意図)。 */}
+      <div class="mx-auto max-w-3xl px-4 pt-10 pb-0 flex flex-col items-center text-center gap-8">
         {/* Orb motif — 縦 5 個のドット (DESIGN.md §14) */}
         <div
           class="flex flex-col items-center gap-2 py-2"

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -599,6 +599,12 @@ export default function Studio() {
     // workerSetSource で reject されるだけ。最初の段階で弾いてエラー UI
     // を据え置く。
     if (wasmStatus() === 'error') return;
+    // #174 invariant: 画像差し替え時は shape / glyphChar / glyphRotate /
+    // imageShapeInvert / countPreset / speedPreset / softnessPreset / aspect
+    // のオプション signal を一切リセットしない。ユーザーが新しい画像を
+    // ドロップした際、下に並ぶ調整ボタンの選択状態は前画像の操作を継承する。
+    // (acceptFile が触るのは pickedName / pickedThumbUrl / phase / decoded /
+    // errorMsg のみで、UI 4 軸 + shape は無関係に維持される。)
     setErrorMsg('');
     setPickedName(file.name);
     // サムネイル URL を差し替え。前回分は revoke してメモリリークを防ぐ。

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -605,6 +605,12 @@ export default function Studio() {
     // ドロップした際、下に並ぶ調整ボタンの選択状態は前画像の操作を継承する。
     // (acceptFile が触るのは pickedName / pickedThumbUrl / phase / decoded /
     // errorMsg のみで、UI 4 軸 + shape は無関係に維持される。)
+    //
+    // imageShapeInvert は shape='image' で使う「画像シルエット」ファイル側の
+    // 極性反転トグルで、ドロップエリアに入れる「ソース画像」とは別の File
+    // 経路 (onImageShapePick / onImageShapeInvertChange) に紐づく。
+    // ソース画像を差し替えてもシルエットファイルは worker キャッシュに残る
+    // ため、invert 状態を継承するのが正しい (ユーザーの意図的選択)。
     setErrorMsg('');
     setPickedName(file.name);
     // サムネイル URL を差し替え。前回分は revoke してメモリリークを防ぐ。
@@ -1166,6 +1172,10 @@ export default function Studio() {
   // 視覚変化が乏しく、ユーザーから「チェックマークが出ていない」と
   // 報告されていた。背景指定を外して OS ネイティブの accent-color 塗り
   // (白塗り + 黒/濃グレーのチェックマーク) に委ねる。
+  // unchecked 状態は border-glassBorder (1.5px hairline) で枠を確保するので、
+  // デスクトップ Firefox/Chrome の dark theme でも box 自体は背景から見分け
+  // られる。bg を指定しないことで透けるのは UA 既定 (薄い灰塗り) で
+  // 一貫したチェック描画が得られる。
   const GLASS_CHECKBOX_INPUT =
     'h-4 w-4 rounded-sm border border-glassBorder ' +
     'accent-fg ' +

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -1155,8 +1155,13 @@ export default function Studio() {
   const GLASS_CHECKBOX_LABEL =
     'inline-flex items-center gap-2 cursor-pointer text-sm text-fg ' +
     'has-[:disabled]:opacity-40 has-[:disabled]:cursor-not-allowed';
+  // #174: 旧 `bg-glassBg` を削除。iOS Safari / Android Chrome では半透明白
+  // 背景の上に accent-fg (白) でチェックを描画すると checked 状態でも
+  // 視覚変化が乏しく、ユーザーから「チェックマークが出ていない」と
+  // 報告されていた。背景指定を外して OS ネイティブの accent-color 塗り
+  // (白塗り + 黒/濃グレーのチェックマーク) に委ねる。
   const GLASS_CHECKBOX_INPUT =
-    'h-4 w-4 rounded-sm border border-glassBorder bg-glassBg ' +
+    'h-4 w-4 rounded-sm border border-glassBorder ' +
     'accent-fg ' +
     'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing ' +
     'disabled:cursor-not-allowed';
@@ -1365,9 +1370,12 @@ export default function Studio() {
           </button>
         </div>
 
-        {/* #133: glyph 入力欄は datalist combobox 化。
-            候補は supportedGlyphChoices() (Noto Sans Symbols 2 同梱記号)、
-            自由入力は IME 経由で emoji なども受け付ける。
+        {/* #133 / #174: glyph 入力欄。旧 datalist combobox は iOS Safari /
+            Android Chrome でドロップダウンが表示されない (PWA モードでは更に
+            不安定) という問題があったため、#174 で datalist と list 属性を
+            削除した。下に並ぶ 9×2 picker grid が代替 UI として既に存在し、
+            機能的に等価。input は素の text 入力として残し、IME 経由で emoji
+            なども自由入力できる挙動は維持する。
             glyph-symbol-text class で picker / input 表示を Noto Sans Symbols 2
             に揃え、⚡ などの白ベタ描画を実現する (Base.astro)。 */}
         <Show when={shape() === 'glyph'}>
@@ -1375,7 +1383,6 @@ export default function Studio() {
             <span />
             <input
               type="text"
-              list="glyph-suggestions"
               aria-label={t('glyphCharLabel')}
               value={glyphChar()}
               placeholder={t('glyphCharPlaceholder')}
@@ -1402,11 +1409,6 @@ export default function Studio() {
                 'disabled:opacity-40 disabled:cursor-not-allowed'
               }
             />
-            <datalist id="glyph-suggestions">
-              <For each={supportedGlyphChoices()}>
-                {(sym) => <option value={sym} />}
-              </For>
-            </datalist>
             <span />
             {/* 9 列 × 2 段の固定グリッド。各ボタンは w-full でセル幅を埋め、
                 右端が他の segmented control 行とぴったり揃う。 */}

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -179,6 +179,15 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
       .glyph-symbol-text {
         font-family: 'Noto Sans Symbols 2', system-ui, sans-serif;
         font-variant-emoji: text;
+        /* #174: Noto Sans Symbols 2 はフォント自体の baseline / metrics box
+           が cap-height に対して下に偏っているため、flex items-center だけで
+           は picker ボタン内で記号が下寄り (もしくは右寄り) に見える。
+           font-feature 指定で metric を均し、line-height を 1 に強制した上で
+           text-align: center を当て、span 側の flex centring と二重に揃える。
+           Y 軸の追加補正は OS / フォントバージョン差で別ズレを誘発するので
+           足さず、まずは line-height + text-align のみで揃えて様子を見る。 */
+        line-height: 1;
+        text-align: center;
       }
       .skeleton {
         background-color: rgba(255, 255, 255, 0.04);

--- a/web/src/lib/jsGlyphSdf.test.ts
+++ b/web/src/lib/jsGlyphSdf.test.ts
@@ -234,6 +234,57 @@ describe('generateImageSdf()', () => {
     expect(inverted.sdf[3 * SIZE + 3]).toBe(64);
   });
 
+  test('#174 非正方形画像 — レタボックスの透明領域に引きずられず被写体輪郭を抽出する', () => {
+    // 16×8 の不透明 (alpha=255) 画像を 16×16 SDF サイズへ contain 描画する想定。
+    // bitmap.width=16, bitmap.height=8 → scale=1, dw=16, dh=8, dx=0, dy=4。
+    // 描画矩形 = rows 4..11、それ以外 (rows 0..3 と 12..15) はレタボ alpha=0。
+    //
+    // 旧実装は s*s 全体で alpha 集計したため、レタボ 8 行分 (128 px)で
+    // hasMeaningfulAlpha=true → alpha 経路に倒れ、描画矩形全 128 px が inside と
+    // 判定されて結果が「16×8 の矩形シルエット」になっていた (#174)。
+    //
+    // 新実装は描画矩形 (0..16, 4..12) 内だけで alpha を集計する。drawn pixel は
+    // 全 alpha=255 なので alphaPixelCount=0 → 輝度経路 → 「少数派 = 被写体」で
+    // 中央 2×2 の暗パッチだけが inside、白背景は outside になる。
+    const SIZE = 16;
+    const data = new Uint8ClampedArray(SIZE * SIZE * 4);
+    // レタボ部分は alpha=0 のまま (clearRect 後の initial state を再現)。
+    // 描画矩形 (rows 4..11) は白背景 alpha=255 + 中央 2×2 を黒で塗る。
+    for (let y = 4; y < 12; y++) {
+      for (let x = 0; x < 16; x++) {
+        const i = y * SIZE + x;
+        data[i * 4] = 255;
+        data[i * 4 + 1] = 255;
+        data[i * 4 + 2] = 255;
+        data[i * 4 + 3] = 255;
+      }
+    }
+    // 中央 2×2 の暗パッチ (= 被写体)。位置 (7,7), (8,7), (7,8), (8,8)。
+    for (const [x, y] of [
+      [7, 7],
+      [8, 7],
+      [7, 8],
+      [8, 8],
+    ] as const) {
+      const i = y * SIZE + x;
+      data[i * 4] = 0;
+      data[i * 4 + 1] = 0;
+      data[i * 4 + 2] = 0;
+    }
+    vi.stubGlobal('OffscreenCanvas', makeStubCanvas(data, SIZE));
+    const fakeBitmap = { width: 16, height: 8 } as unknown as ImageBitmap;
+    const r = generateImageSdf(fakeBitmap, SIZE);
+    expect(r.ok).toBe(true);
+    // 中央 2×2 の暗パッチ ((7,7) etc.) は inside (= byte > 127)。
+    expect(r.sdf[7 * SIZE + 7]).toBeGreaterThan(127);
+    // 描画矩形内の白背景 ((2,7) など、被写体と同じ row だが背景側) は outside。
+    expect(r.sdf[7 * SIZE + 2]).toBeLessThan(127);
+    // レタボ部分 (row 0 や row 15) も outside。旧実装ではここも inside 判定
+    // された結果矩形シルエットになっていた。
+    expect(r.sdf[0 * SIZE + 0]).toBeLessThan(127);
+    expect(r.sdf[15 * SIZE + 8]).toBeLessThan(127);
+  });
+
   test('#171 alpha<255 が 1px だけの「実質不透明」画像は alpha 経路に入らない', () => {
     // 8×8 の隅 1 px だけ alpha=128、他 alpha=255、輝度差は中央 1 px に持たせる。
     // alphaPixelCount = 1、s*s = 64、1*100 = 100、64 と比べて 100 > 64 → true。

--- a/web/src/lib/jsGlyphSdf.ts
+++ b/web/src/lib/jsGlyphSdf.ts
@@ -135,62 +135,96 @@ export function generateImageSdf(
   const img = ctx.getImageData(0, 0, s, s);
   const data = img.data;
 
-  // #171: 透過判定は「alpha < 255 のピクセルが画像全体の 1% 以上」で初めて
-  // 透過画像とみなす。1 px 単位の混入 (JPEG → PNG 変換のロス由来など) で
-  // alpha 経路に倒れて輝度ベースの被写体抽出が走らなくなる事故を防ぐ。
+  // #174: contain-fit で生じるレタボックス領域 (描画矩形 dx..dx+dw / dy..dy+dh
+  // の外側) は `clearRect` 後に alpha=0 のまま残る。旧実装はこのレタボ部分
+  // も含めて s*s 全体で alpha 集計していたため、JPEG (本来不透明) を非正方形
+  // で入力すると `alphaPixelCount` がレタボ分だけ膨らみ `hasMeaningfulAlpha`
+  // が常に true 化、alpha 経路に倒れて「描画矩形 = inside」の純粋な矩形
+  // シルエットになっていた (#174 報告: 白背景 + キャラの絵でもキャラ輪郭が
+  // 取れず矩形のまま)。
+  // 修正: 透過判定 / 輝度判定の両経路とも、評価範囲を描画矩形 (dx..dx+dw,
+  // dy..dy+dh) に限定する。レタボ部分は inside=0 を維持し、最終 SDF では
+  // 確実に背景として扱われる。
+  const drawnPixelCount = dw * dh;
+
+  // #171 + #174: 透過判定は「描画矩形内で alpha<255 のピクセルが 1% 以上」。
+  // 1 px 単位の混入 (JPEG → PNG 変換のロス由来など) で alpha 経路に倒れて
+  // 輝度ベース抽出が無効化される事故を防ぐ閾値はそのまま、母数だけ
+  // s*s → dw*dh に置換。
   let alphaPixelCount = 0;
-  for (let i = 0; i < s * s; i++) {
-    if (data[i * 4 + 3] < 255) alphaPixelCount++;
+  for (let y = dy; y < dy + dh; y++) {
+    for (let x = dx; x < dx + dw; x++) {
+      if (data[(y * s + x) * 4 + 3] < 255) alphaPixelCount++;
+    }
   }
-  // ドキュメント上は「1% 以上」表記なので >= で揃える (boundary を inclusive)。
-  const hasMeaningfulAlpha = alphaPixelCount * 100 >= s * s;
+  const hasMeaningfulAlpha = alphaPixelCount * 100 >= drawnPixelCount;
 
   const inside = new Uint8Array(s * s);
   let insideCount = 0;
   if (hasMeaningfulAlpha) {
-    // alpha しきい値経路
-    for (let i = 0; i < s * s; i++) {
-      if (data[i * 4 + 3] >= 128) {
-        inside[i] = 1;
-        insideCount++;
+    // alpha しきい値経路 — 描画矩形内のみ評価。レタボ部分は inside=0 のまま。
+    for (let y = dy; y < dy + dh; y++) {
+      for (let x = dx; x < dx + dw; x++) {
+        const i = y * s + x;
+        if (data[i * 4 + 3] >= 128) {
+          inside[i] = 1;
+          insideCount++;
+        }
       }
     }
   } else {
-    // 輝度しきい値経路 (auto-polarity: 少数派 = 被写体)
+    // 輝度しきい値経路 (auto-polarity: 少数派 = 被写体)。
+    // 平均輝度・dark/light 集計・しきい値判定すべて描画矩形内に閉じる。
     let sumY = 0;
     const yBuf = new Float32Array(s * s);
-    for (let i = 0; i < s * s; i++) {
-      const r = data[i * 4];
-      const g = data[i * 4 + 1];
-      const b = data[i * 4 + 2];
-      const y = 0.299 * r + 0.587 * g + 0.114 * b;
-      yBuf[i] = y;
-      sumY += y;
+    for (let y = dy; y < dy + dh; y++) {
+      for (let x = dx; x < dx + dw; x++) {
+        const i = y * s + x;
+        const r = data[i * 4];
+        const g = data[i * 4 + 1];
+        const b = data[i * 4 + 2];
+        const yv = 0.299 * r + 0.587 * g + 0.114 * b;
+        yBuf[i] = yv;
+        sumY += yv;
+      }
     }
-    const avgY = sumY / (s * s);
+    const avgY = sumY / drawnPixelCount;
     let darkCount = 0;
-    for (let i = 0; i < s * s; i++) {
-      if (yBuf[i] < avgY) darkCount++;
+    for (let y = dy; y < dy + dh; y++) {
+      for (let x = dx; x < dx + dw; x++) {
+        const i = y * s + x;
+        if (yBuf[i] < avgY) darkCount++;
+      }
     }
-    const insideIsDark = darkCount < s * s / 2;
-    for (let i = 0; i < s * s; i++) {
-      const isInside = insideIsDark ? yBuf[i] < avgY : yBuf[i] >= avgY;
-      if (isInside) {
-        inside[i] = 1;
-        insideCount++;
+    const insideIsDark = darkCount < drawnPixelCount / 2;
+    for (let y = dy; y < dy + dh; y++) {
+      for (let x = dx; x < dx + dw; x++) {
+        const i = y * s + x;
+        const isInside = insideIsDark ? yBuf[i] < avgY : yBuf[i] >= avgY;
+        if (isInside) {
+          inside[i] = 1;
+          insideCount++;
+        }
       }
     }
   }
 
-  // #170: invert が true なら inside/outside を flip。auto-polarity で
-  // 反転誤判定された画像の救済。
+  // #170 + #174: invert は描画矩形内のみで反転。レタボ部分は inside=0 を維持。
+  // 旧実装は s*s 全体で flip していたため、レタボ部分も inside=1 化して
+  // 不要な巨大シルエットが生成されていた。
   if (invert) {
-    for (let i = 0; i < s * s; i++) inside[i] = inside[i] ? 0 : 1;
-    insideCount = s * s - insideCount;
+    for (let y = dy; y < dy + dh; y++) {
+      for (let x = dx; x < dx + dw; x++) {
+        const i = y * s + x;
+        inside[i] = inside[i] ? 0 : 1;
+      }
+    }
+    insideCount = drawnPixelCount - insideCount;
   }
 
   // #169: 全 inside でも全 outside でもコントラスト 0 として扱う。
-  if (insideCount === 0 || insideCount === s * s) {
+  // 母数は描画矩形内 (drawnPixelCount) で判定する。
+  if (insideCount === 0 || insideCount === drawnPixelCount) {
     return { sdf: new Uint8Array(s * s), ok: false };
   }
 

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -173,10 +173,15 @@ export const STRINGS = {
   viewsLabelSuffix: { ja: '', en: ' views' },
   // #146 review S2: Footer 全体の aria-label を i18n 化。
   footerAriaLabel: { ja: 'orber フッター', en: 'orber footer' },
-  // Footer 末尾の小さい link 行 (machigai-salad パターン)。
-  // [authorSite] · [GitHub Sponsors テキスト] · © kako-jun を 1 行で。
+  // Footer 末尾の小さい link 行。#174 でテキストリンクからアイコン並びに変更
+  // (osaka-kenpo / sasso / agasteer と統一)。© kako-jun は whitespace-nowrap で
+  // ハイフンを跨ぐ改行を防ぐ (旧: `kako-` で改行され `jun` だけ次行に落ちる)。
   authorSiteLabel: { ja: 'kako-jun の他作品', en: 'More by kako-jun' },
   sponsorTextLabel: { ja: 'GitHub Sponsors', en: 'GitHub Sponsors' },
+  // #174: アイコンリンクの aria-label。
+  authorSiteAriaLabel: { ja: 'kako-jun のサイト', en: "kako-jun's site" },
+  repoLinkAriaLabel: { ja: 'GitHub リポジトリ', en: 'GitHub repository' },
+  sponsorAriaLabel: { ja: 'GitHub Sponsors', en: 'GitHub Sponsors' },
   // #146: About 見出し / aboutBody / aboutBuiltWith / repoLinkLabel は Footer から外した。
   // privacyNote だけ「画像はブラウザ内で処理される」境界条件として残す。
   // #148: PWA install prompt (machigai-salad と同パターンの toast)。

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -142,7 +142,9 @@ export const STRINGS = {
   },
   // #128 / #156: Footer (Amazon affiliate / QR / Copyright / Counter)。
   // sponsorLabel / sponsorTitle は #156 で大きい GH Sponsors button を削除して
-  // 以来未使用 (テキストリンクは sponsorTextLabel 側) なので削除済み。
+  // 以来未使用なので削除済み。authorSiteLabel / sponsorTextLabel も #174 で
+  // テキストリンク → アイコン化に伴い未使用になり削除済み (置換キー:
+  // authorSiteAriaLabel / repoLinkAriaLabel / sponsorAriaLabel)。
   //
   // affiliate 文言:
   //   - User 「本やゲームは機材じゃない」「Amazon と 2 回言う必要はない」
@@ -176,9 +178,7 @@ export const STRINGS = {
   // Footer 末尾の小さい link 行。#174 でテキストリンクからアイコン並びに変更
   // (osaka-kenpo / sasso / agasteer と統一)。© kako-jun は whitespace-nowrap で
   // ハイフンを跨ぐ改行を防ぐ (旧: `kako-` で改行され `jun` だけ次行に落ちる)。
-  authorSiteLabel: { ja: 'kako-jun の他作品', en: 'More by kako-jun' },
-  sponsorTextLabel: { ja: 'GitHub Sponsors', en: 'GitHub Sponsors' },
-  // #174: アイコンリンクの aria-label。
+  // 各アイコンリンクの aria-label / title。
   authorSiteAriaLabel: { ja: 'kako-jun のサイト', en: "kako-jun's site" },
   repoLinkAriaLabel: { ja: 'GitHub リポジトリ', en: 'GitHub repository' },
   sponsorAriaLabel: { ja: 'GitHub Sponsors', en: 'GitHub Sponsors' },


### PR DESCRIPTION
## 関連 Issue
closes #174

## 変更内容
スマホで報告された UX バグを 4 コミット + レビュー対応 1 コミットで修正。

### A. AffiliateGrid 幅 (220639f)
`max-w-xl` の内側中央寄せを外し、Footer の `max-w-3xl` コンテナいっぱい (= 画像ドラッグエリアと同じ幅) に広げる。スマホで 3 列が窮屈に見える問題を解消。

### B. Footer アイコン化 + 水平線削除 (ee52f30)
- 末尾のテキストリンク (`More by kako-jun` / `GitHub Sponsors`) を home / GitHub / Sponsors の SVG アイコン並びに置換 (osaka-kenpo / sasso / agasteer と同形式)
- **追加判断**: Issue #174 では既存 2 リンクのアイコン化のみ指示されていたが、参考リポ群 (osaka-kenpo / sasso) では GitHub リポリンクも併設されていたため、`https://github.com/kako-jun/orber` への 3 つ目のアイコンを追加した
- `© kako-jun` に `whitespace-nowrap` を付与し `kako-` で改行されてハイフンが前行に残る崩れを禁ずる
- 上端の `border-t border-hairline` を削除。区切り線をやめ、オーブモチーフ (●×5) の上下が同サイズの余白になるよう `pt-10` を据える

### C. モバイル チェックマーク不可視 (600d89c に同梱)
`GLASS_CHECKBOX_INPUT` から `bg-glassBg` を削除。iOS Safari / Android Chrome では半透明白の上に `accent-fg` (白) でチェックを描画すると視覚変化が乏しく「チェックマークが出ていない」と報告されていた。OS ネイティブの accent-color 塗りに委ねる。

### G. モバイル combobox ドロップダウン不表示 (600d89c に同梱)
`<datalist id="glyph-suggestions">` と `list="glyph-suggestions"` 属性を削除。iOS Safari ではドロップダウンが表示されず、PWA モードで更に不安定。9×2 picker grid が代替 UI として既に存在するため機能等価。素の text 入力は維持。

### F. グリフボタンの中央配置 (600d89c に同梱)
`.glyph-symbol-text` に `line-height: 1` / `text-align: center` を追加。Noto Sans Symbols 2 のフォント metrics 由来の下/右寄りズレを抑える。Y 軸の transform 補正は OS / フォントバージョン差で別ズレを誘発するため導入しない。

### E. 画像シルエット抽出のレタボ誤判定 (4ff4f5b)
`generateImageSdf` で contain-fit のレタボックス領域 (`alpha=0` のまま残る部分) を alpha 集計に含めていたため、非正方形の不透明 JPEG/PNG では `hasMeaningfulAlpha` が常に true 化し描画矩形全体が inside 判定 = 矩形シルエットになっていた。透過判定 / 輝度判定 / invert / コントラスト不足判定の全経路で評価範囲を描画矩形 `(dx..dx+dw, dy..dy+dh)` に限定。母数も `drawnPixelCount=dw*dh` に置換。

テスト追加: 16×8 の白背景+中央 2×2 黒の bitmap を 16×16 SDF に contain 描画する想定で、被写体パッチが inside、白背景とレタボが outside になることを確認。既存 12 件は全て正方形入力 (dx=dy=0) で挙動不変。

### D. 画像再ドロップでオプションがリセットされる (4ff4f5b に同梱)
コードを精査した結果、`acceptFile` は `pickedName` / `pickedThumbUrl` / `phase` / `decoded` / `errorMsg` のみを触り、UI 4 軸 + shape + glyph 関連はリセットしないことを確認。invariant をコメントで明文化し regression-guard とする。実機でなお挙動が異なる場合は別 Issue として再切出しを依頼。

### レビュー対応 (a0547ea)
- Footer.tsx: `py-10 pb-0` → `pt-10 pb-0` (コメントとクラス順を一致)
- Studio.tsx: `imageShapeInvert` がシルエットファイル側に紐づくこと、unchecked box が `border-glassBorder` で識別可能なことを invariant コメントに明記

## 検証
- `cd web && npm test`: 23 passed (新規 #174 非正方形テスト含む)
- `cd web && npm run build`: clean (wasm rebuild 含む)
- 実機確認は CF Pages preview デプロイで行う想定