### PR TITLE
fix(web): kako-jun/orber#174 二次対応 — Footer 余白 / checkbox / glyph 中央 / Orb 改名

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -350,7 +350,10 @@ Reduced motion: respect `prefers-reduced-motion: reduce` by clamping all transit
 
 ### Image 入力 (#160)
 
-- shape segmented pill は `Circle / Glyph / Image` の 3 択
+- shape segmented pill は `Orb / Glyph / Image` の 3 択 (内部値 `circle` /
+  `glyph` / `image` は wasm enum と紐付くため不変。UI ラベルのみ #174 で
+  Circle → Orb に改名し、専用ぼかし経路と Glyph の汎用 SDF 経路の挙動差を
+  明示)
 - `Image` を選ぶとシェイプ row の下に画像入力 row が出現する: ファイル選択
   ボタン + 9×9 サムネイル + ファイル名表示
 - 入力画像 (PNG / JPG / WebP / GIF / SVG) は **`File` を worker に

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -110,8 +110,8 @@ export default function Footer() {
             上 = mt-8 (32px) + 内側 py-2 (8px) = 40px
             下 = 内側 py-2 (8px) + gap-8 (32px) = 40px
           下端は main の p-8 (32px) のみに頼り、footer の bottom padding は
-          pb-0 で削る (旧実装と同じ意図)。 */}
-      <div class="mx-auto max-w-3xl px-4 pt-0 pb-0 flex flex-col items-center text-center gap-8">
+          py-0 で削る (旧実装と同じ意図)。 */}
+      <div class="mx-auto max-w-3xl px-4 py-0 flex flex-col items-center text-center gap-8">
         {/* Orb motif — 縦 5 個のドット (DESIGN.md §14) */}
         <div
           class="flex flex-col items-center gap-2 py-2"

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -99,14 +99,19 @@ export default function Footer() {
 
   return (
     <footer
-      class="mt-16"
+      class="mt-8"
       aria-label={t('footerAriaLabel')}
     >
-      {/* #174: 旧 border-t border-hairline は削除。区切り線をやめてオーブ
-          モチーフ (●×5) の上下が同サイズの余白になるよう、上端 pt-10 を据える。
-          下端は main の p-8 (32px) のみに頼り、footer 自体の bottom padding
-          は pb-0 で削る (旧実装と同じ意図)。 */}
-      <div class="mx-auto max-w-3xl px-4 pt-10 pb-0 flex flex-col items-center text-center gap-8">
+      {/* #174: 旧 border-t border-hairline は削除済み。border が無いままで
+          pt-10 を残すと「水平線が消えただけで上の余白が広すぎる」見え方に
+          なるため、上端パディングを 0 に。footer 自体の上下分離は mt-8
+          (Studio との区切り) のみに頼り、オーブモチーフ (●×5) の上下が
+          gap-8 ベースで同サイズの余白になる:
+            上 = mt-8 (32px) + 内側 py-2 (8px) = 40px
+            下 = 内側 py-2 (8px) + gap-8 (32px) = 40px
+          下端は main の p-8 (32px) のみに頼り、footer の bottom padding は
+          pb-0 で削る (旧実装と同じ意図)。 */}
+      <div class="mx-auto max-w-3xl px-4 pt-0 pb-0 flex flex-col items-center text-center gap-8">
         {/* Orb motif — 縦 5 個のドット (DESIGN.md §14) */}
         <div
           class="flex flex-col items-center gap-2 py-2"

--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -1167,18 +1167,16 @@ export default function Studio() {
   const GLASS_CHECKBOX_LABEL =
     'inline-flex items-center gap-2 cursor-pointer text-sm text-fg ' +
     'has-[:disabled]:opacity-40 has-[:disabled]:cursor-not-allowed';
-  // #174: 旧 `bg-glassBg` を削除。iOS Safari / Android Chrome では半透明白
-  // 背景の上に accent-fg (白) でチェックを描画すると checked 状態でも
-  // 視覚変化が乏しく、ユーザーから「チェックマークが出ていない」と
-  // 報告されていた。背景指定を外して OS ネイティブの accent-color 塗り
-  // (白塗り + 黒/濃グレーのチェックマーク) に委ねる。
-  // unchecked 状態は border-glassBorder (1.5px hairline) で枠を確保するので、
-  // デスクトップ Firefox/Chrome の dark theme でも box 自体は背景から見分け
-  // られる。bg を指定しないことで透けるのは UA 既定 (薄い灰塗り) で
-  // 一貫したチェック描画が得られる。
+  // #174 (二次対応): accent-color: white は iOS Safari / Android Chrome では
+  // 「白い箱に白いチェックマーク」となり、checked かどうか視認できない。
+  // 旧版は accent-fg + bg-glassBg だったが効果が無かったため、appearance:none
+  // にして自前で checked 状態を描画する方式に切り替える。
+  // - unchecked: border-glassBorder + 透明背景 (UA defaults を完全置換)
+  // - checked: bg-fg (白塗り) + ::after の SVG 風チェックマークを CSS で描画
+  // クラス `glass-checkbox` を Base.astro に置き、Tailwind では到達できない
+  // ::after / :checked + ::after を CSS 側で表現する。
   const GLASS_CHECKBOX_INPUT =
-    'h-4 w-4 rounded-sm border border-glassBorder ' +
-    'accent-fg ' +
+    'glass-checkbox h-4 w-4 ' +
     'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focusRing ' +
     'disabled:cursor-not-allowed';
   const isRunning = () =>
@@ -1448,10 +1446,13 @@ export default function Studio() {
                         Noto Sans Symbols 2 のモノクロ描画を強制する。Chromium は
                         font-variant-emoji: text で対応済み。selector は display 用で、
                         value (sym) には付けないので状態管理は影響を受けない。
-                        Noto Sans Symbols 2 はフォント独自の baseline でボタン中央
-                        からズレるので、span を flex で h-full 化して再度
-                        items-center / justify-center を当てて強制センタリングする。 */}
-                    <span class="flex h-full w-full items-center justify-center leading-none">
+                        #174 (二次対応): flex items-center だけでは Noto Sans Symbols 2
+                        のフォント metrics (asc/desc 不均等) によりボタン中央からズレ
+                        続けるため、grid place-items-center に切り替え + line-height: 1
+                        で line box を最小化、かつ class .glyph-picker-cell を当てて
+                        Base.astro 側の `transform: translateY(...)` で X-height 中心と
+                        ボタン中央のズレを微補正する。 */}
+                    <span class="glyph-picker-cell grid h-full w-full place-items-center leading-none">
                       {sym + '︎'}
                     </span>
                   </button>

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -179,15 +179,66 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
       .glyph-symbol-text {
         font-family: 'Noto Sans Symbols 2', system-ui, sans-serif;
         font-variant-emoji: text;
-        /* #174: Noto Sans Symbols 2 はフォント自体の baseline / metrics box
-           が cap-height に対して下に偏っているため、flex items-center だけで
-           は picker ボタン内で記号が下寄り (もしくは右寄り) に見える。
-           font-feature 指定で metric を均し、line-height を 1 に強制した上で
-           text-align: center を当て、span 側の flex centring と二重に揃える。
-           Y 軸の追加補正は OS / フォントバージョン差で別ズレを誘発するので
-           足さず、まずは line-height + text-align のみで揃えて様子を見る。 */
         line-height: 1;
         text-align: center;
+      }
+      /* #174 (二次対応): Noto Sans Symbols 2 はフォント自体の asc/desc が
+         cap-height に対して下に偏っており、grid place-items-center で line
+         box を中央に置いても glyph 自体は line box 内で下寄りに描画される。
+         picker セル限定で 1px 上に持ち上げ、ボタンの光学中心と一致させる。
+         input / button 自体には適用しない (placeholder の位置がズレるため)。
+         tabular-nums で metric 揺れを抑え、span を inline-grid 化することで
+         line-height: 0 でも下端が切れないようにする。 */
+      .glyph-picker-cell {
+        font-feature-settings: 'tnum' 1;
+        transform: translateY(-1px);
+      }
+      /* #174 (二次対応): 自前チェックボックス。
+         accent-color では iOS / Android で「白箱+白チェック」になり checked が
+         見えなかったため、appearance:none で UA 描画を完全に殺し、
+         ::before の SVG-mask でチェックマークを描く。色は fg / bg / glassBorder
+         トークンのみ使用し、DESIGN.md のモノクロ縛りを守る。
+         - unchecked: 透明背景 + 1.5px hairline の枠
+         - checked:   bg-fg (白) で塗り潰し、::before に bg (#040404) のチェック
+         - focus:     focus-ring を残す (Tailwind side で focus-visible:ring) */
+      .glass-checkbox {
+        appearance: none;
+        -webkit-appearance: none;
+        position: relative;
+        cursor: pointer;
+        background-color: transparent;
+        border: 1.5px solid rgba(255, 255, 255, 0.32);
+        border-radius: 3px;
+        flex-shrink: 0;
+        transition: background-color 120ms ease, border-color 120ms ease;
+      }
+      .glass-checkbox:hover:not(:disabled) {
+        border-color: rgba(255, 255, 255, 0.55);
+      }
+      .glass-checkbox:checked {
+        background-color: #ffffff;
+        border-color: #ffffff;
+      }
+      /* チェックマーク本体: ::after 内に白背景上の暗いチェックを SVG mask で
+         描く。背景は bg トークン (#040404) と同値で、orber のページ背景に
+         自然に溶け込む濃さ。 */
+      .glass-checkbox:checked::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: #040404;
+        -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3.5 8.5l3 3 6-6.5' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+        mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3.5 8.5l3 3 6-6.5' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+        mask-position: center;
+        -webkit-mask-size: 90% 90%;
+        mask-size: 90% 90%;
+      }
+      .glass-checkbox:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
       }
       .skeleton {
         background-color: rgba(255, 255, 255, 0.04);

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -191,15 +191,19 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
          line-height: 0 でも下端が切れないようにする。 */
       .glyph-picker-cell {
         font-feature-settings: 'tnum' 1;
-        transform: translateY(-1px);
+        /* #174 review S2: 旧 transform: translateY(-1px) は paint だけでなく
+           合成レイヤを生み 9×2 全セルで GPU レイヤ分裂のおそれ。低スペック
+           Android での stutter 回避のため position-relative + top に切替。 */
+        position: relative;
+        top: -1px;
       }
       /* #174 (二次対応): 自前チェックボックス。
          accent-color では iOS / Android で「白箱+白チェック」になり checked が
          見えなかったため、appearance:none で UA 描画を完全に殺し、
-         ::before の SVG-mask でチェックマークを描く。色は fg / bg / glassBorder
+         ::after の SVG-mask でチェックマークを描く。色は fg / bg / glassBorder
          トークンのみ使用し、DESIGN.md のモノクロ縛りを守る。
-         - unchecked: 透明背景 + 1.5px hairline の枠
-         - checked:   bg-fg (白) で塗り潰し、::before に bg (#040404) のチェック
+         - unchecked: 透明背景 + 1.5px の glassBorder 枠
+         - checked:   bg-fg (白) で塗り潰し、::after に bg (#040404) のチェック
          - focus:     focus-ring を残す (Tailwind side で focus-visible:ring) */
       .glass-checkbox {
         appearance: none;
@@ -207,7 +211,10 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
         position: relative;
         cursor: pointer;
         background-color: transparent;
-        border: 1.5px solid rgba(255, 255, 255, 0.32);
+        /* #174 review S1: 0.32 (fgSubtle 相当) は他 glass 系より突出して濃い。
+           他コンポーネント (glyph input 等) と同じ glassBorder (0.12) に揃える。
+           DESIGN.md トークンと整合。 */
+        border: 1.5px solid rgba(255, 255, 255, 0.12);
         border-radius: 3px;
         flex-shrink: 0;
         transition: background-color 120ms ease, border-color 120ms ease;
@@ -221,14 +228,15 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
       }
       /* チェックマーク本体: ::after 内に白背景上の暗いチェックを SVG mask で
          描く。背景は bg トークン (#040404) と同値で、orber のページ背景に
-         自然に溶け込む濃さ。 */
+         自然に溶け込む濃さ。data: URL は ;charset=utf-8, 形式で記述
+         (一部パーサが ;utf8, を非標準扱いするため)。 */
       .glass-checkbox:checked::after {
         content: '';
         position: absolute;
         inset: 0;
         background-color: #040404;
-        -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3.5 8.5l3 3 6-6.5' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-        mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3.5 8.5l3 3 6-6.5' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+        -webkit-mask-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3.5 8.5l3 3 6-6.5' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+        mask-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3.5 8.5l3 3 6-6.5' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
         -webkit-mask-repeat: no-repeat;
         mask-repeat: no-repeat;
         -webkit-mask-position: center;
@@ -239,6 +247,21 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
       .glass-checkbox:disabled {
         opacity: 0.4;
         cursor: not-allowed;
+      }
+      /* #174 review S3: Windows 高コントラストモード対応。
+         forced-colors 環境では background-color が無視されチェックが消える
+         既知パターンのため、CanvasText/Canvas システム色で再描画する。 */
+      @media (forced-colors: active) {
+        .glass-checkbox {
+          border-color: CanvasText;
+        }
+        .glass-checkbox:checked {
+          background-color: CanvasText;
+          border-color: CanvasText;
+        }
+        .glass-checkbox:checked::after {
+          background-color: Canvas;
+        }
       }
       .skeleton {
         background-color: rgba(255, 255, 255, 0.04);

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -44,7 +44,11 @@ export const STRINGS = {
     en: 'Roll again with the same image',
   },
   shapeLabel: { ja: '形状', en: 'Shape' },
-  shapeOptionCircle: { ja: '円', en: 'Circle' },
+  // #174 (二次対応): 'Circle' は orber 専用のぼかし経路で描画される (SDF を
+  // 介さず純粋な soft circle gradient)。Glyph の ● は generateJsGlyphSdf を
+  // 通る汎用 SDF 経路でエッジが立つ。両者は意図的に挙動が違うため、UI 上は
+  // 専用経路であることが伝わる 'Orb' / 'オーブ' に改名する。
+  shapeOptionCircle: { ja: 'オーブ', en: 'Orb' },
   shapeOptionGlyph: { ja: '文字', en: 'Glyph' },
   shapeOptionImage: { ja: '画像', en: 'Image' },
   // #160: Image shape (任意の画像をシルエット化して orb として使う) の UI。


### PR DESCRIPTION
## 関連 Issue
refs #174 (主 PR #175 のフォローアップ)

## 変更内容

### A. Footer 上部の余白縮小
水平線削除後、丸 5 個より上のスペースが「水平線が消えただけ」の広いままだった。

- `mt-16` → `mt-8`、内側 `pt-10` → `pt-0`
- これでオーブモチーフ上下が同サイズの 40px 余白に揃う:
  - 上 = mt-8 (32) + py-2 (8) = 40px
  - 下 = py-2 (8) + gap-8 (32) = 40px

### B. チェックマーク不可視 (再対応)
`accent-color: white` は iOS Safari / Android Chrome で「白箱に白チェック」となり checked が見えない問題が残っていた。

- 新 class `.glass-checkbox` を Base.astro に追加
- `appearance: none` で UA 描画を完全に殺し、`::after` の SVG mask で暗色 (#040404) チェックマークを描く
- checked: 白塗り、unchecked: 透明背景 + hairline 枠
- DESIGN.md のモノクロ縛り (fg / bg / glassBorder のみ) は維持

### C. グリフ中央配置 (再対応)
`flex items-center` + `line-height: 1` だけでは Noto Sans Symbols 2 の asc/desc 不均等で picker ボタン中央からズレ続けていた。

- span を `grid place-items-center` 化
- 新 class `.glyph-picker-cell` で `transform: translateY(-1px)` の微補正を picker セル限定で当てる
- input / button 自体には適用しない (placeholder 位置がズレるため)

### D. shape ラベル Circle → Orb 改名
ユーザー報告: Circle と Glyph 「●」 の見た目差が「同じ円なのに違う = バグ?」と読まれていた。実際は意図的:

- `Circle` は orber 専用の soft circle gradient 経路 (純粋なぼかし)
- `Glyph ●` は `generateJsGlyphSdf` 経由の汎用 SDF 経路 (エッジが立つ)

専用経路であることが伝わる 'Orb' / 'オーブ' に改名。内部値 `shape='circle'` は wasm enum と紐付いているため不変。

## 検証
- `cd web && npm test`: 23 passed
- `cd web && npm run build`: clean
- 実機確認は CF Pages preview デプロイで行う想定