### PR TITLE
fix(web): kako-jun/orber#174 グリフ picker の tnum を削除 (右上寄せ回避)

### DIFF
--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -190,12 +190,14 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
          tabular-nums で metric 揺れを抑え、span を inline-grid 化することで
          line-height: 0 でも下端が切れないようにする。 */
       .glyph-picker-cell {
-        font-feature-settings: 'tnum' 1;
         /* #174 review S2: 旧 transform: translateY(-1px) は paint だけでなく
            合成レイヤを生み 9×2 全セルで GPU レイヤ分裂のおそれ。低スペック
            Android での stutter 回避のため position-relative + top に切替。 */
         position: relative;
         top: -1px;
+        /* tnum (tabular-nums) は数字用フィーチャーだが、シンボルフォントに
+           適用するとグリフが右寄せされる挙動が出るため不採用 (#174 二次
+           レビュー後に判明)。 */
       }
       /* #174 (二次対応): 自前チェックボックス。
          accent-color では iOS / Android で「白箱+白チェック」になり checked が


### PR DESCRIPTION
## 関連 Issue
refs #174

## 内容
PR #176 で picker セルに付けた `font-feature-settings: 'tnum' 1` を削除。

tabular-nums は数字用の OpenType feature だが、Noto Sans Symbols 2 のようなシンボルフォントに当てると glyph が右寄せされる挙動が出る実装がある。実機で「グリフがボタン内の右上寄せになっている」報告を受けたため即修正。

位置補正は `position: relative; top: -1px;` のみで、Y 軸中央配置は従来通り保つ。

## 検証
- npm test: 23 passed (CSS 変更のみで logic 影響なし)
- 実機確認はマージ後の CF Pages preview で