### PR TITLE
fix(web): kako-jun/orber#174 グリフ picker を 3px 下押しで光学中心に揃える

### DIFF
--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -189,15 +189,16 @@ const canonicalUrl = new URL(Astro.url.pathname, SITE_URL).toString();
          input / button 自体には適用しない (placeholder の位置がズレるため)。
          tabular-nums で metric 揺れを抑え、span を inline-grid 化することで
          line-height: 0 でも下端が切れないようにする。 */
+      /* #174 (三次対応): Noto Sans Symbols 2 はフォント自体が glyph を em-box
+         の上半分寄りに置く設計のため、flex items-center だけでは光学中心が
+         上にズレる。フォント側を変更できないため、CSS で下方向にピクセル単位の
+         オフセットを掛けて視覚中心と一致させる。
+         translateY ではなく position:relative + top にすることで GPU 合成
+         レイヤを生まずに済む。値は実機 (h-9 ボタン + Noto Sans Symbols 2 1rem)
+         で 3px 下押しがおおむね中央に揃う実測値。 */
       .glyph-picker-cell {
-        /* #174 review S2: 旧 transform: translateY(-1px) は paint だけでなく
-           合成レイヤを生み 9×2 全セルで GPU レイヤ分裂のおそれ。低スペック
-           Android での stutter 回避のため position-relative + top に切替。 */
         position: relative;
-        top: -1px;
-        /* tnum (tabular-nums) は数字用フィーチャーだが、シンボルフォントに
-           適用するとグリフが右寄せされる挙動が出るため不採用 (#174 二次
-           レビュー後に判明)。 */
+        top: 3px;
       }
       /* #174 (二次対応): 自前チェックボックス。
          accent-color では iOS / Android で「白箱+白チェック」になり checked が


### PR DESCRIPTION
## refs #174

Noto Sans Symbols 2 はフォント設計上 glyph を em-box の上半分寄りに置くため、flex items-center や grid place-items-center といった box ベースの中央配置ではどうしても光学中心が上にズレる (PR #176/#179 で flex/grid を試したが解消せず)。

フォント本体は変更できないので CSS 側で picker セルに 3px 下方向オフセットを掛ける。GPU 合成レイヤ分裂を避けるため transform でなく `position:relative; top: 3px;` で実装。

実機で値が大きすぎ/小さすぎる場合は数値だけ調整する。