### PR TITLE
fix(web): kako-jun/orber#181 シルエット反転トグルを削除

### DIFF
--- a/web/src/components/Studio.tsx
+++ b/web/src/components/Studio.tsx
@@ -136,9 +136,9 @@ export default function Studio() {
   const [imageShapeName, setImageShapeName] = createSignal<string>('');
   const [imageShapeUrl, setImageShapeUrl] = createSignal<string>('');
   const [imageShapeReady, setImageShapeReady] = createSignal<boolean>(false);
-  // #170: シルエット反転トグル。auto-polarity (= 少数派 = 被写体) が外れる
-  // 画像 (証明写真など被写体が画面の半分以上) の救済。
-  const [imageShapeInvert, setImageShapeInvert] = createSignal<boolean>(false);
+  // #181: シルエット反転トグル (#170) は #174 のレタボ誤判定修正後に
+  // 実機検証で効果が視認できないレベルになったため削除。auto-polarity が
+  // 外れる画像があれば外部 (magick -negate 等) で反転して再ドロップする。
   // setImageShape を再送するための File ref。runBatch / crash 経路で参照。
   let lastImageFileRef: File | null = null;
   // M1: 初期値は `''`（identity）。UI 側で「標準」ボタンが `aria-pressed` 状態に
@@ -600,17 +600,11 @@ export default function Studio() {
     // を据え置く。
     if (wasmStatus() === 'error') return;
     // #174 invariant: 画像差し替え時は shape / glyphChar / glyphRotate /
-    // imageShapeInvert / countPreset / speedPreset / softnessPreset / aspect
-    // のオプション signal を一切リセットしない。ユーザーが新しい画像を
-    // ドロップした際、下に並ぶ調整ボタンの選択状態は前画像の操作を継承する。
+    // countPreset / speedPreset / softnessPreset / aspect のオプション signal
+    // を一切リセットしない。ユーザーが新しい画像をドロップした際、下に並ぶ
+    // 調整ボタンの選択状態は前画像の操作を継承する。
     // (acceptFile が触るのは pickedName / pickedThumbUrl / phase / decoded /
     // errorMsg のみで、UI 4 軸 + shape は無関係に維持される。)
-    //
-    // imageShapeInvert は shape='image' で使う「画像シルエット」ファイル側の
-    // 極性反転トグルで、ドロップエリアに入れる「ソース画像」とは別の File
-    // 経路 (onImageShapePick / onImageShapeInvertChange) に紐づく。
-    // ソース画像を差し替えてもシルエットファイルは worker キャッシュに残る
-    // ため、invert 状態を継承するのが正しい (ユーザーの意図的選択)。
     setErrorMsg('');
     setPickedName(file.name);
     // サムネイル URL を差し替え。前回分は revoke してメモリリークを防ぐ。
@@ -759,7 +753,7 @@ export default function Studio() {
   const onImageShapePick = async (file: File, triggerRun = true) => {
     try {
       lastImageFileRef = file;
-      await workerSetImageShape(file, imageShapeInvert());
+      await workerSetImageShape(file);
       const oldUrl = imageShapeUrl();
       if (oldUrl) URL.revokeObjectURL(oldUrl);
       setImageShapeUrl(URL.createObjectURL(file));
@@ -770,23 +764,6 @@ export default function Studio() {
       console.warn('failed to load image shape', err);
       setErrorMsg(t('imageShapeLoadFailed'));
       setImageShapeReady(false);
-    }
-  };
-
-  // #170: invert トグル切替時に worker 側 SDF を再生成する。File ref が
-  // 残っていれば再 upload を試み、失敗時は signal をロールバックして UI
-  // と worker 状態の整合を保つ (S2)。スタイルは onImageShapePick の async
-  // /try-catch に揃える (N1)。
-  const onImageShapeInvertChange = async (next: boolean) => {
-    setImageShapeInvert(next);
-    if (!lastImageFileRef || shape() !== 'image') return;
-    try {
-      await workerSetImageShape(lastImageFileRef, next);
-      runBatchIfReady();
-    } catch (err) {
-      console.warn('failed to re-upload image shape on invert toggle', err);
-      setImageShapeInvert(!next);
-      setErrorMsg(formatRunBatchError(err));
     }
   };
 
@@ -1516,19 +1493,10 @@ export default function Studio() {
                 </span>
               </Show>
             </div>
-            {/* #170: シルエット反転トグル。auto-polarity が外れる画像
-                (被写体が画面の半分以上を占める証明写真風など) の救済。 */}
-            <span />
-            <label class={GLASS_CHECKBOX_LABEL}>
-              <input
-                type="checkbox"
-                class={GLASS_CHECKBOX_INPUT}
-                checked={imageShapeInvert()}
-                onChange={(e) => void onImageShapeInvertChange(e.currentTarget.checked)}
-                disabled={!decoded() || downloading() || !imageShapeReady()}
-              />
-              <span>{t('imageShapeInvert')}</span>
-            </label>
+            {/* #181: シルエット反転トグル (#170) は #174 のレタボ修正後に
+                効果が視認できないレベルになったため削除。auto-polarity が
+                外れる画像があれば外部 (magick -negate 等) で反転して再ドロップ
+                で対処する。 */}
           </>
         </Show>
 

--- a/web/src/lib/jsGlyphSdf.test.ts
+++ b/web/src/lib/jsGlyphSdf.test.ts
@@ -215,24 +215,7 @@ describe('generateImageSdf()', () => {
     expect(r.sdf.every((v) => v === 0)).toBe(true);
   });
 
-  test('#170 invert=true で inside/outside が反転する', () => {
-    // 不透明・中央 1px 白 (= 自動判定で inside=中央)。invert=true で
-    // 中央以外が inside になり、SDF byte 値が大きく変わる。
-    const SIZE = 8;
-    const data = new Uint8ClampedArray(SIZE * SIZE * 4);
-    for (let i = 0; i < SIZE * SIZE; i++) data[i * 4 + 3] = 255;
-    data[(3 * SIZE + 3) * 4 + 0] = 255;
-    data[(3 * SIZE + 3) * 4 + 1] = 255;
-    data[(3 * SIZE + 3) * 4 + 2] = 255;
-    vi.stubGlobal('OffscreenCanvas', makeStubCanvas(data, SIZE));
-    const fakeBitmap = { width: SIZE, height: SIZE } as unknown as ImageBitmap;
-    const direct = generateImageSdf(fakeBitmap, SIZE, false);
-    const inverted = generateImageSdf(fakeBitmap, SIZE, true);
-    // 中央: direct は inside (signed_px=+0.5 → byte=191)、
-    //       invert は outside (signed_px=-0.5 → byte=64)。
-    expect(direct.sdf[3 * SIZE + 3]).toBe(191);
-    expect(inverted.sdf[3 * SIZE + 3]).toBe(64);
-  });
+  // #181: invert (#170) は削除済み。テストも撤去。
 
   test('#174 非正方形画像 — レタボックスの透明領域に引きずられず被写体輪郭を抽出する', () => {
     // 16×8 の不透明 (alpha=255) 画像を 16×16 SDF サイズへ contain 描画する想定。

--- a/web/src/lib/jsGlyphSdf.ts
+++ b/web/src/lib/jsGlyphSdf.ts
@@ -97,8 +97,9 @@ export interface ImageSdfResult {
  *   平均輝度を境界に **inside ピクセルが少数派** になる側を採用する (典型的
  *   な被写体は背景より小領域である前提のヒューリスティック)
  *
- * #170: `invert` が true なら inside / outside を強制的に逆転させる
- * (被写体が画面の半分以上を占める画像で自動判定が反転するときの救済)。
+ * #181: 旧 invert 引数 (#170) は #174 のレタボ修正後に効果が視認できない
+ * レベルになり削除。auto-polarity (= 少数派 = 被写体) のみで判定する。
+ * 自動判定が外れる画像があれば外部 (magick -negate 等) で反転入力する。
  *
  * #169: シルエットが抽出できない (= inside ピクセルが 0、または全画素が
  * inside でコントラストが無い) 場合は `ok: false` を返し、呼び出し側で UI
@@ -110,7 +111,6 @@ export interface ImageSdfResult {
 export function generateImageSdf(
   bitmap: ImageBitmap,
   size: number,
-  invert: boolean = false,
 ): ImageSdfResult {
   const s = Math.max(1, size | 0);
   if (typeof OffscreenCanvas === 'undefined') {
@@ -209,18 +209,8 @@ export function generateImageSdf(
     }
   }
 
-  // #170 + #174: invert は描画矩形内のみで反転。レタボ部分は inside=0 を維持。
-  // 旧実装は s*s 全体で flip していたため、レタボ部分も inside=1 化して
-  // 不要な巨大シルエットが生成されていた。
-  if (invert) {
-    for (let y = dy; y < dy + dh; y++) {
-      for (let x = dx; x < dx + dw; x++) {
-        const i = y * s + x;
-        inside[i] = inside[i] ? 0 : 1;
-      }
-    }
-    insideCount = drawnPixelCount - insideCount;
-  }
+  // #181: invert 反転 (#170) は削除済み。auto-polarity の精度が #174 で
+  // 上がって以降、UI トグルとしての価値が消えていた。
 
   // #169: 全 inside でも全 outside でもコントラスト 0 として扱う。
   // 母数は描画矩形内 (drawnPixelCount) で判定する。

--- a/web/src/lib/orberClient.ts
+++ b/web/src/lib/orberClient.ts
@@ -254,15 +254,11 @@ export async function workerGlyphSupported(ch: string): Promise<boolean> {
  * 後の再 upload が可能になる。worker 側で `createImageBitmap(file)` を
  * 呼んで ImageBitmap 化し、古い bitmap は close() される。
  *
- * #170: `invert` で inside/outside を強制反転する (auto-polarity が外れる
- * 画像の救済)。worker 側で SDF キャッシュに含まれるため、トグル切替時は
- * 必ず再 upload する必要がある。
+ * #181: 旧 invert 引数 (#170) は #174 のレタボ修正後に効果が視認できない
+ * レベルになり削除。auto-polarity (= 少数派 = 被写体) のみで判定する。
  */
-export async function workerSetImageShape(
-  file: File,
-  invert: boolean = false,
-): Promise<void> {
-  await call<void>({ kind: 'setImageShape', file, invert });
+export async function workerSetImageShape(file: File): Promise<void> {
+  await call<void>({ kind: 'setImageShape', file });
 }
 
 /** 1 タイル分の mp4 を返す（WebCodecs + mp4-muxer で h264 化）。 */

--- a/web/src/lib/orberWorker.ts
+++ b/web/src/lib/orberWorker.ts
@@ -50,17 +50,17 @@ let cachedCanvas: { canvas: OffscreenCanvas; renderer: GlRenderer; width: number
 // invalidate する必要がある（テクスチャも一緒に dispose されるため）。
 //
 // #160 / #172: shape='image' のときは ch ではなく ImageBitmap (cachedImageBitmap)
-// と invert flag (cachedImageInvert) を SDF の元にする。`cachedGlyph` の image
-// 分岐は SDF アップロード状態の identity (= どの (bitmap, invert, size) で
-// upload 済か) を表すフラグなので、bitmap reference を再保持する必要は無い:
-// setImageShape で cachedImageBitmap が差し替わるたびに cachedGlyph を null
-// にすれば、次の ensureImageSdfUploaded で必ず再 upload される (#172 N1)。
+// を SDF の元にする。`cachedGlyph` の image 分岐は SDF アップロード状態の
+// identity (= どの (bitmap, size) で upload 済か) を表すフラグなので、
+// bitmap reference を再保持する必要は無い: setImageShape で
+// cachedImageBitmap が差し替わるたびに cachedGlyph を null にすれば、次の
+// ensureImageSdfUploaded で必ず再 upload される (#172 N1)。
+// #181: invert flag (#170) は削除済み。
 let cachedGlyph:
   | { kind: 'char'; ch: string; size: number }
-  | { kind: 'image'; size: number; invert: boolean }
+  | { kind: 'image'; size: number }
   | null = null;
 let cachedImageBitmap: ImageBitmap | null = null;
-let cachedImageInvert = false;
 
 function getRenderer(width: number, height: number): { canvas: OffscreenCanvas; renderer: GlRenderer } {
   if (cachedCanvas && cachedCanvas.width === width && cachedCanvas.height === height) {
@@ -128,8 +128,8 @@ function ensureGlyphSdfUploaded(renderer: GlRenderer, ch: string): void {
 
 // #160: shape='image' 用。Studio 側で `setImageShape` 経由で送られて
 // `cachedImageBitmap` に入っている画像をシルエット化 → SDF 化 → upload。
-// 同じ (bitmap, invert) なら再生成しない (setImageShape が cachedGlyph を
-// null にするので reference が変われば必ず再 upload される)。
+// 同じ bitmap (= setImageShape が cachedGlyph を null にしないかぎり) なら
+// 再生成しない。
 //
 // #169: シルエット抽出に失敗 (コントラスト不足) したら専用 Error を投げる。
 // 呼び出し側 (Studio) で `imageShapeNoContrast` 文言の UI に使う。
@@ -141,16 +141,15 @@ function ensureImageSdfUploaded(renderer: GlRenderer): void {
   if (
     cachedGlyph &&
     cachedGlyph.kind === 'image' &&
-    cachedGlyph.size === size &&
-    cachedGlyph.invert === cachedImageInvert
+    cachedGlyph.size === size
   )
     return;
-  const result = generateImageSdf(cachedImageBitmap, size, cachedImageInvert);
+  const result = generateImageSdf(cachedImageBitmap, size);
   if (!result.ok) {
     throw new Error('image-shape-no-contrast');
   }
   renderer.setGlyphSdf(result.sdf, size);
-  cachedGlyph = { kind: 'image', size, invert: cachedImageInvert };
+  cachedGlyph = { kind: 'image', size };
 }
 
 // #160 / #172 N2: shape='image' のとき wasm 側に渡すダミー glyph_char。
@@ -233,7 +232,7 @@ type Req =
   // Transferable を使わず structured-clone で渡す ── main 側が File 参照
   // を保持し続けることで、worker クラッシュ / terminateAndRespawn 後の
   // 再 upload が可能になる。
-  | { kind: 'setImageShape'; id: number; file: File; invert: boolean };
+  | { kind: 'setImageShape'; id: number; file: File };
 
 /// #56: wasm get_render_data の Float32Array header word 3 (= bg.a in 0..1) を 0 に
 /// 上書きして「透過背景でレンダリングしてくれ」と shader に依頼する。元 buffer は
@@ -273,10 +272,8 @@ self.addEventListener('message', async (e: MessageEvent<Req>) => {
           cachedImageBitmap.close();
         }
         cachedImageBitmap = newBitmap;
-        cachedImageInvert = req.invert;
-        // 既存の image SDF キャッシュを invalidate (新 bitmap / invert で
-        // 再生成させる)。これによって ensureImageSdfUploaded 側は単純な
-        // (size, invert) 比較だけで済む (#172 N1)。
+        // 既存の image SDF キャッシュを invalidate (新 bitmap で再生成させる)。
+        // ensureImageSdfUploaded 側は size 比較だけで済む (#172 N1)。
         if (cachedGlyph && cachedGlyph.kind === 'image') {
           cachedGlyph = null;
         }

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -62,7 +62,7 @@ export const STRINGS = {
     ja: '画像を選択してください',
     en: 'Pick an image first',
   },
-  imageShapeInvert: { ja: 'シルエット反転', en: 'Invert silhouette' },
+  // #181: imageShapeInvert (#170) はトグルごと削除済み。
   imageShapeNoContrast: {
     ja: 'この画像にはコントラストがありません',
     en: 'This image has no contrast',


### PR DESCRIPTION
closes #181

## 背景
#170 で auto-polarity 救済として追加した `imageShapeInvert` トグルは、#174 のレタボ誤判定修正後に実機検証で効果が視認できないレベルに。

## 削除内容
- Studio.tsx: signal / handler / checkbox UI 一式
- orberClient.ts: workerSetImageShape の invert 引数
- orberWorker.ts: cachedImageInvert / cachedGlyph.invert
- jsGlyphSdf.ts::generateImageSdf: invert 引数 + 反転ループ
- jsGlyphSdf.test.ts: #170 invert テスト
- strings.ts: imageShapeInvert i18n キー

## 検証
- npm test: 22 passed (旧 23 から #170 invert 1 件減)
- npm run build: clean

## エッジケース
auto-polarity が外れる画像 (証明写真など被写体が画面の半分以上) は外部 `magick -negate` 等で反転して再ドロップで対処。