### PR TITLE
chore(web): kako-jun/orber#184 ffmpeg.wasm diagnostic log (OOB 原因特定用)

### DIFF
--- a/web/src/lib/encodeWebmAlphaWasm.ts
+++ b/web/src/lib/encodeWebmAlphaWasm.ts
@@ -249,30 +249,52 @@ async function runEncode(
   };
   ffmpeg.on('progress', progressHandler);
 
+  // #184 diagnostic: ffmpeg 内部ログを捕捉する。`memory access out of bounds`
+  // 等の wasm trap が起きた時に、ffmpeg 側がどこまで進んでいたか / どんな
+  // メッセージを出していたかを Error 文に同梱して console / UI に伝えるため。
+  const logLines: string[] = [];
+  const logHandler = ({ message }: { message: string; type: string }) => {
+    logLines.push(message);
+    if (logLines.length > 80) logLines.shift();
+    // 本番ではブラウザ console にも直接出す (deploy 中の調査用、後で外す)
+    // eslint-disable-next-line no-console
+    console.log('[ffmpeg]', message);
+  };
+  ffmpeg.on('log', logHandler);
+
   try {
     // 透過 WebM (libvpx-vp9 + yuva420p)。
     // - `-auto-alt-ref 0`: VP9 alpha と同時に使えない libvpx の制約。必須。
     // - `-pix_fmt yuva420p`: alpha plane を保持する 4:2:0 形式。
     // - bitrate 2M: encodeMp4 / 旧 encodeWebmAlpha と揃える。
-    await ffmpeg.exec([
-      '-framerate',
-      String(fps),
-      '-i',
-      inputPattern,
-      '-c:v',
-      'libvpx-vp9',
-      '-pix_fmt',
-      'yuva420p',
-      '-b:v',
-      '2M',
-      '-auto-alt-ref',
-      '0',
-      '-s',
-      `${width}x${height}`,
-      outputName,
-    ]);
+    try {
+      await ffmpeg.exec([
+        '-framerate',
+        String(fps),
+        '-i',
+        inputPattern,
+        '-c:v',
+        'libvpx-vp9',
+        '-pix_fmt',
+        'yuva420p',
+        '-b:v',
+        '2M',
+        '-auto-alt-ref',
+        '0',
+        '-s',
+        `${width}x${height}`,
+        outputName,
+      ]);
+    } catch (e) {
+      const tail = logLines.slice(-30).join('\n');
+      const orig = e instanceof Error ? e.message : String(e);
+      throw new Error(
+        `ffmpeg.exec failed (${width}x${height}, ${total}f): ${orig}\n--- ffmpeg log tail ---\n${tail}`,
+      );
+    }
   } finally {
     ffmpeg.off('progress', progressHandler);
+    ffmpeg.off('log', logHandler);
   }
 
   const data = await ffmpeg.readFile(outputName);


### PR DESCRIPTION
本番で透過 DL が `memory access out of bounds` で fail し続ける問題の原因特定のため、ffmpeg.wasm の log event を捕捉して console + Error 文に同梱する。

- `ffmpeg.on('log', handler)` で全 ffmpeg log を console.log('[ffmpeg]', ...) に出す
- `ffmpeg.exec` が throw した場合、log の末尾 30 行を Error 文に append → catch 側で`hi-res download failed` メッセージと共に console に出る
- 解像度 / フレーム数も Error 文に含めて状況を一意に特定
- 原因特定後にこの diagnostic は削除する想定

これで本番 console を見れば libvpx-vp9 / libavcodec / libavformat がどこで死んだか分かる。