### PR TITLE
fix(web): kako-jun/orber#184 libvpx-vp9 lookahead 無効化で wasm OOB を解消

### DIFF
--- a/web/src/lib/encodeWebmAlphaWasm.ts
+++ b/web/src/lib/encodeWebmAlphaWasm.ts
@@ -265,6 +265,12 @@ async function runEncode(
   try {
     // 透過 WebM (libvpx-vp9 + yuva420p)。
     // - `-auto-alt-ref 0`: VP9 alpha と同時に使えない libvpx の制約。必須。
+    // - `-lag-in-frames 0`: lookahead バッファ無効化。デフォルト 25 frame の
+    //   lookahead を抱えたまま yuva420p (YUV + alpha 二重) の初回 output を
+    //   出そうとすると wasm 単スレッド ffmpeg のヒープが枯渇して
+    //   `RuntimeError: memory access out of bounds` で死ぬ。本番再現済み (#184)。
+    // - `-deadline realtime -cpu-used 8`: 最速プリセット (品質落ちる代わりに
+    //   メモリ使用量も激減)。orb は blurry なので品質劣化は実用上問題なし。
     // - `-pix_fmt yuva420p`: alpha plane を保持する 4:2:0 形式。
     // - bitrate 2M: encodeMp4 / 旧 encodeWebmAlpha と揃える。
     try {
@@ -281,6 +287,12 @@ async function runEncode(
         '2M',
         '-auto-alt-ref',
         '0',
+        '-lag-in-frames',
+        '0',
+        '-deadline',
+        'realtime',
+        '-cpu-used',
+        '8',
         '-s',
         `${width}x${height}`,
         outputName,


### PR DESCRIPTION
## 根本原因 (diagnostic log で確定)

PR #189 で仕込んだ ffmpeg log 捕捉により、本番でのエラーが "メモリ不足" ではなく **libvpx-vp9 の lookahead バッファ問題**であることが判明:

```
frame=   25 ...  size=       0kB  ← まだ output 0、25 frame 分 lookahead 中
frame=   26 ...  q=23.0 size=  0kB time=00:00:00.04 ← 初の output エンコード開始
frame=   27 ...  q=34.0 size=  0kB
[wasm OOB]                       ← 直後にヒープ枯渇
```

libvpx-vp9 のデフォルト lookahead は **25 frame**。yuva420p (YUV + alpha 二重エンコード) で 25 frame ぶんバッファした状態で初の output を出そうとした瞬間、wasm 単スレッド ffmpeg.wasm のヒープが破綻していた。

`-auto-alt-ref 0` は altref を無効化するだけで lookahead 自体は止めない。lookahead を完全無効化するには **`-lag-in-frames 0`** が必要。

## 修正

```
-lag-in-frames 0
-deadline realtime
-cpu-used 8
```

を ffmpeg.exec 引数に追加。

- `-lag-in-frames 0`: lookahead 完全無効化 → メモリ使用量を frame-by-frame に圧縮
- `-deadline realtime -cpu-used 8`: 最速プリセット → 内部バッファ縮小も期待
- 品質劣化は理論上ある (rate control / 量子化が荒くなる) が、orb は blurry なので実用上問題なし

## テスト

vitest 56/56 pass。実機検証は CF Pages デプロイ後 (`Studio.<hash>.js` の更新を確認後)。

## 副次効果

エンコード速度も大幅向上見込み (`-cpu-used 8` で 5-10x 速くなることが多い)。これで 540x960 × 192 frame が現実的な時間で完走する。

## 次の手 (もしまだ OOB が出たら)

- フレーム数を半減 (8s → 4s)
- 解像度を 1/3 (360x640)
- 別フォーマット (animated WebP) 検討

ただし lookahead 無効化で 25 frame ぶんのバッファが消えるため、解決確率は高い。