### PR TITLE
fix(web): kako-jun/orber#184 libvpx realtime preset を撤去 (yuva420p で init OOB)

### DIFF
--- a/web/src/lib/encodeWebmAlphaWasm.ts
+++ b/web/src/lib/encodeWebmAlphaWasm.ts
@@ -269,8 +269,9 @@ async function runEncode(
     //   lookahead を抱えたまま yuva420p (YUV + alpha 二重) の初回 output を
     //   出そうとすると wasm 単スレッド ffmpeg のヒープが枯渇して
     //   `RuntimeError: memory access out of bounds` で死ぬ。本番再現済み (#184)。
-    // - `-deadline realtime -cpu-used 8`: 最速プリセット (品質落ちる代わりに
-    //   メモリ使用量も激減)。orb は blurry なので品質劣化は実用上問題なし。
+    //   `-deadline realtime -cpu-used 8` も試したが、yuva420p alpha encoder と
+    //   非互換で init 段階で即 OOB。RTC encoder パスは VP9 alpha 非対応の模様。
+    //   `-lag-in-frames 0` のみで普通の "good" deadline (cpu-used 0) を使う。
     // - `-pix_fmt yuva420p`: alpha plane を保持する 4:2:0 形式。
     // - bitrate 2M: encodeMp4 / 旧 encodeWebmAlpha と揃える。
     try {
@@ -289,10 +290,6 @@ async function runEncode(
         '0',
         '-lag-in-frames',
         '0',
-        '-deadline',
-        'realtime',
-        '-cpu-used',
-        '8',
         '-s',
         `${width}x${height}`,
         outputName,


### PR DESCRIPTION
PR #190 で追加した `-deadline realtime -cpu-used 8` が yuva420p (VP9 alpha) と非互換で、エンコーダ初期化段階で即 OOB することが diagnostic log で判明。

```
[ffmpeg] Output #0, webm, to 'out.webm':
  ...
  Side data:
    cpb: bitrate max/min/avg: 0/0/0 buffer size: 0 vbv_delay: N/A
hi-res download failed: ffmpeg.exec failed (960x540, 192f): memory access out of bounds
```

frame 0 すら出力されず init で死亡。RTC encoder パスは VP9 alpha と互換性がない模様。

修正: realtime preset を撤去し、`-lag-in-frames 0` のみ残す。デフォルト deadline 'good' + cpu-used 0 で標準パスを使う。