### PR TITLE
fix: Linux Edge / Chromium で H.264 未提供時に VP9 / AV1 へ probe + フォールバック (#196)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,11 @@ The GUI runs entirely client-side. The `orber-wasm` crate handles rendering
 via the WebCodecs API (Chrome 94+ / Safari 16.4+ / Firefox 130+). The encoder
 probes H.264 → VP9 → AV1 and falls back automatically, so browsers without an
 H.264 encoder (Linux Chrome / Edge / Firefox) still produce mp4 loops via VP9
-or AV1. On older browsers with no WebCodecs support at all, the video tiles
+or AV1. Generation and playback happen in the same browser session (a freshly
+encoded video Blob is rendered as an inline `<video>`), so codec compatibility
+with other browsers is not a concern — Safari users always get H.264 because
+their browser has it, Linux Chrome users get VP9 / AV1 and play it back
+themselves. On older browsers with no WebCodecs support at all, the video tiles
 fall back to the static PNG. Source: `web/` (Astro + Solid +
 Tailwind). The visual language and component conventions are documented in
 [`DESIGN.md`](./DESIGN.md). UI text is auto-localized: Japanese for `ja-*`

--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ divisor count (1/2/3/4/6/12) lets the grid lay out cleanly across phone widths.
 Unlike the CLI's fixed `--variations` preset, the GUI samples direction / speed /
 count / orb size / blur randomly per drop, so the same image yields a different
 layout each time. The first **8 tiles** are static PNGs; the **last 4 tiles**
-are H.264 mp4 loops generated client-side via WebCodecs and inlined as
-`<video muted playsinline loop>`. Each of the 4 video tiles flows in a
+are mp4 loops generated client-side via WebCodecs (H.264 by default, with VP9 /
+AV1 fallback for browsers without an H.264 encoder, e.g. Linux Chrome / Edge /
+Firefox) and inlined as `<video muted playsinline loop>`. Each of the 4 video tiles flows in a
 different direction (left→right, right→left, top→bottom, bottom→top), shown in
 that order so every batch always offers all four motion axes side by side. The
 4 videos start playing **simultaneously** once all encodes finish, so the field
@@ -181,9 +182,12 @@ source image full-size in an overlay, release to close — handy for verifying
 which photo is loaded without losing the rest of the GUI.
 
 The GUI runs entirely client-side. The `orber-wasm` crate handles rendering
-(measured ≈ 220 KB gzipped at v0.3.0); H.264 encoding is done in the browser via
-the WebCodecs API (Chrome 94+ / Safari 16.4+ / Firefox 130+). On older browsers
-the video tiles fall back to the static PNG. Source: `web/` (Astro + Solid +
+(measured ≈ 220 KB gzipped at v0.3.0); video encoding is done in the browser
+via the WebCodecs API (Chrome 94+ / Safari 16.4+ / Firefox 130+). The encoder
+probes H.264 → VP9 → AV1 and falls back automatically, so browsers without an
+H.264 encoder (Linux Chrome / Edge / Firefox) still produce mp4 loops via VP9
+or AV1. On older browsers with no WebCodecs support at all, the video tiles
+fall back to the static PNG. Source: `web/` (Astro + Solid +
 Tailwind). The visual language and component conventions are documented in
 [`DESIGN.md`](./DESIGN.md). UI text is auto-localized: Japanese for `ja-*`
 browsers, English everywhere else, with no language picker.

--- a/crates/core/src/orb.rs
+++ b/crates/core/src/orb.rs
@@ -15,10 +15,10 @@
 //!   blur=1 → 中心の不透明領域が点に近く、緩やかに減衰
 //! - 彩度調整は palette の HSL 経由
 
-use aquarelle::{render_aquarelle_orb, AquarelleParams};
 use crate::cluster::Cluster;
 use crate::glyph::{render_glyph_orb, GlyphFontId};
 use crate::style::{rim_mid_stop, soft_hold_stop, FalloffProfile, SoftnessPreset};
+use aquarelle::{render_aquarelle_orb, AquarelleParams};
 use image::RgbaImage;
 use palette::{FromColor, Hsl, IntoColor, Srgb};
 use tiny_skia::{

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -289,7 +289,9 @@ DOM) and a **dedicated Worker thread** (wasm + WebGL2 + WebCodecs):
    │   └ workerAnimateOne(i) ─────────→  │   for i in 0..192:
    │                                     │     - shader.renderFrame(t = i/192)
    │                                     │     - new VideoFrame(canvas) → encode
-   │                                     ├ WebCodecs VideoEncoder (prefer-hardware)
+   │                                     ├ WebCodecs VideoEncoder
+   │                                     │   (codec probe: H.264 → VP9 → AV1,
+   │                                     │    hwAccel probe: prefer-hardware → no-preference; #196)
    │                                     │   └→ mp4 Blob (Transferable)
    └ DL high-res                         └ same APIs, with width/height = 1080×1920
        └ workerGenerateOne / workerAnimateOne (per selected index)
@@ -351,6 +353,14 @@ in Worker context. iOS Safari 16.4+, current Android Chrome / Firefox 130+.
 There is no fallback path for older browsers — the GUI shows an error if
 WebCodecs is unavailable. WebGL2 support is a strict superset of WebCodecs in
 practice, so any browser that can run the encoder can also run the renderer.
+The animated-tile path requires *some* `VideoEncoder` codec to be available:
+H.264 → VP9 → AV1 are probed in that order via
+`VideoEncoder.isConfigSupported`, falling back from `prefer-hardware` to
+`no-preference` per candidate (#196). Linux Chrome / Edge / Firefox ship
+without an H.264 encoder but accept VP9 / AV1, so this probe is what keeps the
+animated tiles working there. If every candidate is rejected the per-tile
+encode throws and Studio surfaces the existing
+"some tiles could not be animated" warning while keeping the stills.
 
 **Progressive UX.** While the Worker is busy:
 

--- a/web/src/lib/encodeMp4.test.ts
+++ b/web/src/lib/encodeMp4.test.ts
@@ -119,13 +119,8 @@ describe('pickSupportedVideoCodec - 異常系', () => {
   it('B6: VideoEncoder が undefined なら null（isConfigSupported は呼ばれない）', async () => {
     vi.unstubAllGlobals();
     vi.stubGlobal('VideoEncoder', undefined);
-    // ローカルの spy を新たに置いて 0 回呼ばれた事を確認
-    const spy = vi.fn();
-    // VideoEncoder 自体が undefined なのでこの spy は呼ばれ得ないが
-    // 念のため別経路として用意（実行時アクセスを検知する目的ではない）
     const picked = await pickSupportedVideoCodec(1280, 720);
     expect(picked).toBeNull();
-    expect(spy).not.toHaveBeenCalled();
   });
 
   it('B7: VideoEncoder.isConfigSupported が関数でない場合 null', async () => {
@@ -263,7 +258,7 @@ describe('pickSupportedVideoCodec - 事故パターン予防', () => {
     expect(picked?.codec).toBe('vp09.00.41.08');
   });
 
-  it('E20: 連続 2 回呼んでも同じ結果（純関数性、呼び出し回数も 2 倍）', async () => {
+  it('E20: 連続 2 回呼んでも同じ結果（内部キャッシュ無し / no internal caching、呼び出し回数も 2 倍）', async () => {
     isConfigSupported.mockResolvedValue({ supported: false, config: {} });
     const a = await pickSupportedVideoCodec(1280, 720);
     const b = await pickSupportedVideoCodec(1280, 720);
@@ -273,6 +268,9 @@ describe('pickSupportedVideoCodec - 事故パターン予防', () => {
   });
 
   it('E21: throw catch 時に console.error / console.warn を呼ばない', async () => {
+    // probe 失敗時に console を汚さない方針。ユーザー環境で「正常な fallback
+    // 経路」として warn が大量に出ないようにするための固定。将来ログを出す
+    // べきと判断した時にこのテストが先に落ちる前提で固定。
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     isConfigSupported.mockRejectedValue(new Error('probe failed'));

--- a/web/src/lib/encodeMp4.test.ts
+++ b/web/src/lib/encodeMp4.test.ts
@@ -1,0 +1,284 @@
+// orber#196 — pickSupportedVideoCodec の単体テスト。
+//
+// VideoEncoder.isConfigSupported を vi.stubGlobal でモックし、
+// H.264 → VP9 → AV1 の探索順序、prefer-hardware → no-preference の
+// 2 段リトライ、解像度に応じた avc1 codec string 切替を検証する。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { pickSupportedVideoCodec } from './encodeMp4';
+
+type AccelHint = 'prefer-hardware' | 'no-preference';
+interface ProbeConfig {
+  codec: string;
+  width: number;
+  height: number;
+  framerate: number;
+  bitrate: number;
+  hardwareAcceleration: AccelHint;
+}
+
+let isConfigSupported: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  isConfigSupported = vi.fn();
+  vi.stubGlobal('VideoEncoder', { isConfigSupported });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// (A) 正常系 — 採用 codec の確定 -----------------------------------------
+
+describe('pickSupportedVideoCodec - 正常系', () => {
+  it('A1: H.264 が hw で supported なら avc1 + prefer-hardware を返す', async () => {
+    isConfigSupported.mockResolvedValueOnce({ supported: true, config: {} });
+    const picked = await pickSupportedVideoCodec(1280, 720);
+    expect(picked).toEqual({
+      codec: 'avc1.42E01F',
+      muxerCodec: 'avc',
+      hardwareAcceleration: 'prefer-hardware',
+    });
+  });
+
+  it('A2: H.264 false → VP9 が hw で supported なら vp9 を返す', async () => {
+    isConfigSupported
+      .mockResolvedValueOnce({ supported: false, config: {} })
+      .mockResolvedValueOnce({ supported: true, config: {} });
+    const picked = await pickSupportedVideoCodec(1080, 1920);
+    expect(picked).toEqual({
+      codec: 'vp09.00.41.08',
+      muxerCodec: 'vp9',
+      hardwareAcceleration: 'prefer-hardware',
+    });
+  });
+
+  it('A3: H.264/VP9 false → AV1 が hw で supported なら av1 を返す', async () => {
+    isConfigSupported
+      .mockResolvedValueOnce({ supported: false, config: {} })
+      .mockResolvedValueOnce({ supported: false, config: {} })
+      .mockResolvedValueOnce({ supported: true, config: {} });
+    const picked = await pickSupportedVideoCodec(1080, 1920);
+    expect(picked).toEqual({
+      codec: 'av01.0.09M.08',
+      muxerCodec: 'av1',
+      hardwareAcceleration: 'prefer-hardware',
+    });
+  });
+
+  it('A4: hw 全滅 → no-preference で H.264 supported なら hardwareAcceleration: no-preference', async () => {
+    isConfigSupported
+      .mockResolvedValueOnce({ supported: false, config: {} }) // hw avc
+      .mockResolvedValueOnce({ supported: false, config: {} }) // hw vp9
+      .mockResolvedValueOnce({ supported: false, config: {} }) // hw av1
+      .mockResolvedValueOnce({ supported: true, config: {} }); // no-pref avc
+    const picked = await pickSupportedVideoCodec(1280, 720);
+    expect(picked).toEqual({
+      codec: 'avc1.42E01F',
+      muxerCodec: 'avc',
+      hardwareAcceleration: 'no-preference',
+    });
+  });
+
+  it('A5: hw 全滅 → no-pref で AV1 のみ true なら av01 + no-preference (探索順序も検証)', async () => {
+    isConfigSupported
+      .mockResolvedValueOnce({ supported: false, config: {} }) // hw avc
+      .mockResolvedValueOnce({ supported: false, config: {} }) // hw vp9
+      .mockResolvedValueOnce({ supported: false, config: {} }) // hw av1
+      .mockResolvedValueOnce({ supported: false, config: {} }) // no-pref avc
+      .mockResolvedValueOnce({ supported: false, config: {} }) // no-pref vp9
+      .mockResolvedValueOnce({ supported: true, config: {} }); // no-pref av1
+    const picked = await pickSupportedVideoCodec(1080, 1920);
+    expect(picked).toEqual({
+      codec: 'av01.0.09M.08',
+      muxerCodec: 'av1',
+      hardwareAcceleration: 'no-preference',
+    });
+
+    // mock.calls で探索順序を厳密に確認
+    expect(isConfigSupported).toHaveBeenCalledTimes(6);
+    const calls = isConfigSupported.mock.calls.map((c) => {
+      const cfg = c[0] as ProbeConfig;
+      return [cfg.codec, cfg.hardwareAcceleration];
+    });
+    expect(calls).toEqual([
+      ['avc1.42E02A', 'prefer-hardware'],
+      ['vp09.00.41.08', 'prefer-hardware'],
+      ['av01.0.09M.08', 'prefer-hardware'],
+      ['avc1.42E02A', 'no-preference'],
+      ['vp09.00.41.08', 'no-preference'],
+      ['av01.0.09M.08', 'no-preference'],
+    ]);
+  });
+});
+
+// (B) 異常系・null 返却 ---------------------------------------------------
+
+describe('pickSupportedVideoCodec - 異常系', () => {
+  it('B6: VideoEncoder が undefined なら null（isConfigSupported は呼ばれない）', async () => {
+    vi.unstubAllGlobals();
+    vi.stubGlobal('VideoEncoder', undefined);
+    // ローカルの spy を新たに置いて 0 回呼ばれた事を確認
+    const spy = vi.fn();
+    // VideoEncoder 自体が undefined なのでこの spy は呼ばれ得ないが
+    // 念のため別経路として用意（実行時アクセスを検知する目的ではない）
+    const picked = await pickSupportedVideoCodec(1280, 720);
+    expect(picked).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('B7: VideoEncoder.isConfigSupported が関数でない場合 null', async () => {
+    vi.unstubAllGlobals();
+    vi.stubGlobal('VideoEncoder', { isConfigSupported: 'not-a-function' });
+    const picked = await pickSupportedVideoCodec(1280, 720);
+    expect(picked).toBeNull();
+  });
+
+  it('B8: 全 6 試行で supported: false なら null（呼び出し回数ちょうど 6）', async () => {
+    isConfigSupported.mockResolvedValue({ supported: false, config: {} });
+    const picked = await pickSupportedVideoCodec(1280, 720);
+    expect(picked).toBeNull();
+    expect(isConfigSupported).toHaveBeenCalledTimes(6);
+  });
+
+  it('B9: throw した候補はスキップして次へ進む (H.264 throw → VP9 true)', async () => {
+    isConfigSupported
+      .mockRejectedValueOnce(new Error('invalid codec string'))
+      .mockResolvedValueOnce({ supported: true, config: {} });
+    const picked = await pickSupportedVideoCodec(1280, 720);
+    expect(picked).toEqual({
+      codec: 'vp09.00.41.08',
+      muxerCodec: 'vp9',
+      hardwareAcceleration: 'prefer-hardware',
+    });
+  });
+
+  it('B10: 全候補で throw → null', async () => {
+    isConfigSupported.mockRejectedValue(new Error('boom'));
+    const picked = await pickSupportedVideoCodec(1280, 720);
+    expect(picked).toBeNull();
+    expect(isConfigSupported).toHaveBeenCalledTimes(6);
+  });
+});
+
+// (C) 同値分割・境界値（解像度） ------------------------------------------
+
+describe('pickSupportedVideoCodec - 解像度境界値', () => {
+  it('C11: 1280x720 (codedArea = 921,600 ジャスト) は avc1.42E01F', async () => {
+    isConfigSupported.mockResolvedValueOnce({ supported: true, config: {} });
+    const picked = await pickSupportedVideoCodec(1280, 720);
+    expect(picked?.codec).toBe('avc1.42E01F');
+    const firstArg = isConfigSupported.mock.calls[0][0] as ProbeConfig;
+    expect(firstArg.codec).toBe('avc1.42E01F');
+  });
+
+  it('C12: 1281x720 (codedArea > 921,600) は avc1.42E02A', async () => {
+    isConfigSupported.mockResolvedValueOnce({ supported: true, config: {} });
+    const picked = await pickSupportedVideoCodec(1281, 720);
+    expect(picked?.codec).toBe('avc1.42E02A');
+  });
+
+  it('C13: 1080x1920 は avc1.42E02A (1080p 縦)', async () => {
+    isConfigSupported.mockResolvedValueOnce({ supported: true, config: {} });
+    const picked = await pickSupportedVideoCodec(1080, 1920);
+    expect(picked?.codec).toBe('avc1.42E02A');
+  });
+
+  it('C14: 64x64 は avc1.42E01F、VP9/AV1 文字列は固定', async () => {
+    isConfigSupported.mockResolvedValue({ supported: false, config: {} });
+    await pickSupportedVideoCodec(64, 64);
+    const codecs = isConfigSupported.mock.calls.map(
+      (c) => (c[0] as ProbeConfig).codec,
+    );
+    // 各 hint で同じ 3 候補を順に試すので、最初の 3 件 = 候補一覧
+    expect(codecs.slice(0, 3)).toEqual([
+      'avc1.42E01F',
+      'vp09.00.41.08',
+      'av01.0.09M.08',
+    ]);
+  });
+});
+
+// (D) isConfigSupported に渡す引数 ----------------------------------------
+
+describe('pickSupportedVideoCodec - probe 引数', () => {
+  it('D15: 1 回目の call args が必要キーを全て含む (framerate キー名)', async () => {
+    isConfigSupported.mockResolvedValueOnce({ supported: true, config: {} });
+    await pickSupportedVideoCodec(1280, 720);
+    const arg = isConfigSupported.mock.calls[0][0] as ProbeConfig;
+    expect(arg).toEqual({
+      codec: 'avc1.42E01F',
+      width: 1280,
+      height: 720,
+      framerate: 24,
+      bitrate: 2_000_000,
+      hardwareAcceleration: 'prefer-hardware',
+    });
+    // `framerate` キーが存在することを単独でも検証 (frameRate と取り違えていないか)
+    expect(Object.keys(arg)).toContain('framerate');
+    expect(Object.keys(arg)).not.toContain('frameRate');
+  });
+
+  it('D16: 第 2 候補は vp09.00.41.08、第 3 候補は av01.0.09M.08 で probe される', async () => {
+    isConfigSupported.mockResolvedValue({ supported: false, config: {} });
+    await pickSupportedVideoCodec(1280, 720);
+    const calls = isConfigSupported.mock.calls.map(
+      (c) => (c[0] as ProbeConfig).codec,
+    );
+    expect(calls[1]).toBe('vp09.00.41.08');
+    expect(calls[2]).toBe('av01.0.09M.08');
+  });
+});
+
+// (E) 事故パターン予防 ---------------------------------------------------
+
+describe('pickSupportedVideoCodec - 事故パターン予防', () => {
+  it('E17: 1 回目で true なら 2 回目以降は呼ばれない', async () => {
+    isConfigSupported.mockResolvedValueOnce({ supported: true, config: {} });
+    await pickSupportedVideoCodec(1280, 720);
+    expect(isConfigSupported).toHaveBeenCalledTimes(1);
+  });
+
+  it('E18: AV1 採用ケースで muxerCodec === "av1" を明示 assert', async () => {
+    isConfigSupported
+      .mockResolvedValueOnce({ supported: false, config: {} })
+      .mockResolvedValueOnce({ supported: false, config: {} })
+      .mockResolvedValueOnce({ supported: true, config: {} });
+    const picked = await pickSupportedVideoCodec(1080, 1920);
+    expect(picked?.muxerCodec).toBe('av1');
+  });
+
+  it('E19: { supported: false, config: {...} } を返したら採用せず次候補へ', async () => {
+    // 1 回目: supported: false だが config プロパティは付いている
+    // 2 回目: supported: true → こちらが採用される事
+    isConfigSupported
+      .mockResolvedValueOnce({
+        supported: false,
+        config: { codec: 'avc1.42E01F', width: 1280, height: 720 },
+      })
+      .mockResolvedValueOnce({ supported: true, config: {} });
+    const picked = await pickSupportedVideoCodec(1280, 720);
+    expect(picked?.muxerCodec).toBe('vp9');
+    expect(picked?.codec).toBe('vp09.00.41.08');
+  });
+
+  it('E20: 連続 2 回呼んでも同じ結果（純関数性、呼び出し回数も 2 倍）', async () => {
+    isConfigSupported.mockResolvedValue({ supported: false, config: {} });
+    const a = await pickSupportedVideoCodec(1280, 720);
+    const b = await pickSupportedVideoCodec(1280, 720);
+    expect(a).toBeNull();
+    expect(b).toBeNull();
+    expect(isConfigSupported).toHaveBeenCalledTimes(12);
+  });
+
+  it('E21: throw catch 時に console.error / console.warn を呼ばない', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    isConfigSupported.mockRejectedValue(new Error('probe failed'));
+    const picked = await pickSupportedVideoCodec(1280, 720);
+    expect(picked).toBeNull();
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/encodeMp4.ts
+++ b/web/src/lib/encodeMp4.ts
@@ -88,6 +88,10 @@ export async function pickSupportedVideoCodec(
   for (const hardwareAcceleration of accelHints) {
     for (const cand of candidates) {
       try {
+        // probe 時の bitrate / framerate / 解像度は実際の encoder.configure と
+        // 完全一致させる方針。probe で OK と判定された組み合わせをそのまま
+        // configure に渡すことで、isConfigSupported: true だったのに configure
+        // で失敗するケースを最小化する。
         const result = await VideoEncoder.isConfigSupported({
           codec: cand.codec,
           width,

--- a/web/src/lib/encodeMp4.ts
+++ b/web/src/lib/encodeMp4.ts
@@ -1,4 +1,4 @@
-// 後半タイルのアニメーションを WebCodecs + mp4-muxer で h264 mp4 化する。
+// 後半タイルのアニメーションを WebCodecs + mp4-muxer で mp4 化する。
 //
 // #112 の WebGL 経路では OffscreenCanvas (WebGL2) に 1 frame 描画して
 // `new VideoFrame(canvas)` で直接エンコーダに食わせる。RGBA バッファの GPU→CPU
@@ -8,6 +8,11 @@
 // 互換性: VideoEncoder / VideoFrame(canvas) が要る。
 // Chrome 94+ / Safari 16.4+ / Firefox 130+。非対応ブラウザでは throw する
 // （Studio 側で catch して静止画フォールバックする）。
+//
+// #196: Linux Chrome / Edge / Firefox は H.264 エンコーダを持たないため、
+// `pickSupportedVideoCodec` で H.264 → VP9 → AV1 を順に probe し、最初に
+// サポートされた codec を encoder / muxer 両方に流す。mp4-muxer は
+// `'avc' | 'vp9' | 'av1'` をサポート済みなので、mp4 拡張子は維持できる。
 
 import { Muxer, ArrayBufferTarget } from 'mp4-muxer';
 
@@ -23,6 +28,88 @@ export const ANIM_TOTAL_FRAMES = ANIM_FPS * ANIM_DURATION_SECONDS;
 
 export function isWebCodecsSupported(): boolean {
   return typeof VideoEncoder !== 'undefined' && typeof VideoFrame !== 'undefined';
+}
+
+// #196: Linux Chrome / Edge / Firefox は H.264 エンコーダを持たないため
+// (`VideoEncoder.isConfigSupported({ codec: 'avc1.*' })` が false で返る)、
+// VP9 / AV1 にフォールバックする必要がある。muxer 側は mp4-muxer が
+// `'avc' | 'vp9' | 'av1'` をサポートしているのでそのまま乗せる。
+export interface PickedVideoCodec {
+  /** WebCodecs `VideoEncoder.configure({ codec })` に渡す文字列。 */
+  codec: string;
+  /** mp4-muxer `Muxer({ video: { codec } })` に渡すタグ。 */
+  muxerCodec: 'avc' | 'vp9' | 'av1';
+  /** `VideoEncoder.configure({ hardwareAcceleration })` で採用する hint。 */
+  hardwareAcceleration: 'prefer-hardware' | 'no-preference';
+}
+
+interface CodecCandidate {
+  codec: string;
+  muxerCodec: 'avc' | 'vp9' | 'av1';
+}
+
+function buildCandidates(width: number, height: number): CodecCandidate[] {
+  // H.264 codec string は既存ロジックを維持: Level 3.1 (≤ 720p 相当) / 4.2 (1080p)。
+  const codedArea = Math.ceil(width / 16) * 16 * Math.ceil(height / 16) * 16;
+  const avcCodec = codedArea <= 921_600 ? 'avc1.42E01F' : 'avc1.42E02A';
+  // VP9 / AV1 は 1080×1920 で安全に通る Level 4.1 を既定にし、`isConfigSupported`
+  // が false を返したら次の候補へ落とす。
+  //   - vp09.<profile>.<level>.<bitDepth>  → Profile 0 / Level 4.1 / 8bit
+  //   - av01.<profile>.<level><tier>.<bitDepth> → Main / Level 4.1 / Main tier / 8bit
+  return [
+    { codec: avcCodec, muxerCodec: 'avc' },
+    { codec: 'vp09.00.41.08', muxerCodec: 'vp9' },
+    { codec: 'av01.0.09M.08', muxerCodec: 'av1' },
+  ];
+}
+
+/**
+ * VideoEncoder.isConfigSupported で H.264 → VP9 → AV1 の順に probe し、
+ * 最初にサポートされた codec を返す。`prefer-hardware` で全滅した場合は
+ * `no-preference` で再 probe する 2 段リトライ構成。
+ *
+ * 戻り値は `encoder.configure()` と `Muxer({ video.codec })` の両方に
+ * そのまま流し込めるオブジェクト。全 codec で false なら null を返す。
+ *
+ * #196: Linux Chrome / Edge は H.264 エンコーダ未提供。
+ */
+export async function pickSupportedVideoCodec(
+  width: number,
+  height: number,
+): Promise<PickedVideoCodec | null> {
+  if (typeof VideoEncoder === 'undefined' || typeof VideoEncoder.isConfigSupported !== 'function') {
+    return null;
+  }
+  const candidates = buildCandidates(width, height);
+  const accelHints: Array<'prefer-hardware' | 'no-preference'> = [
+    'prefer-hardware',
+    'no-preference',
+  ];
+  for (const hardwareAcceleration of accelHints) {
+    for (const cand of candidates) {
+      try {
+        const result = await VideoEncoder.isConfigSupported({
+          codec: cand.codec,
+          width,
+          height,
+          framerate: ANIM_FPS,
+          bitrate: 2_000_000,
+          hardwareAcceleration,
+        });
+        if (result.supported) {
+          return {
+            codec: cand.codec,
+            muxerCodec: cand.muxerCodec,
+            hardwareAcceleration,
+          };
+        }
+      } catch {
+        // 不正な codec string などで throw する実装もあるが、その場合は次の
+        // 候補に進めばよい。
+      }
+    }
+  }
+  return null;
 }
 
 /**
@@ -52,10 +139,18 @@ export async function encodeAnimationFromCanvas(
     throw new Error('totalFrames must be > 0');
   }
 
+  // #196: H.264 → VP9 → AV1 の順で probe。Linux Chrome / Edge / Firefox は
+  // H.264 エンコーダを持たないので、ここで VP9 / AV1 に倒れて Studio の
+  // partial failure 経路（静止画フォールバック）に巻き込まれずに済む。
+  const picked = await pickSupportedVideoCodec(width, height);
+  if (picked === null) {
+    throw new Error('No supported VideoEncoder codec (tried H.264 / VP9 / AV1)');
+  }
+
   const muxer = new Muxer({
     target: new ArrayBufferTarget(),
     video: {
-      codec: 'avc',
+      codec: picked.muxerCodec,
       width,
       height,
       frameRate: ANIM_FPS,
@@ -72,18 +167,13 @@ export async function encodeAnimationFromCanvas(
       if (firstError === null) firstError = e;
     },
   });
-  // 解像度に応じて AVC level を選択する。
-  //   - Level 3.1 (0x1F): coded area 上限 921,600px（≈ 720p まで）
-  //   - Level 4.2 (0x2A): coded area 上限 2,228,224px（1080p で余裕）
-  const codedArea = Math.ceil(width / 16) * 16 * Math.ceil(height / 16) * 16;
-  const codecString = codedArea <= 921_600 ? 'avc1.42E01F' : 'avc1.42E02A';
   encoder.configure({
-    codec: codecString,
+    codec: picked.codec,
     width,
     height,
     framerate: ANIM_FPS,
     bitrate: 2_000_000,
-    hardwareAcceleration: 'prefer-hardware',
+    hardwareAcceleration: picked.hardwareAcceleration,
   });
 
   const microsecondsPerFrame = 1_000_000 / ANIM_FPS;


### PR DESCRIPTION
## 関連 Issue
closes #196

## 変更内容
- `web/src/lib/encodeMp4.ts` に `pickSupportedVideoCodec(width, height)` を新規 export。`VideoEncoder.isConfigSupported` で H.264 → VP9 → AV1 を順に probe し、`prefer-hardware` 全滅時は `no-preference` で 2 段リトライ。`encodeAnimationFromCanvas` 冒頭でこれを呼び、`encoder.configure({ codec, hardwareAcceleration })` と `Muxer({ video: { codec } })` を連動させる。全候補 false 時は throw して既存 partial failure 経路 (静止画フォールバック) に乗る。
- VP9 は `vp09.00.41.08` (Profile 0 / Level 4.1 / 8bit)、AV1 は `av01.0.09M.08` (Main / Level 4.1 / Main tier / 8bit) を採用。H.264 codec string は既存の解像度別 Level 切替 (3.1 / 4.2) を維持。
- `encodeAnimationFromCanvas` のシグネチャ無変更 (orberWorker.ts 側の呼び出し変更不要)。
- `web/src/lib/encodeMp4.test.ts` を新規追加。`vi.stubGlobal('VideoEncoder', ...)` でモックして probe 順序・hwAccel フォールバック・解像度境界・throw スキップ・null 返却条件などを 21 ケースで検証 (全 PASS)。
- README / docs/overview.md を H.264 固定言及から VP9 / AV1 フォールバック付き表記に更新。

## 動作確認
- 実機 (Linux Edge) で `await VideoEncoder.isConfigSupported({ codec: 'avc1.42E01F', ... })` が `supported: false`、`vp09.00.10.08` / `av01.0.04M.08` が `true` を返すことを確認済。これが本 PR の修正動機。
- `cd web && npm run build` 成功 (wasm rebuild + astro build + sw.js stamp)。
- `cd web && npx vitest run src/lib/encodeMp4.test.ts` → 21/21 PASS。
- 既存 `src/lib/strings.test.ts` の 1 件失敗は main 時点で既に存在しており本 PR と無関係。

## 残課題 (次以降)
- マージ後、Linux Edge / Linux Chrome で実機確認し動画化が通ることを目視で確認する。