### PR TITLE
fix: Glyph/image softening 合成を r-max から alpha-max に変更して halo を復活 (#201)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -499,23 +499,31 @@ speed / softness without dropping to the terminal.
   then feeds the **same rim/soft falloff curve**. Because `rot_speed_signed`
   is an integer multiple of the existing `speed_mult`, glyph rotation stays
   loop-closed at `t = 0 ≡ 1`.
-- **#198 follow-up — SDF + Euclidean composite for Glyph/image.** The Glyph
-  arm (`u_shape_id == 1`, which also handles uploaded images via the shared
-  `jsGlyphSdf` path) originally fed only `r_sdf` into `falloff_curve`, so the
-  soft falloff was confined to the SDF's UV box and the result looked harder
-  than Circle. It now computes both `r_sdf` from the sampled SDF and
-  `r_euclid = distance(center, px) / radius`, then takes `r = max(r_sdf,
-  r_euclid)`. Inside the glyph both terms stay small so the opaque core is
-  preserved; near the glyph edge `r_sdf` still drives the shape falloff; and
-  outside the glyph (including outside the SDF UV box, where `r_sdf` is
-  clamped past 1) `r_euclid` takes over and produces the same full-radius
-  halo Circle has. With Glyph='●' the two terms are nearly equal, so the
-  `max` collapses to the Circle expression and the two shapes become visually
-  indistinguishable. The Circle arm (`u_shape_id == 0`), the `falloff_curve`
-  function, and every uniform binding are unchanged. This is the Web-side
-  counterpart to the CLI-side bleed pass added in #195/#199: separate
-  implementations, same visual goal of matching Glyph/image softness to
-  Circle.
+- **#198 follow-up / #201 fix — SDF + Euclidean composite for Glyph/image
+  (alpha-max).** The Glyph arm (`u_shape_id == 1`, which also handles
+  uploaded images via the shared `jsGlyphSdf` path) originally fed only
+  `r_sdf` into `falloff_curve`, so the soft falloff was confined to the SDF's
+  UV box and the result looked harder than Circle. #198 attempted to fix this
+  by taking `r = max(r_sdf, r_euclid)` and feeding the merged `r` into
+  `falloff_curve` once, but visual inspection showed Glyph='●' still had no
+  halo at all: outside the SDF transition `r_sdf > 1` dominated the max and
+  `falloff_curve` returned 0, killing the Circle-style halo before
+  `r_euclid` could contribute. #201 corrects this by computing TWO alpha
+  contributions and taking `alpha = max(alpha_sdf, alpha_euclid)` instead:
+  `alpha_sdf = falloff_curve(style_bit, r_sdf, blur, opacity)` captures the
+  glyph shape; `alpha_euclid = falloff_curve(style_bit, r_euclid, blur,
+  opacity)` captures the Circle-style halo computed exactly like the
+  `u_shape_id == 0` branch. Inside the glyph both alphas are high so the
+  opaque core is preserved; at the glyph outline `alpha_sdf` drops while
+  `alpha_euclid` carries the falloff; outside the glyph but within radius
+  `alpha_sdf = 0` and `alpha_euclid > 0`, producing the same full-radius
+  halo Circle has; outside radius both are 0. With Glyph='●' `alpha_sdf` and
+  `alpha_euclid` are nearly equal, so the max collapses to the Circle
+  formula and the two shapes become visually indistinguishable. The Circle
+  arm (`u_shape_id == 0`), the `falloff_curve` function, and every uniform
+  binding are unchanged. This is the Web-side counterpart to the CLI-side
+  bleed pass added in #195/#199: separate implementations, same visual goal
+  of matching Glyph/image softness to Circle.
 - `get_render_data`'s 16-word header schema reserves words 9 and 10 for
   `alpha_mul` and `shape_id` (previously zero-filled reserved words). The
   per-orb 16-word slots now also use words 11 and 12 for `base_angle` and

--- a/web/src/lib/orberGl.test.ts
+++ b/web/src/lib/orberGl.test.ts
@@ -1,7 +1,7 @@
-// orber#198 — fragment shader の Glyph アームに SDF + Euclidean の max 合成が
-// 入っていることを最小限の boilerplate で検査する。視覚パリティ (Circle と
-// Glyph='●' がぱっと見区別つかない) は kako-jun の手目視で確認する前提なので、
-// ここでは「shader source が想定通りの形で書かれているか」だけを押さえる。
+// orber#198 / #201 — fragment shader の Glyph アームに SDF + Euclidean の
+// alpha-max 合成が入っていることを最小限の boilerplate で検査する。視覚パリティ
+// (Circle と Glyph='●' がぱっと見区別つかない) は kako-jun の手目視で確認する
+// 前提なので、ここでは「shader source が想定通りの形で書かれているか」だけを押さえる。
 //
 // 直接 createGlRenderer を vitest (jsdom) で叩くと WebGL2 context が取れず
 // throw するため、`_FS_FOR_TEST` でエクスポートした raw shader source を
@@ -11,14 +11,20 @@ import { describe, expect, test } from 'vitest';
 
 import { _FS_FOR_TEST, GLYPH_SDF_SIZE } from './orberGl';
 
-describe('orberGl fragment shader (#198)', () => {
+describe('orberGl fragment shader (#198 / #201)', () => {
   test('Glyph アームで r_sdf と r_euclid の両方を計算している', () => {
     expect(_FS_FOR_TEST).toContain('float r_euclid = dist / radius;');
     expect(_FS_FOR_TEST).toContain('r_sdf = 1.0 - signed_unit;');
   });
 
-  test('Glyph アームで max(r_sdf, r_euclid) を採用している', () => {
-    expect(_FS_FOR_TEST).toContain('float r = max(r_sdf, r_euclid);');
+  test('Glyph アームで alpha_sdf / alpha_euclid を計算し max を採用している (#201)', () => {
+    expect(_FS_FOR_TEST).toContain(
+      'float alpha_sdf = falloff_curve(style_bit, r_sdf, blur, opacity);',
+    );
+    expect(_FS_FOR_TEST).toContain(
+      'float alpha_euclid = falloff_curve(style_bit, r_euclid, blur, opacity);',
+    );
+    expect(_FS_FOR_TEST).toContain('alpha = max(alpha_sdf, alpha_euclid);');
   });
 
   test('UV 範囲外では r_sdf を 1.0 超に固定する', () => {
@@ -46,10 +52,12 @@ describe('orberGl fragment shader (#198)', () => {
     expect(GLYPH_SDF_SIZE).toBe(256);
   });
 
-  test('shader source に #198 の履歴コメントが残っている', () => {
-    // 将来「なぜ max(r_sdf, r_euclid) を取っているのか」が分からず削除される
-    // 事故予防として、shader source 内に #198 の参照が残っていることを担保する。
+  test('shader source に #198 と #201 の履歴コメントが残っている', () => {
+    // 将来「なぜ alpha-max を取っているのか」が分からず削除される事故予防として、
+    // shader source 内に #198 (初期設計) と #201 (alpha-max 修正) の参照が
+    // 両方残っていることを担保する。
     expect(_FS_FOR_TEST).toMatch(/#198/);
+    expect(_FS_FOR_TEST).toMatch(/#201/);
   });
 
   test('r_sdf へのリテラル代入は 2.0 のみ (defensive 値の逆方向改変を検出)', () => {
@@ -65,9 +73,18 @@ describe('orberGl fragment shader (#198)', () => {
     }
   });
 
-  test('falloff_curve(style_bit, r, blur, opacity) は Glyph / Circle 両アームで 1 回ずつ呼ばれる', () => {
-    // refactor で if-else どちらかから呼び出しを消してしまう事故を検出する。
+  test('falloff_curve(style_bit, r, blur, opacity) は Circle アームでのみ呼ばれる (旧 r-max 痕跡なし)', () => {
+    // #201 で Glyph アームは r ではなく r_sdf / r_euclid を直接 falloff_curve に渡すように
+    // 変更されたため、`falloff_curve(style_bit, r, blur, opacity)` literal は Circle アームの
+    // 1 回だけ残るのが正しい。Glyph 経路にこの literal が復活していたら r-max 退行のサイン。
     const calls = _FS_FOR_TEST.match(/falloff_curve\(style_bit, r, blur, opacity\)/g) ?? [];
-    expect(calls.length).toBe(2);
+    expect(calls.length).toBe(1);
+  });
+
+  test('Glyph + Circle 合算で falloff_curve の実呼び出しは 3 回 (Glyph=2, Circle=1)', () => {
+    // 関数定義やコメント内参照を除外するため、call site のシグネチャに直接マッチする。
+    // Glyph アーム: alpha_sdf, alpha_euclid 用に 2 回 / Circle アーム: alpha 用に 1 回。
+    const callSites = _FS_FOR_TEST.match(/falloff_curve\(style_bit,/g) ?? [];
+    expect(callSites.length).toBe(3);
   });
 });

--- a/web/src/lib/orberGl.ts
+++ b/web/src/lib/orberGl.ts
@@ -1,6 +1,8 @@
 // orber#112 — WebGL2 fragment shader による per-pixel orb 描画。
 // orber#55 Phase B — Glyph shape (SDF sampling) 経路と softness 軸を追加。
 // orber#198 で SDF + Euclidean を合成して Glyph/image を Circle と同レベルにソフト化。
+// orber#201: 当初 r 値で max を取っていたが、グリフ外側で r_sdf > 1 が支配して
+// halo が出ない問題があった。alpha 値で max を取るように修正。
 //
 // `orber-wasm` の `get_render_data` で得た Float32Array をそのまま uniform に
 // 流し、fragment shader 1 pass で全 orb の Source-Over 合成を行う。CPU 経路
@@ -192,10 +194,11 @@ void main() {
     float cy = ny * u_resolution.y;
 
     // alpha calculation: shape == 0 (Circle) uses Euclidean r = distance/radius
-    // unchanged from the legacy path. shape == 1 (Glyph / image) combines the
-    // SDF-derived r with the same Euclidean r via max(), so both shapes get a
-    // Circle-level soft falloff outside the glyph boundary while keeping the
-    // glyph silhouette near the boundary. See orber#198.
+    // unchanged from the legacy path. shape == 1 (Glyph / image) computes TWO
+    // alpha contributions (SDF-derived and Euclidean) via the shared
+    // falloff_curve and takes max(alpha_sdf, alpha_euclid), so the Glyph arm
+    // gains a Circle-level soft halo while keeping the glyph silhouette.
+    // See orber#198 (initial design) and orber#201 (alpha-max fix).
     float alpha = 0.0;
     if (u_shape_id == 1) {
       vec2 local = px - vec2(cx, cy);
@@ -208,29 +211,33 @@ void main() {
       vec2 rotated = vec2(c * local.x - s * local.y, s * local.x + c * local.y);
       vec2 uv = rotated / (2.0 * radius) * GLYPH_SDF_CONTENT_SPAN + 0.5;
 
-      // orber#198: blend SDF and Euclidean r so Glyph/image gain a Circle-like
-      // soft halo on top of the SDF outline.
+      // orber#198 + #201: combine SDF outline and Euclidean halo as TWO alpha
+      // contributions and take the brighter one.
       //
-      //   r_sdf:    SDF-derived r. Inside the glyph it stays small, at the glyph
-      //             outline it rises to ~1 producing the existing falloff.
-      //   r_euclid: distance(center, px) / radius. Identical to the Circle arm.
+      //   alpha_sdf:    glyph shape (r_sdf goes 0..1 across the SDF transition).
+      //                 Inside the glyph it stays opaque, at the outline it falls.
+      //                 Outside the glyph (r_sdf > 1) it is zero.
+      //   alpha_euclid: Circle-style halo computed exactly like the u_shape_id == 0
+      //                 branch (r_euclid = distance / radius).
       //
-      // r = max(r_sdf, r_euclid) means:
-      //   - Inside glyph (both small): full opacity preserved.
-      //   - At glyph outline (r_sdf ≈ 1): r_sdf dominates and shapes the edge.
-      //   - Outside glyph but still within radius (r_sdf > 1, r_euclid < 1):
-      //     r_euclid wins and produces the Circle-style halo.
+      // alpha = max(alpha_sdf, alpha_euclid) means:
+      //   - Inside glyph: alpha_sdf high (and alpha_euclid also high), opaque.
+      //   - At glyph outline: alpha_sdf drops, alpha_euclid carries the falloff.
+      //   - Outside glyph but within radius: alpha_sdf = 0, alpha_euclid > 0,
+      //     giving the Circle-style halo around the glyph.
+      //   - Outside radius: both 0, transparent.
       //
-      // UV-box edge case: outside the UV box r_euclid is already greater than √2
-      // because the UV box only covers ±radius·√2 in pixel space. falloff_curve
-      // returns 0 once r >= 1, so the UV-outside region is transparent regardless
-      // of r_sdf. The r_sdf = 2.0 defensive assignment exists only to keep the
-      // max() expression semantically consistent (both operands above the cutoff)
-      // without changing the final alpha.
+      // The earlier #198 implementation took max on r values, which let r_sdf > 1
+      // outside the SDF transition dominate the result and kill the halo. Taking
+      // max on alpha instead keeps each contribution independent.
       //
-      // Glyph='●' case: the SDF is a filled circle, so r_sdf ≈ r_euclid and the
-      // max() collapses to the Circle formula — visually indistinguishable from
-      // shape=Circle. This is the perceptual goal of #198.
+      // The r_sdf = 2.0 fallback for UV-outside is still emitted defensively, but
+      // falloff_curve(r_sdf=2) returns 0 so alpha_sdf is always 0 there; the
+      // result is decided purely by alpha_euclid in that band.
+      //
+      // Glyph='●' case: the SDF is a filled circle whose r_sdf curve mirrors
+      // r_euclid, so alpha_sdf ≈ alpha_euclid everywhere and the max collapses to
+      // the Circle formula — visually indistinguishable from shape=Circle.
       //
       // The Circle arm below (u_shape_id == 0) is intentionally untouched.
       float dist = distance(px, vec2(cx, cy));
@@ -242,12 +249,13 @@ void main() {
         r_sdf = 1.0 - signed_unit;
       } else {
         // Outside the SDF UV box the texture lookup is meaningless. Push r_sdf
-        // past 1.0 so falloff_curve treats this sample as fully transparent
-        // for the SDF term, letting r_euclid drive the result via max().
+        // past 1.0 so falloff_curve treats the SDF term as fully transparent,
+        // letting alpha_euclid drive the result via max().
         r_sdf = 2.0;
       }
-      float r = max(r_sdf, r_euclid);
-      alpha = falloff_curve(style_bit, r, blur, opacity);
+      float alpha_sdf = falloff_curve(style_bit, r_sdf, blur, opacity);
+      float alpha_euclid = falloff_curve(style_bit, r_euclid, blur, opacity);
+      alpha = max(alpha_sdf, alpha_euclid);
     } else {
       float dist = distance(px, vec2(cx, cy));
       float r = dist / radius;


### PR DESCRIPTION
## 関連 Issue
closes #201
(関連: #198 / PR #200 の follow-up)

## 症状
#198 で Glyph/image アームに SDF + Euclidean の max 合成を入れたが、視覚確認で「Glyph='●' が Circle と似ていない、円の外側へのぼやけが一切ない」と判明。

## 原因
**r 値で max を取っていた**。グリフ外側で `r_sdf` が 1.0 を超えると `r_euclid < 1.0` でも max が r_sdf を選び、`falloff_curve` が 0 を返して halo が完全に消えていた。

## 修正
`r` ではなく **`alpha` 値で max を取る**:

```glsl
float alpha_sdf = falloff_curve(style_bit, r_sdf, blur, opacity);
float alpha_euclid = falloff_curve(style_bit, r_euclid, blur, opacity);
alpha = max(alpha_sdf, alpha_euclid);
```

挙動:
- グリフ内側: 両 alpha 高 → opaque
- グリフ輪郭 (r_sdf ≈ 1): alpha_sdf 低、alpha_euclid 中 → 滑らか fade
- グリフ外・orb 内 (r_sdf > 1, r_euclid < 1): alpha_sdf = 0、alpha_euclid > 0 → **Circle 風 halo が出る**
- orb 外: 両 0 → 透明

Glyph='●' で SDF が orb と一致サイズなら alpha_sdf ≈ alpha_euclid → 結果も Circle と区別つかない (体感ゴール)。

## 変更
- `web/src/lib/orberGl.ts`: shader Glyph アームを alpha-max 合成に書き換え。shader 内コメント + ヘッダコメントも追従更新
- `web/src/lib/orberGl.test.ts`: 旧 r-max テスト群を alpha-max 構造に追従、新規 1 件追加 (`falloff_curve` の実呼び出しは 3 回 = Glyph 2 + Circle 1)
- `docs/overview.md`: Phase B の #198 follow-up セクションを alpha-max に書き直し

Circle アーム (`u_shape_id == 0` else block) と `falloff_curve` 関数は完全に不変。

## 動作確認
- `cd web && npm run build` 成功
- `cd web && npx vitest run src/lib/orberGl.test.ts` → 10/10 PASS

## 視覚確認
マージ後、Linux Edge で Circle と Glyph='●' を並べて見比べ、見分けつかなくなるかを目視確認する (kako-jun)。