### PR TITLE
fix: Glyph/image アームを SDF マスク × Circle profile の乗算合成に確定 (#203)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -503,26 +503,32 @@ speed / softness without dropping to the terminal.
   profile".** The Glyph arm (`u_shape_id == 1`, which also handles uploaded
   images via the shared `jsGlyphSdf` path) originally fed only `r_sdf` into
   `falloff_curve`, so the soft falloff was confined to the SDF's UV box and
-  the result looked harder than Circle. Three rounds of revision followed:
+  the result looked harder than Circle. Three rounds of revision followed.
+
   **#198 (r-max)** tried `r = max(r_sdf, r_euclid)` fed into `falloff_curve`
   once, but outside the SDF transition `r_sdf > 1` dominated the max and the
-  halo was killed before `r_euclid` could contribute. **#201 (alpha-max)**
-  switched to computing two alpha contributions and `alpha = max(alpha_sdf,
-  alpha_euclid)`, which restored the Glyph='●' halo, but for `A` / image
-  silhouettes the saturating `alpha_euclid` core erased the inner Circle-style
-  fade and produced a circular halo around every silhouette — destroying the
-  shape's individuality. **#203 (mask × profile)** splits responsibilities:
-  the SDF becomes a pure shape mask via `sdf_mask = smoothstep(-0.05, 0.05,
-  signed_unit)` (with mask=0 for UV outside the box), and the Circle-identical
+  halo was killed before `r_euclid` could contribute.
+
+  **#201 (alpha-max)** switched to computing two alpha contributions and
+  `alpha = max(alpha_sdf, alpha_euclid)`, which restored the Glyph='●' halo,
+  but for `A` / image silhouettes the saturating `alpha_euclid` core erased
+  the inner Circle-style fade and produced a circular halo around every
+  silhouette — destroying the shape's individuality.
+
+  **#203 (mask × profile)** splits responsibilities: the SDF becomes a pure
+  shape mask via `sdf_mask = smoothstep(-0.05, 0.05, signed_unit)` (with
+  mask=0 for UV outside the box), and the Circle-identical
   `radial_alpha = falloff_curve(style_bit, r_euclid, blur, opacity)` provides
   the soft center-to-edge profile. The final alpha is the product
   `radial_alpha * sdf_mask`. For Glyph='●' the SDF is a filled disk so the
-  mask is 1 across the entire orb and alpha collapses to `falloff_curve(r_euclid)`
-  — visually indistinguishable from `shape=Circle`, which matches the
-  mathematical identity `●` = Circle. For Glyph='A' or image silhouettes the
-  mask carries the shape and the Circle profile carries the soft fade, so no
-  orb-shaped halo leaks outside the silhouette and the original individuality
-  is preserved. The Circle arm (`u_shape_id == 0`), the `falloff_curve`
+  mask is 1 inside the silhouette and alpha collapses to
+  `falloff_curve(r_euclid)` — visually very close to `shape=Circle` (the
+  outermost ~10% fade ring is omitted because the glyph's SDF radius is
+  ~0.9 × orb radius, so it is a close approximation rather than a
+  byte-identical match). For Glyph='A' or image silhouettes the mask carries
+  the shape and the Circle profile carries the soft fade, so no orb-shaped
+  halo leaks outside the silhouette and the original individuality is
+  preserved. The Circle arm (`u_shape_id == 0`), the `falloff_curve`
   function, and every uniform binding remain unchanged. This is the Web-side
   counterpart to the CLI-side bleed pass added in #195/#199: separate
   implementations, same visual goal of matching Glyph/image softness to Circle.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -499,31 +499,33 @@ speed / softness without dropping to the terminal.
   then feeds the **same rim/soft falloff curve**. Because `rot_speed_signed`
   is an integer multiple of the existing `speed_mult`, glyph rotation stays
   loop-closed at `t = 0 ≡ 1`.
-- **#198 follow-up / #201 fix — SDF + Euclidean composite for Glyph/image
-  (alpha-max).** The Glyph arm (`u_shape_id == 1`, which also handles
-  uploaded images via the shared `jsGlyphSdf` path) originally fed only
-  `r_sdf` into `falloff_curve`, so the soft falloff was confined to the SDF's
-  UV box and the result looked harder than Circle. #198 attempted to fix this
-  by taking `r = max(r_sdf, r_euclid)` and feeding the merged `r` into
-  `falloff_curve` once, but visual inspection showed Glyph='●' still had no
-  halo at all: outside the SDF transition `r_sdf > 1` dominated the max and
-  `falloff_curve` returned 0, killing the Circle-style halo before
-  `r_euclid` could contribute. #201 corrects this by computing TWO alpha
-  contributions and taking `alpha = max(alpha_sdf, alpha_euclid)` instead:
-  `alpha_sdf = falloff_curve(style_bit, r_sdf, blur, opacity)` captures the
-  glyph shape; `alpha_euclid = falloff_curve(style_bit, r_euclid, blur,
-  opacity)` captures the Circle-style halo computed exactly like the
-  `u_shape_id == 0` branch. Inside the glyph both alphas are high so the
-  opaque core is preserved; at the glyph outline `alpha_sdf` drops while
-  `alpha_euclid` carries the falloff; outside the glyph but within radius
-  `alpha_sdf = 0` and `alpha_euclid > 0`, producing the same full-radius
-  halo Circle has; outside radius both are 0. With Glyph='●' `alpha_sdf` and
-  `alpha_euclid` are nearly equal, so the max collapses to the Circle
-  formula and the two shapes become visually indistinguishable. The Circle
-  arm (`u_shape_id == 0`), the `falloff_curve` function, and every uniform
-  binding are unchanged. This is the Web-side counterpart to the CLI-side
-  bleed pass added in #195/#199: separate implementations, same visual goal
-  of matching Glyph/image softness to Circle.
+- **#198 → #201 → #203 — Glyph/image softening converges to "SDF mask × Circle
+  profile".** The Glyph arm (`u_shape_id == 1`, which also handles uploaded
+  images via the shared `jsGlyphSdf` path) originally fed only `r_sdf` into
+  `falloff_curve`, so the soft falloff was confined to the SDF's UV box and
+  the result looked harder than Circle. Three rounds of revision followed:
+  **#198 (r-max)** tried `r = max(r_sdf, r_euclid)` fed into `falloff_curve`
+  once, but outside the SDF transition `r_sdf > 1` dominated the max and the
+  halo was killed before `r_euclid` could contribute. **#201 (alpha-max)**
+  switched to computing two alpha contributions and `alpha = max(alpha_sdf,
+  alpha_euclid)`, which restored the Glyph='●' halo, but for `A` / image
+  silhouettes the saturating `alpha_euclid` core erased the inner Circle-style
+  fade and produced a circular halo around every silhouette — destroying the
+  shape's individuality. **#203 (mask × profile)** splits responsibilities:
+  the SDF becomes a pure shape mask via `sdf_mask = smoothstep(-0.05, 0.05,
+  signed_unit)` (with mask=0 for UV outside the box), and the Circle-identical
+  `radial_alpha = falloff_curve(style_bit, r_euclid, blur, opacity)` provides
+  the soft center-to-edge profile. The final alpha is the product
+  `radial_alpha * sdf_mask`. For Glyph='●' the SDF is a filled disk so the
+  mask is 1 across the entire orb and alpha collapses to `falloff_curve(r_euclid)`
+  — visually indistinguishable from `shape=Circle`, which matches the
+  mathematical identity `●` = Circle. For Glyph='A' or image silhouettes the
+  mask carries the shape and the Circle profile carries the soft fade, so no
+  orb-shaped halo leaks outside the silhouette and the original individuality
+  is preserved. The Circle arm (`u_shape_id == 0`), the `falloff_curve`
+  function, and every uniform binding remain unchanged. This is the Web-side
+  counterpart to the CLI-side bleed pass added in #195/#199: separate
+  implementations, same visual goal of matching Glyph/image softness to Circle.
 - `get_render_data`'s 16-word header schema reserves words 9 and 10 for
   `alpha_mul` and `shape_id` (previously zero-filled reserved words). The
   per-orb 16-word slots now also use words 11 and 12 for `base_angle` and

--- a/web/src/lib/orberGl.test.ts
+++ b/web/src/lib/orberGl.test.ts
@@ -1,7 +1,8 @@
-// orber#198 / #201 — fragment shader の Glyph アームに SDF + Euclidean の
-// alpha-max 合成が入っていることを最小限の boilerplate で検査する。視覚パリティ
-// (Circle と Glyph='●' がぱっと見区別つかない) は kako-jun の手目視で確認する
-// 前提なので、ここでは「shader source が想定通りの形で書かれているか」だけを押さえる。
+// orber#198 → #201 → #203 — fragment shader の Glyph アームが
+// 「SDF マスク × Circle profile」の乗算合成で構成されていることを最小限の
+// boilerplate で検査する。視覚パリティ (Circle と Glyph='●' がぱっと見区別つかない)
+// は kako-jun の手目視で確認する前提なので、ここでは「shader source が想定通りの
+// 形で書かれているか」だけを押さえる。
 //
 // 直接 createGlRenderer を vitest (jsdom) で叩くと WebGL2 context が取れず
 // throw するため、`_FS_FOR_TEST` でエクスポートした raw shader source を
@@ -11,25 +12,39 @@ import { describe, expect, test } from 'vitest';
 
 import { _FS_FOR_TEST, GLYPH_SDF_SIZE } from './orberGl';
 
-describe('orberGl fragment shader (#198 / #201)', () => {
-  test('Glyph アームで r_sdf と r_euclid の両方を計算している', () => {
+describe('orberGl fragment shader (#203 mask × profile)', () => {
+  test('Glyph アームで SDF を smoothstep マスクに変換している', () => {
+    // SDF マスクの宣言と smoothstep 適用が両方残っていること。0.05 の閾値は
+    // SDF 解像度 256 に対する経験則値で、これが書き換えられたらレビュー対象。
+    expect(_FS_FOR_TEST).toContain('float sdf_mask;');
+    expect(_FS_FOR_TEST).toContain('smoothstep(-0.05, 0.05, signed_unit);');
+  });
+
+  test('Glyph アームの radial_alpha は Circle と同じ falloff_curve(r_euclid)', () => {
     expect(_FS_FOR_TEST).toContain('float r_euclid = dist / radius;');
-    expect(_FS_FOR_TEST).toContain('r_sdf = 1.0 - signed_unit;');
+    expect(_FS_FOR_TEST).toContain(
+      'float radial_alpha = falloff_curve(style_bit, r_euclid, blur, opacity);',
+    );
   });
 
-  test('Glyph アームで alpha_sdf / alpha_euclid を計算し max を採用している (#201)', () => {
-    expect(_FS_FOR_TEST).toContain(
-      'float alpha_sdf = falloff_curve(style_bit, r_sdf, blur, opacity);',
-    );
-    expect(_FS_FOR_TEST).toContain(
-      'float alpha_euclid = falloff_curve(style_bit, r_euclid, blur, opacity);',
-    );
-    expect(_FS_FOR_TEST).toContain('alpha = max(alpha_sdf, alpha_euclid);');
+  test('Glyph アームの合成は radial_alpha * sdf_mask の乗算 (#203)', () => {
+    // この行が #203 の核心。max(...) や ぼやけた合成式に退行していないことを担保する。
+    expect(_FS_FOR_TEST).toContain('alpha = radial_alpha * sdf_mask;');
   });
 
-  test('UV 範囲外では r_sdf を 1.0 超に固定する', () => {
-    // 値は実装上 2.0。falloff_curve(r >= 1.0) が 0 を返す挙動に乗る。
-    expect(_FS_FOR_TEST).toContain('r_sdf = 2.0;');
+  test('UV 範囲外では sdf_mask = 0 で透明確定', () => {
+    // grafer 外側のテクスチャ参照を無効化するガード。
+    expect(_FS_FOR_TEST).toContain('sdf_mask = 0.0;');
+  });
+
+  test('旧仕様 (r-max / alpha-max) の痕跡が残っていない', () => {
+    // #198 / #201 の合成式が復活していないこと。alpha_sdf / alpha_euclid という
+    // 旧変数名は使わない方針。
+    expect(_FS_FOR_TEST).not.toContain('float alpha_sdf');
+    expect(_FS_FOR_TEST).not.toContain('float alpha_euclid');
+    expect(_FS_FOR_TEST).not.toContain('max(alpha_sdf, alpha_euclid)');
+    // r_sdf 変数自体が #203 で消滅したのでリテラル代入も無い。
+    expect(_FS_FOR_TEST).not.toMatch(/\br_sdf\s*=/);
   });
 
   test('Circle アーム (u_shape_id == 0) は従来式 r = dist / radius のまま', () => {
@@ -39,10 +54,22 @@ describe('orberGl fragment shader (#198 / #201)', () => {
     expect(_FS_FOR_TEST).toMatch(/float dist = distance\(px, vec2\(cx, cy\)\);\s*\n\s*float r = dist \/ radius;/);
   });
 
-  test('Circle 経路の falloff_curve 呼び出しは Glyph 経路と同じ関数を共有している', () => {
-    // falloff_curve がただ 1 つ定義されている (refactor で 2 系統に分裂していない) こと。
+  test('falloff_curve の定義は 1 つだけ (Glyph と Circle で共有)', () => {
     const defCount = (_FS_FOR_TEST.match(/float falloff_curve\(/g) ?? []).length;
     expect(defCount).toBe(1);
+  });
+
+  test('falloff_curve の実呼び出しは Glyph 1 + Circle 1 = 2 回 (#203 で旧 3 回から削減)', () => {
+    // #201 では Glyph アームで alpha_sdf / alpha_euclid と 2 回呼んでいたが、
+    // #203 では radial_alpha 1 本に統合したので Glyph 経路の呼び出しは 1 回に減る。
+    const callSites = _FS_FOR_TEST.match(/falloff_curve\(style_bit,/g) ?? [];
+    expect(callSites.length).toBe(2);
+  });
+
+  test('Circle アームの falloff_curve(style_bit, r, blur, opacity) は 1 回だけ', () => {
+    // Glyph 経路は r_euclid 引数なのでこのリテラルは Circle アームでのみ出現する。
+    const calls = _FS_FOR_TEST.match(/falloff_curve\(style_bit, r, blur, opacity\)/g) ?? [];
+    expect(calls.length).toBe(1);
   });
 
   test('GLYPH_SDF_CONTENT_SPAN の GLSL 宣言が TS 定数と整合している', () => {
@@ -52,39 +79,11 @@ describe('orberGl fragment shader (#198 / #201)', () => {
     expect(GLYPH_SDF_SIZE).toBe(256);
   });
 
-  test('shader source に #198 と #201 の履歴コメントが残っている', () => {
-    // 将来「なぜ alpha-max を取っているのか」が分からず削除される事故予防として、
-    // shader source 内に #198 (初期設計) と #201 (alpha-max 修正) の参照が
-    // 両方残っていることを担保する。
+  test('shader source に #198 / #201 / #203 の試行履歴コメントが残っている', () => {
+    // 将来「なぜ mask × profile を取っているのか」が分からず削除される事故予防として、
+    // shader source 内に試行履歴の参照が残っていることを担保する。
     expect(_FS_FOR_TEST).toMatch(/#198/);
     expect(_FS_FOR_TEST).toMatch(/#201/);
-  });
-
-  test('r_sdf へのリテラル代入は 2.0 のみ (defensive 値の逆方向改変を検出)', () => {
-    // `r_sdf = 0.0;` や `r_sdf = 0.5;` のようなリテラル代入が混入すると、
-    // UV 外で透明にならず描画されてしまう。`r_sdf = 1.0 - signed_unit;` のような
-    // 式代入はここでは拾わず、リテラル数値代入だけを検査する。
-    const literalAssignments = [..._FS_FOR_TEST.matchAll(/r_sdf\s*=\s*([0-9.]+)\s*;/g)].map(
-      (m) => m[1],
-    );
-    expect(literalAssignments.length).toBeGreaterThan(0);
-    for (const val of literalAssignments) {
-      expect(val).toBe('2.0');
-    }
-  });
-
-  test('falloff_curve(style_bit, r, blur, opacity) は Circle アームでのみ呼ばれる (旧 r-max 痕跡なし)', () => {
-    // #201 で Glyph アームは r ではなく r_sdf / r_euclid を直接 falloff_curve に渡すように
-    // 変更されたため、`falloff_curve(style_bit, r, blur, opacity)` literal は Circle アームの
-    // 1 回だけ残るのが正しい。Glyph 経路にこの literal が復活していたら r-max 退行のサイン。
-    const calls = _FS_FOR_TEST.match(/falloff_curve\(style_bit, r, blur, opacity\)/g) ?? [];
-    expect(calls.length).toBe(1);
-  });
-
-  test('Glyph + Circle 合算で falloff_curve の実呼び出しは 3 回 (Glyph=2, Circle=1)', () => {
-    // 関数定義やコメント内参照を除外するため、call site のシグネチャに直接マッチする。
-    // Glyph アーム: alpha_sdf, alpha_euclid 用に 2 回 / Circle アーム: alpha 用に 1 回。
-    const callSites = _FS_FOR_TEST.match(/falloff_curve\(style_bit,/g) ?? [];
-    expect(callSites.length).toBe(3);
+    expect(_FS_FOR_TEST).toMatch(/#203/);
   });
 });

--- a/web/src/lib/orberGl.test.ts
+++ b/web/src/lib/orberGl.test.ts
@@ -33,7 +33,7 @@ describe('orberGl fragment shader (#203 mask × profile)', () => {
   });
 
   test('UV 範囲外では sdf_mask = 0 で透明確定', () => {
-    // grafer 外側のテクスチャ参照を無効化するガード。
+    // glyph 外側のテクスチャ参照を無効化するガード。
     expect(_FS_FOR_TEST).toContain('sdf_mask = 0.0;');
   });
 

--- a/web/src/lib/orberGl.ts
+++ b/web/src/lib/orberGl.ts
@@ -5,9 +5,15 @@
 // のコメントブロックを参照。
 //
 // `orber-wasm` の `get_render_data` で得た Float32Array をそのまま uniform に
-// 流し、fragment shader 1 pass で全 orb の Source-Over 合成を行う。CPU 経路
-// (`crates/core::animate::render_frame_with_params`) と同じ数式・同じ per-orb
-// パラメータを使うので、視覚パリティは「最終的な見た目が同じ」が保たれる。
+// 流し、fragment shader 1 pass で全 orb の Source-Over 合成を行う。
+//
+// CPU/GPU の対応関係:
+//   - Circle アームは CPU 経路 (`crates/core::animate::render_frame_with_params`)
+//     と完全に同式・同パラメータで、視覚パリティが byte-near まで取れる
+//   - Glyph/image アームは CPU = falloff_curve(r_sdf) + 別 pass の aquarelle
+//     bleed (#195/#199)、GPU = SDF mask × Circle profile の乗算 (#203) と
+//     別実装。両者で同じ「Circle に近いソフトさ」を目指すが、合成式は別物。
+//     詳細は docs/overview.md の Phase B follow-up セクションを参照。
 //
 // shape == "glyph" のときは、`u_glyph_sdf` (256x256 SDF texture) を `(cx, cy)`
 // 中心の正方領域で sampling し、回転用 padding を残した中央帯だけを使って
@@ -36,9 +42,11 @@
 //
 // review S1: CPU 側 (crates/core::orb) は alpha を `(opacity * 255).round() as u8`
 // と `(opacity * 80).round() as u8` で 1/255 ステップに量子化してから tiny-skia
-// に渡している。本 shader は raw float のまま blend する。差分は最大 ≤ 1/255
-// (≒ 0.4% の輝度差) で肉眼識別不能。kako-jun 合意の「最終的な見た目が同じ」
-// 合格ラインを守る前提で量子化は省略している。
+// に渡している。本 shader は raw float のまま blend する。Circle アームでは
+// 差分は最大 ≤ 1/255 (≒ 0.4% の輝度差) で肉眼識別不能。kako-jun 合意の
+// 「最終的な見た目が同じ」合格ラインを守る前提で量子化は省略している。
+// Glyph/image アームは上記のとおり CPU と合成式自体が別実装なので、この
+// 「≤ 1/255」の上限は成立しない（Circle に近い見た目を目指す近似）。
 
 /// uniform 配列の上限。`crates/core::animate::MAX_ORB_COUNT = 1024` ほど大きく
 /// する必要はなく、GUI 経路では `random_batch_specs` の count_range
@@ -208,9 +216,13 @@ void main() {
     //                 produces the smooth center-to-edge fade.
     //   alpha = radial_alpha * sdf_mask
     //
-    // Glyph='●' case: the SDF is a filled circle. Inside the entire orb the mask
-    // is 1, so alpha = falloff_curve(r_euclid) — visually indistinguishable from
-    // shape=Circle.
+    // Glyph='●' case: the SDF is a filled circle. Inside the silhouette the
+    // mask is 1, so alpha = falloff_curve(r_euclid) — visually very close to
+    // shape=Circle. Note: the SDF's '●' radius is roughly 0.9 × orb radius
+    // (GLYPH_SDF_CONTENT_SPAN-derived), so the outermost ~10% fade ring that
+    // Circle would render is cut by mask=0 here. At rim/blur≈0.5, r=0.95 the
+    // omitted ring is around opacity × 0.08 alpha — close to Circle, not
+    // byte-identical to it.
     //
     // Glyph='A' / image silhouette case: sdf_mask carries the shape (A or
     // silhouette), Circle profile carries the soft inner fade. Outside the
@@ -235,6 +247,11 @@ void main() {
       // the 256x256 SDF resolution; widen for a softer outline, narrow for a
       // crisper one. UV outside the SDF box is forced to mask=0 so no
       // texture lookup leaks outside the silhouette.
+      //
+      // Screen-space transition width is roughly 0.85% of orb radius (e.g.
+      // ~1.3 px at radius=150). If GLYPH_SDF_MAX_DIST_FACTOR
+      // (crates/core/src/glyph.rs) is changed, this value shifts
+      // proportionally and the on-screen edge softness scales with it.
       float sdf_mask;
       if (uv.x >= 0.0 && uv.x <= 1.0 && uv.y >= 0.0 && uv.y <= 1.0) {
         float sdf01 = texture(u_glyph_sdf, uv).r;

--- a/web/src/lib/orberGl.ts
+++ b/web/src/lib/orberGl.ts
@@ -1,8 +1,8 @@
 // orber#112 — WebGL2 fragment shader による per-pixel orb 描画。
 // orber#55 Phase B — Glyph shape (SDF sampling) 経路と softness 軸を追加。
-// orber#198 で SDF + Euclidean を合成して Glyph/image を Circle と同レベルにソフト化。
-// orber#201: 当初 r 値で max を取っていたが、グリフ外側で r_sdf > 1 が支配して
-// halo が出ない問題があった。alpha 値で max を取るように修正。
+// orber#198 → #201 → #203 で Glyph/image アームの softening 合成を最終的に
+// 「SDF マスク × Circle profile」の乗算形に確定。過去の試行履歴は shader 本体
+// のコメントブロックを参照。
 //
 // `orber-wasm` の `get_render_data` で得た Float32Array をそのまま uniform に
 // 流し、fragment shader 1 pass で全 orb の Source-Over 合成を行う。CPU 経路
@@ -193,12 +193,31 @@ void main() {
     float cx = nx * u_resolution.x;
     float cy = ny * u_resolution.y;
 
-    // alpha calculation: shape == 0 (Circle) uses Euclidean r = distance/radius
-    // unchanged from the legacy path. shape == 1 (Glyph / image) computes TWO
-    // alpha contributions (SDF-derived and Euclidean) via the shared
-    // falloff_curve and takes max(alpha_sdf, alpha_euclid), so the Glyph arm
-    // gains a Circle-level soft halo while keeping the glyph silhouette.
-    // See orber#198 (initial design) and orber#201 (alpha-max fix).
+    // orber#198 → #201 → #203: Glyph/image の softening を Circle と揃える試行履歴。
+    //
+    //   #198 (r-max):  r 値で max を取ると外側で r_sdf > 1 が支配して halo が出ない
+    //   #201 (alpha-max): alpha 値で max を取ると内側で alpha_sdf が saturate し
+    //                     Circle 風 fade が消え、画像シルエットも円形 halo に呑まれる
+    //   #203 (mask × profile): SDF を形状マスク、Circle profile (r_euclid) を fade
+    //                          として分離して乗算
+    //
+    // Implementation:
+    //   sdf_mask: 1 inside silhouette, 0 outside, smooth transition (smoothstep
+    //             on signed_unit). Pure shape gate.
+    //   radial_alpha: falloff_curve(r_euclid) — identical to the Circle branch,
+    //                 produces the smooth center-to-edge fade.
+    //   alpha = radial_alpha * sdf_mask
+    //
+    // Glyph='●' case: the SDF is a filled circle. Inside the entire orb the mask
+    // is 1, so alpha = falloff_curve(r_euclid) — visually indistinguishable from
+    // shape=Circle.
+    //
+    // Glyph='A' / image silhouette case: sdf_mask carries the shape (A or
+    // silhouette), Circle profile carries the soft inner fade. Outside the
+    // silhouette the mask is 0 so no orb-shaped halo leaks out; the silhouette's
+    // individuality is preserved.
+    //
+    // The Circle arm below (u_shape_id == 0) is intentionally untouched.
     float alpha = 0.0;
     if (u_shape_id == 1) {
       vec2 local = px - vec2(cx, cy);
@@ -211,51 +230,29 @@ void main() {
       vec2 rotated = vec2(c * local.x - s * local.y, s * local.x + c * local.y);
       vec2 uv = rotated / (2.0 * radius) * GLYPH_SDF_CONTENT_SPAN + 0.5;
 
-      // orber#198 + #201: combine SDF outline and Euclidean halo as TWO alpha
-      // contributions and take the brighter one.
-      //
-      //   alpha_sdf:    glyph shape (r_sdf goes 0..1 across the SDF transition).
-      //                 Inside the glyph it stays opaque, at the outline it falls.
-      //                 Outside the glyph (r_sdf > 1) it is zero.
-      //   alpha_euclid: Circle-style halo computed exactly like the u_shape_id == 0
-      //                 branch (r_euclid = distance / radius).
-      //
-      // alpha = max(alpha_sdf, alpha_euclid) means:
-      //   - Inside glyph: alpha_sdf high (and alpha_euclid also high), opaque.
-      //   - At glyph outline: alpha_sdf drops, alpha_euclid carries the falloff.
-      //   - Outside glyph but within radius: alpha_sdf = 0, alpha_euclid > 0,
-      //     giving the Circle-style halo around the glyph.
-      //   - Outside radius: both 0, transparent.
-      //
-      // The earlier #198 implementation took max on r values, which let r_sdf > 1
-      // outside the SDF transition dominate the result and kill the halo. Taking
-      // max on alpha instead keeps each contribution independent.
-      //
-      // The r_sdf = 2.0 fallback for UV-outside is still emitted defensively, but
-      // falloff_curve(r_sdf=2) returns 0 so alpha_sdf is always 0 there; the
-      // result is decided purely by alpha_euclid in that band.
-      //
-      // Glyph='●' case: the SDF is a filled circle whose r_sdf curve mirrors
-      // r_euclid, so alpha_sdf ≈ alpha_euclid everywhere and the max collapses to
-      // the Circle formula — visually indistinguishable from shape=Circle.
-      //
-      // The Circle arm below (u_shape_id == 0) is intentionally untouched.
-      float dist = distance(px, vec2(cx, cy));
-      float r_euclid = dist / radius;
-      float r_sdf;
+      // SDF -> smooth shape mask. signed_unit > 0 inside, < 0 outside.
+      // The 0.05 half-width is an empirical edge-softness tuning constant for
+      // the 256x256 SDF resolution; widen for a softer outline, narrow for a
+      // crisper one. UV outside the SDF box is forced to mask=0 so no
+      // texture lookup leaks outside the silhouette.
+      float sdf_mask;
       if (uv.x >= 0.0 && uv.x <= 1.0 && uv.y >= 0.0 && uv.y <= 1.0) {
         float sdf01 = texture(u_glyph_sdf, uv).r;
         float signed_unit = sdf01 * 2.0 - 1.0;
-        r_sdf = 1.0 - signed_unit;
+        sdf_mask = smoothstep(-0.05, 0.05, signed_unit);
       } else {
-        // Outside the SDF UV box the texture lookup is meaningless. Push r_sdf
-        // past 1.0 so falloff_curve treats the SDF term as fully transparent,
-        // letting alpha_euclid drive the result via max().
-        r_sdf = 2.0;
+        sdf_mask = 0.0;
       }
-      float alpha_sdf = falloff_curve(style_bit, r_sdf, blur, opacity);
-      float alpha_euclid = falloff_curve(style_bit, r_euclid, blur, opacity);
-      alpha = max(alpha_sdf, alpha_euclid);
+
+      // Circle-identical radial profile, computed from Euclidean r_euclid.
+      // Same falloff_curve call as the Circle arm — only the variable name
+      // differs to avoid shadowing.
+      float dist = distance(px, vec2(cx, cy));
+      float r_euclid = dist / radius;
+      float radial_alpha = falloff_curve(style_bit, r_euclid, blur, opacity);
+
+      // Multiply: shape gate × Circle-style fade.
+      alpha = radial_alpha * sdf_mask;
     } else {
       float dist = distance(px, vec2(cx, cy));
       float r = dist / radius;


### PR DESCRIPTION
## 関連 Issue
closes #203
(関連: #198 / PR #200、#201 / PR #202 の試行)

## 過去の経緯
- #198 (PR #200): r-max 合成 — グリフ外側で halo が出ない
- #201 (PR #202): alpha-max 合成 — 内側の Circle fade が消え、画像シルエットが円形 halo に呑まれる
- **#203 (本 PR)**: SDF マスク × Circle profile — 数式上 Glyph='●' = Circle、シルエット個性も保持

## 修正

Glyph/image アームを「SDF を**形状マスク**、Circle profile (r_euclid) を**ぼけ方**」として**乗算合成**:

```glsl
float sdf_mask;
if (uv 範囲内) {
    float sdf01 = texture(u_glyph_sdf, uv).r;
    float signed_unit = sdf01 * 2.0 - 1.0;
    sdf_mask = smoothstep(-0.05, 0.05, signed_unit);
} else {
    sdf_mask = 0.0;
}
float dist = distance(px, vec2(cx, cy));
float r_euclid = dist / radius;
float radial_alpha = falloff_curve(style_bit, r_euclid, blur, opacity);
alpha = radial_alpha * sdf_mask;
```

挙動:
- **Glyph='●'** (orb と同サイズ): sdf_mask = 1 (全域) → `alpha = falloff_curve(r_euclid)` → **Circle と数式上同一**
- **Glyph='A'**: A シルエット × Circle 風中心 fade。A 外側 = 0 (halo 無し)
- **画像シルエット**: シルエット形状 × Circle 風中心 fade。シルエット外 = 0 → 個性保持

Circle アーム / `falloff_curve` 関数 / uniforms 全て不変。Glyph アームでの `falloff_curve` 呼び出しは旧 alpha-max の 2 回から **1 回** に削減。

## 変更
- `web/src/lib/orberGl.ts`: shader Glyph アームを mask × profile に書き換え。shader 内コメント (試行履歴 #198 → #201 → #203 を残す) も更新
- `web/src/lib/orberGl.test.ts`: 旧 alpha_sdf/alpha_euclid テストを削除、新仕様の構造テスト 11 件に再整理
- `docs/overview.md`: Phase B follow-up を新仕様ベースに書き直し

## 動作確認
- `cd web && npm run build` 成功
- `cd web && npx vitest run src/lib/orberGl.test.ts` → 11/11 PASS

## 視覚確認
マージ後、Linux Edge で:
- Circle と Glyph='●' を並べて見比べ、見分けつかなくなることを目視確認
- 四角芋画像で image shape を選び、シルエット個性 (角の四角さ) が残っていることを確認