### PR TITLE
refactor: SoftnessPreset を blurry 方向にシフト + Glyph/image 輪郭を softness 連動 (#205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,21 @@ that base angle.
 ### Softness
 
 `--softness low|mid|high` (default `mid`) is a single axis that bundles alpha,
-blur, and edge softness:
+blur offset, and glyph/image edge softness.
 
-- `low` — default alpha + weak blur + sharper edges. Tuned for a crisper plate
-  or wallpaper look.
-- `mid` — identical to the previous default. Existing renders are unchanged.
-- `high` — weaker alpha + stronger blur + softer edges. Tuned for sitting
-  **underneath text overlays** so the orbs read as ambient color.
+- `low` — alpha=1.0 + blur+0.0 + crisper glyph/image silhouettes. The
+  crisp baseline (this used to be the default before #205).
+- `mid` — alpha=0.55 + blur+0.25 + medium silhouette softness. **Default
+  since #205**, tuned so every shape reads close to the orb softness on
+  first glance.
+- `high` — alpha=0.35 + blur+0.5 + maximum silhouette softness. Tuned for
+  sitting **underneath text overlays** so the orbs read as ambient color,
+  or for a cinematic mood plate.
+
+> The original Phase A scale had a sharper `low` (`blur_offset = -0.25`)
+> and put `mid` at the legacy default. #205 shifted the whole scale toward
+> blurry — the old sharp `low` is retired since nothing in the GUI relied
+> on the extra sharpness it provided.
 
 ```bash
 orber --input photo.jpg --output wallpaper.png --softness low

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -64,13 +64,15 @@ impl From<CliSpeed> for MotionSpeed {
 }
 
 /// Visual softness preset (`--softness`). Single axis, three steps (#55).
+/// #205 で全体が blurry 方向にシフトされた。旧 Low は廃止、旧 Mid→新 Low、
+/// 旧 High→新 Mid (default)、新 High が追加された。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum CliSoftness {
-    /// Low softness: less blur, sharper edges.
+    /// Crisper baseline (was the legacy default before #205): less blur, sharper edges.
     Low,
-    /// Same look as before (default; no regression).
+    /// Orb-like softness (new default; same look as the previous "high" preset).
     Mid,
-    /// High softness: more blur, softer edges, slightly fainter center.
+    /// Maximum blur — use under text overlays or for cinematic mood.
     High,
 }
 
@@ -303,8 +305,10 @@ struct Cli {
     #[arg(long, default_value = "\u{2606}", value_parser = parse_single_char)]
     glyph_char: char,
 
-    /// Visual softness preset (#55): low / mid / high.
-    /// Low = sharper / less blur, Mid = legacy default, High = softer / more blur.
+    /// Visual softness preset (#55, #205): low / mid / high.
+    /// Low = crisper baseline (was the legacy default before #205),
+    /// Mid = orb-like softness (new default; same look as the previous "high" preset),
+    /// High = maximum blur (use under text overlays or for cinematic mood).
     #[arg(long, value_enum, default_value_t = CliSoftness::Mid)]
     softness: CliSoftness,
 

--- a/crates/core/src/animate.rs
+++ b/crates/core/src/animate.rs
@@ -319,6 +319,11 @@ fn unit_from_hash(x: u64) -> f32 {
 ///
 /// `glyph_rotate` (#136): `false` を渡すと shader 側で per-orb 回転を抑止し、
 /// 全 t で `base_angle` のまま描く。Circle 経路には影響しない。
+///
+/// `edge_softness` (#205): Glyph / image アームの smoothstep 幅を softness preset と
+/// 連動させるため、`SoftnessPreset::edge_softness()` の値 (0.3 / 0.6 / 1.0) を
+/// shader に流す。Circle アームは Euclidean distance + falloff_curve なので影響を
+/// 受けない。
 #[doc(hidden)]
 #[allow(clippy::too_many_arguments)]
 pub fn pack_render_data_for_webgl(
@@ -333,6 +338,7 @@ pub fn pack_render_data_for_webgl(
     alpha_mul: f32,
     shape_id: f32,
     glyph_rotate: bool,
+    edge_softness: f32,
 ) -> Vec<f32> {
     let header_words = 16usize;
     let per_orb_words = 16usize;
@@ -351,6 +357,9 @@ pub fn pack_render_data_for_webgl(
     buf[10] = shape_id;
     // #136: header[11] = glyph_rotate (1.0 = ON / 既定, 0.0 = OFF)。既存ヘッダ予約域に追加。
     buf[11] = if glyph_rotate { 1.0 } else { 0.0 };
+    // #205: header[12] = edge_softness (Glyph/image アーム smoothstep 幅、0.3..=1.0)。
+    // Circle アームは参照しない。残り header[13..16] は今後の拡張用に予約。
+    buf[12] = edge_softness;
 
     if n_orbs == 0 || clusters.is_empty() {
         return buf;

--- a/crates/core/src/orb.rs
+++ b/crates/core/src/orb.rs
@@ -385,12 +385,16 @@ mod tests {
 
     #[test]
     fn single_cluster_centered_color() {
+        // #205: SoftnessPreset の新デフォルト Mid は alpha=0.55 で center が 140 程度まで
+        // 落ちるので、「center R > 200」を担保したい本テストは sharp baseline の Low を
+        // 明示する（旧仕様の default 挙動と等価）。
         let opts = RenderOptions {
             width: 100,
             height: 100,
             blur: 0.5,
             saturation: 1.0,
             orb_size: 1.0,
+            softness: SoftnessPreset::Low,
             ..Default::default()
         };
         let img = render_static(&[cluster([255, 0, 0], 0.5, 0.5, 1.0)], &opts);
@@ -643,6 +647,9 @@ mod tests {
     #[test]
     fn glyph_shape_renders_via_render_static() {
         // OrbShape::Glyph が render_static 経由でも一定数のピクセルを描く。
+        // #205: 新デフォルト Mid は alpha=0.55 + blur+0.25 で lit pixel が大幅に薄れる。
+        // 「Glyph 経路が機能していること」を担保するのが目的なので sharp baseline の
+        // Low を明示する（旧仕様の default 挙動と等価）。
         use crate::glyph::GlyphFontId;
         let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
         let opts = RenderOptions {
@@ -652,6 +659,7 @@ mod tests {
                 ch: '☆',
                 font: GlyphFontId::NotoSymbols2,
             },
+            softness: SoftnessPreset::Low,
             ..Default::default()
         };
         let img = render_static(&[c], &opts);
@@ -793,6 +801,8 @@ mod tests {
     fn glyph_lit_pixels_remain_visible_after_bleed() {
         // bleed pass を通してもグリフの白塗りピクセルが極端に薄まって消えていないこと。
         // 既存 glyph_shape_renders_via_render_static と同じ閾値 (lit > 32) で担保する。
+        // #205: 新デフォルト Mid は alpha/blur が強くなり閾値を割るので sharp baseline の
+        // Low を明示する。
         use crate::glyph::GlyphFontId;
         let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
         let opts = RenderOptions {
@@ -802,6 +812,7 @@ mod tests {
                 ch: '☆',
                 font: GlyphFontId::NotoSymbols2,
             },
+            softness: SoftnessPreset::Low,
             ..Default::default()
         };
         let img = render_static(&[c], &opts);
@@ -840,6 +851,9 @@ mod tests {
                 ch: '☆',
                 font: GlyphFontId::NotoSymbols2,
             },
+            // #205: 新デフォルト Mid は alpha/blur が強くなって halo R がほぼ消える。
+            // bleed pass の到達範囲を計測するのが目的なので Low (旧 default) を使う。
+            softness: SoftnessPreset::Low,
             ..Default::default()
         };
         let img = render_static(&[c], &opts);

--- a/crates/core/src/style.rs
+++ b/crates/core/src/style.rs
@@ -21,45 +21,69 @@ pub(crate) const STYLE_WIDTH: u32 = 1080;
 /// SVG viewBox 高さ。PNG / 動画と揃える。
 pub(crate) const STYLE_HEIGHT: u32 = 1920;
 
-/// orb の見た目の「ぼかし具合」を 1 軸 3 段階で制御する preset (#55)。
+/// orb の見た目の「ぼかし具合」を 1 軸 3 段階で制御する preset (#55, #205)。
 ///
-/// - `Low`: ぼかし弱め / 縁シャープ
-/// - `Mid`: 既存の振る舞いと同じ（regression なし、デフォルト）
-/// - `High`: ぼかし強め / 縁ソフト / alpha 控えめ
+/// #205 で全スケールを blurry 方向にシフト:
+/// - `Low`: 旧 Mid 相当。最も sharp な baseline。
+/// - `Mid` (デフォルト): 旧 High 相当。orb 並みのソフトさを全 shape に適用する新標準。
+/// - `High`: 新規。最も blurry。alpha も更に控えめ。
+///
+/// 旧 Low (`blur_offset = -0.25` の極端な sharp 描画) は #205 で廃止。
 ///
 /// 内部効果:
-/// - alpha 倍率: Low=1.0, Mid=1.0, High=0.55
-/// - blur オフセット: Low=-0.25, Mid=0.0, High=+0.25
+/// - alpha 倍率: Low=1.0, Mid=0.55, High=0.35
+/// - blur オフセット: Low=0.0, Mid=+0.25, High=+0.5
+/// - edge softness (Glyph/image アーム smoothstep 幅): Low=0.3, Mid=0.6, High=1.0
 ///
 /// PNG (animate / render_static) と SVG / CSS の全経路で同じ意味で適用する。
+/// edge_softness は WebGL2 fragment shader (`web/src/lib/orberGl.ts`) の Glyph アーム
+/// でのみ参照され、Circle アームには影響しない。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 pub enum SoftnessPreset {
-    /// ぼかし弱め。縁シャープ。
+    /// 最も sharp。新スケールの baseline (旧 Mid 相当)。
     Low,
-    /// 既存の振る舞いと完全同値（デフォルト）。
+    /// orb 並みのソフトさを全 shape に適用する新デフォルト (旧 High 相当)。
     #[default]
     Mid,
-    /// ぼかし強め。縁ソフトで alpha も控えめ。
+    /// 最も blurry。alpha も更に控えめで、テキストオーバーレイ下敷きに向く。
     High,
 }
 
 impl SoftnessPreset {
-    /// orb 中心の不透明度に掛ける倍率。Mid = 1.0（既存と同値）。
+    /// orb 中心の不透明度に掛ける倍率。新デフォルト Mid = 0.55（旧 High 相当）。
     pub fn alpha_mul(self) -> f32 {
         match self {
+            // 旧 Mid 相当 (最も sharp、新スケールの下限)
             SoftnessPreset::Low => 1.0,
-            SoftnessPreset::Mid => 1.0,
-            SoftnessPreset::High => 0.55,
+            // 旧 High 相当 (新デフォルト)
+            SoftnessPreset::Mid => 0.55,
+            // 新規 (最強、alpha もより透過)
+            SoftnessPreset::High => 0.35,
         }
     }
 
     /// blur パラメータに足すオフセット。最終 blur は呼び出し側で `[0, 1]` に clamp する。
-    /// Mid = 0.0（既存と同値）。Low は -0.25（よりシャープ）、High は +0.25（よりソフト）。
+    /// 新スケールでは Low = 0.0 (旧 Mid 相当の baseline)、Mid = +0.25 (旧 High 相当)、
+    /// High = +0.5 (新規、blur max)。
     pub fn blur_offset(self) -> f32 {
         match self {
-            SoftnessPreset::Low => -0.25,
-            SoftnessPreset::Mid => 0.0,
-            SoftnessPreset::High => 0.25,
+            SoftnessPreset::Low => 0.0,
+            SoftnessPreset::Mid => 0.25,
+            SoftnessPreset::High => 0.5,
+        }
+    }
+
+    /// Glyph / image アームの輪郭 smoothstep 幅（#205）。
+    ///
+    /// WebGL2 fragment shader (`web/src/lib/orberGl.ts`) の Glyph アームで
+    /// `smoothstep(-edge_softness, edge_softness * 0.5, signed_unit)` の閾値として
+    /// 使う。値域は `[0.3, 1.0]` で、対応するスクリーン幅は概ね 4% 〜 17% 程度。
+    /// Circle アームは Euclidean distance + falloff_curve なのでこの値の影響を受けない。
+    pub fn edge_softness(self) -> f32 {
+        match self {
+            SoftnessPreset::Low => 0.3,
+            SoftnessPreset::Mid => 0.6,
+            SoftnessPreset::High => 1.0,
         }
     }
 }
@@ -502,7 +526,14 @@ mod tests {
 
     #[test]
     fn css_stops_strictly_monotonic_default() {
-        let css = render_css(&six_clusters(), &StyleOptions::default());
+        // #205: extract_css_stops は alpha が "1" / "0.5" であることを前提にした文字列
+        // パーサなので、Low (alpha_mul=1.0、旧 default 相当) を明示する。
+        // テストの目的は stop の monotonicity 担保で、softness preset は関係ない。
+        let opts = StyleOptions {
+            softness: SoftnessPreset::Low,
+            ..StyleOptions::default()
+        };
+        let css = render_css(&six_clusters(), &opts);
         let stops = extract_css_stops(&css);
         assert_eq!(stops.len(), 6);
         for (s0, m, e) in stops {
@@ -516,6 +547,7 @@ mod tests {
     fn css_stops_strictly_monotonic_boundary_values() {
         // weight=1.0 / blur=0.0 / orb_size=2.0 の極端なケースで mid/end の
         // 衝突が起きないことを保証する。
+        // #205: extract_css_stops が ",1) " / ",0.5) " 前提なので Low を明示する。
         let extreme_clusters = vec![
             cluster([200, 100, 50], 0.5, 0.5, 1.0),   // 最大 weight
             cluster([50, 200, 100], 0.5, 0.5, 0.001), // 微小 weight
@@ -526,6 +558,7 @@ mod tests {
                     orb_size,
                     blur,
                     saturation: 1.0,
+                    softness: SoftnessPreset::Low,
                     ..Default::default()
                 };
                 let css = render_css(&extreme_clusters, &opts);
@@ -543,9 +576,12 @@ mod tests {
     }
 
     #[test]
-    fn softness_mid_is_regression_compatible_svg() {
-        // softness=Mid を明示的に渡しても、デフォルト（=Mid）と完全一致。
-        // これが回帰の最後の砦。
+    fn softness_default_matches_explicit_mid() {
+        // #205: SoftnessPreset::default() == Mid。明示的な Mid 指定でも
+        // デフォルト（=Mid）と完全一致することを担保する。
+        // 旧仕様の「Mid = legacy default と byte-equal」という意味は #205 で失効した
+        // (Mid は旧 High 相当の値に格上げされた) が、「default() と explicit Mid の一致」
+        // は仕様として保ち続ける。
         let clusters = six_clusters();
         let opts_default = StyleOptions::default();
         let opts_mid = StyleOptions {
@@ -595,17 +631,30 @@ mod tests {
     }
 
     #[test]
-    fn softness_alpha_mul_and_blur_offset_table() {
-        // SoftnessPreset の数値テーブルが仕様通りであることを担保する回帰テスト。
-        // Mid は alpha 1.0 / blur offset 0.0（既存挙動）。
-        assert!((SoftnessPreset::Mid.alpha_mul() - 1.0).abs() < 1e-6);
-        assert!((SoftnessPreset::Mid.blur_offset() - 0.0).abs() < 1e-6);
-        // Low は blur を弱める（よりシャープ）。
-        assert!((SoftnessPreset::Low.alpha_mul() - SoftnessPreset::Mid.alpha_mul()).abs() < 1e-6);
+    fn softness_table_after_shift() {
+        // #205: SoftnessPreset 値テーブルを blurry 方向にシフトした後の回帰テスト。
+        // 旧仕様: Low=(1.0, -0.25)、Mid=(1.0, 0.0)、High=(0.55, 0.25)。
+        // 新仕様: Low=(1.0, 0.0)、Mid=(0.55, 0.25)、High=(0.35, 0.5)。
+        // edge_softness は新規 method で Low=0.3 / Mid=0.6 / High=1.0。
+        assert!((SoftnessPreset::Low.alpha_mul() - 1.0).abs() < 1e-6);
+        assert!((SoftnessPreset::Low.blur_offset() - 0.0).abs() < 1e-6);
+        assert!((SoftnessPreset::Mid.alpha_mul() - 0.55).abs() < 1e-6);
+        assert!((SoftnessPreset::Mid.blur_offset() - 0.25).abs() < 1e-6);
+        assert!((SoftnessPreset::High.alpha_mul() - 0.35).abs() < 1e-6);
+        assert!((SoftnessPreset::High.blur_offset() - 0.5).abs() < 1e-6);
+
+        // 順序: alpha は Low > Mid > High（だんだん透過）、blur は Low < Mid < High。
+        assert!(SoftnessPreset::Low.alpha_mul() > SoftnessPreset::Mid.alpha_mul());
+        assert!(SoftnessPreset::Mid.alpha_mul() > SoftnessPreset::High.alpha_mul());
         assert!(SoftnessPreset::Low.blur_offset() < SoftnessPreset::Mid.blur_offset());
-        // High は alpha を弱め、blur を強める（よりソフト）。
-        assert!(SoftnessPreset::High.alpha_mul() < SoftnessPreset::Mid.alpha_mul());
-        assert!(SoftnessPreset::High.blur_offset() > SoftnessPreset::Mid.blur_offset());
+        assert!(SoftnessPreset::Mid.blur_offset() < SoftnessPreset::High.blur_offset());
+
+        // edge_softness は Low < Mid < High（smoothstep 幅が広がる = 縁がぼける）。
+        assert!((SoftnessPreset::Low.edge_softness() - 0.3).abs() < 1e-6);
+        assert!((SoftnessPreset::Mid.edge_softness() - 0.6).abs() < 1e-6);
+        assert!((SoftnessPreset::High.edge_softness() - 1.0).abs() < 1e-6);
+        assert!(SoftnessPreset::Low.edge_softness() < SoftnessPreset::Mid.edge_softness());
+        assert!(SoftnessPreset::Mid.edge_softness() < SoftnessPreset::High.edge_softness());
     }
 
     #[test]

--- a/crates/core/src/style.rs
+++ b/crates/core/src/style.rs
@@ -329,7 +329,8 @@ pub fn render_css(clusters: &[Cluster], opts: &StyleOptions) -> String {
         // （mid_pct < end_pct を構造的に担保する）。
         let mid_pct = (end_f * mid_factor).round() as i32;
         let mid_pct = mid_pct.clamp(0, end_pct - 1);
-        // softness 軸: alpha 全体に倍率を掛ける。Mid なら 1.0/0.5/0.0 のまま（regression なし）。
+        // softness 軸: alpha 全体に倍率を掛ける。Mid なら alpha_mul=0.55 (#205 後)。
+        // CSS 文字列パースを伴うテストは Low 明示で baseline を取る。
         let stop0 = alpha_mul;
         let stop_mid = 0.5 * alpha_mul;
         gradients.push(format!(

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -535,9 +535,11 @@ pub fn generate_batch(params_js: JsValue, n: u32) -> Result<js_sys::Array, JsErr
 /// - `[6]`: direction_id (0=LR, 1=RL, 2=TB, 3=BT)
 /// - `[7]`: cycle_count (1 = VerySlow, 2 = Slow, 3 = Mid, 4 = Fast)
 /// - `[8]`: n_orbs (整数を f32 として)
-/// - `[9]`: softness_alpha_mul (0..1) — Phase B (#55)。Mid なら 1.0
+/// - `[9]`: softness_alpha_mul (0..1) — Phase B (#55)。Mid なら 0.55 (#205 後)
 /// - `[10]`: shape_id (0=Circle, 1=Glyph) — Phase B (#55)
-/// - `[11..16]`: 予約（0 詰め）
+/// - `[11]`: glyph_rotate (1.0 = ON / 0.0 = OFF) — #136
+/// - `[12]`: edge_softness (Glyph/image アーム smoothstep 幅、0.3..=1.0) — #205
+/// - `[13..16]`: 予約（0 詰め）
 ///
 /// `[16 + 16*i ..]` per orb i:
 /// - `[+0..+3]`: color_rgb (0..1)
@@ -618,9 +620,11 @@ pub fn get_render_data(
 
     let base_radius_unit = (p.width.min(p.height) as f32) * 0.25 * spec.orb_size.max(0.0);
     // Phase B (#55): softness.blur_offset() を base_blur に積算（core/animate と同式）。
-    // Mid なら +0.0 で既存挙動と完全同値。
+    // #205 以降 Mid は +0.25 で blurry 寄りの新 default。
     let base_blur = (spec.blur + softness.blur_offset()).clamp(0.0, 1.0);
     let alpha_mul = softness.alpha_mul().clamp(0.0, 1.0);
+    // #205: Glyph/image アーム smoothstep 幅を softness 連動。Circle は参照しない。
+    let edge_softness = softness.edge_softness();
     let shape_id: f32 = match shape {
         OrbShape::Circle => 0.0,
         OrbShape::Glyph { .. } => 1.0,
@@ -641,6 +645,7 @@ pub fn get_render_data(
         alpha_mul,
         shape_id,
         p.glyph_rotate,
+        edge_softness,
     );
 
     Ok(js_sys::Float32Array::from(buf.as_slice()))
@@ -651,8 +656,8 @@ pub fn get_render_data(
 ///
 /// WebGL path が core のアニメーションと別 RNG 列を持たないよう、乱数列は
 /// ここで再実装せず `orber_core::animate::generate_orb_params` に委譲する。
-// TODO(orber#future): pack_render_data の引数が 11 個に達した。Phase C で
-// orb 形状軸が更に増えるなら struct で受けるリファクタを検討する。
+// TODO(orber#future): pack_render_data の引数が 12 個に達した (#205 で edge_softness 追加)。
+// Phase C で orb 形状軸が更に増えるなら struct で受けるリファクタを検討する。
 #[allow(clippy::too_many_arguments)]
 fn pack_render_data(
     clusters: &[Cluster],
@@ -666,6 +671,7 @@ fn pack_render_data(
     alpha_mul: f32,
     shape_id: f32,
     glyph_rotate: bool,
+    edge_softness: f32,
 ) -> Vec<f32> {
     pack_render_data_for_webgl(
         clusters,
@@ -679,6 +685,7 @@ fn pack_render_data(
         alpha_mul,
         shape_id,
         glyph_rotate,
+        edge_softness,
     )
 }
 
@@ -1148,6 +1155,7 @@ mod tests {
             softness.alpha_mul().clamp(0.0, 1.0),
             1.0,
             true,
+            softness.edge_softness(),
         );
         let expected = pack_render_data_for_webgl(
             &clusters,
@@ -1161,7 +1169,52 @@ mod tests {
             softness.alpha_mul().clamp(0.0, 1.0),
             1.0,
             true,
+            softness.edge_softness(),
         );
         assert_eq!(buf, expected);
+    }
+
+    /// #205: get_render_data の header[12] に softness.edge_softness() がそのまま
+    /// 入っていることを担保する。
+    #[test]
+    fn pack_render_data_header_includes_edge_softness() {
+        let mut p = base_params();
+        p.k = 2;
+        p.source_width = 2;
+        p.source_height = 2;
+        p.source_rgb = vec![
+            255, 0, 0, 255, 0, 0, //
+            0, 0, 255, 0, 0, 255,
+        ];
+        let total = 12usize;
+        let spec_idx = 0usize;
+        let still_count = total - GUI_VIDEO_COUNT_DEFAULT;
+        let (_, bg, clusters) = get_or_build_clusters(&mut p).expect("clusters should build");
+        let specs = random_batch_specs(42, total, still_count);
+        let spec = specs[spec_idx];
+        let speed = speed_for_spec_idx(spec_idx, still_count, &spec);
+        // Low / Mid / High それぞれで header[12] が edge_softness() と一致すること。
+        for preset in [
+            SoftnessPreset::Low,
+            SoftnessPreset::Mid,
+            SoftnessPreset::High,
+        ] {
+            let n_orbs = spec.count.clamp(1, MAX_ORB_COUNT);
+            let buf = pack_render_data(
+                &clusters,
+                bg,
+                (64f32) * 0.25 * spec.orb_size.max(0.0),
+                (spec.blur + preset.blur_offset()).clamp(0.0, 1.0),
+                0.0,
+                speed.cycle_count() as f32,
+                spec.seed,
+                n_orbs,
+                preset.alpha_mul().clamp(0.0, 1.0),
+                1.0,
+                true,
+                preset.edge_softness(),
+            );
+            assert!((buf[12] - preset.edge_softness()).abs() < 1e-6);
+        }
     }
 }

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -483,8 +483,21 @@ The `edge softness` column drives the Glyph / image arm's smoothstep mask
 (`smoothstep(-edge_softness, edge_softness * 0.5, signed_unit)`) in the
 fragment shader. The Circle arm uses Euclidean distance + `falloff_curve`,
 so it is unaffected by this column. Higher values produce a softer
-silhouette outline — the screen-space transition width grows from ~4% of orb
-radius at Low to ~17% at High.
+silhouette outline. The full transition width in `signed_unit` space is
+`1.5 * edge_softness` (from `-edge_softness` to `0.5 * edge_softness`),
+which projects to roughly the following fraction of orb radius:
+
+| preset | edge_softness | full transition width | half-width |
+|---|---|---|---|
+| `low` | 0.3 | ~7.5% of orb radius | ~3.75% |
+| `mid` | 0.6 | ~15% of orb radius | ~7.5% |
+| `high` | 1.0 | ~25% of orb radius | ~12.5% |
+
+Note: edge_softness is consumed only by the WebGL2 fragment shader
+(Glyph/image arm). The CPU path (`render_static` / `animate.rs`) achieves
+the analogous softness via `blur_offset` and the post-render
+`aquarelle bleed pass` (#195/#199). The two implementations differ but
+target the same visual goal.
 
 The preset is implemented as `SoftnessPreset { Low, Mid, High }` in
 `crates/core/src/style.rs`. The values flow into the WebGL2 path via

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -461,19 +461,35 @@ dependency itself is small and pure-Rust (no shaping, no FreeType).
 ## Softness axis
 
 `--softness {low, mid, high}` is a **single user-facing axis** that bundles
-three internal knobs (alpha, blur strength, edge softness) into a 3-stop
-preset.
+three internal knobs (alpha, blur offset, glyph/image edge softness) into a
+3-stop preset.
 
-| preset | alpha | blur | edge | use case |
+| preset | alpha | blur | edge softness | use case |
 |---|---|---|---|---|
-| `low`  | default | weak   | sharp | crisp plate / wallpaper |
-| `mid`  | default | default | default | legacy default |
-| `high` | weak    | strong | soft  | sit underneath text overlay |
+| `low` | 1.0 | 0.0 | 0.3 | crisper baseline (was the legacy default before #205) |
+| `mid` (default) | 0.55 | +0.25 | 0.6 | new default — orb-like softness across all shapes |
+| `high` | 0.35 | +0.5 | 1.0 | maximum blur (sit underneath text overlay or for cinematic mood) |
 
-`mid` is the **identity preset** — its alpha / blur / edge values are exactly
-the existing defaults, so passing `--softness mid` (or omitting the flag) is
-guaranteed to match the pre-preset render bit-for-bit. The preset is
-implemented as `SoftnessPreset { Low, Mid, High }` in `crates/core/src/style.rs`.
+**#205 — Scale shifted toward blurry.** The original Phase A preset put
+`mid` at the legacy default (alpha=1.0 / blur+0.0) and `low` at a sharper
+extreme (blur-0.25). After comparing the Web GUI Glyph / image arm against
+the Circle arm we settled on "orb-like softness as the new baseline", so
+the whole table shifts upward: the old `mid` becomes the new `low`, the old
+`high` becomes the new `mid` (default), and a brand-new `high` extends the
+soft end. The old sharp `low` (`blur_offset = -0.25`) is **retired** —
+nothing in the GUI used the extra sharpness it provided.
+
+The `edge softness` column drives the Glyph / image arm's smoothstep mask
+(`smoothstep(-edge_softness, edge_softness * 0.5, signed_unit)`) in the
+fragment shader. The Circle arm uses Euclidean distance + `falloff_curve`,
+so it is unaffected by this column. Higher values produce a softer
+silhouette outline — the screen-space transition width grows from ~4% of orb
+radius at Low to ~17% at High.
+
+The preset is implemented as `SoftnessPreset { Low, Mid, High }` in
+`crates/core/src/style.rs`. The values flow into the WebGL2 path via
+`pack_render_data_for_webgl` header slots 9 (`alpha_mul`), 5 (base blur after
+`+ blur_offset`), and 12 (`edge_softness`, #205).
 
 ## Phase B — Web GUI parity (#55)
 
@@ -516,11 +532,17 @@ speed / softness without dropping to the terminal.
   silhouette — destroying the shape's individuality.
 
   **#203 (mask × profile)** splits responsibilities: the SDF becomes a pure
-  shape mask via `sdf_mask = smoothstep(-0.05, 0.05, signed_unit)` (with
-  mask=0 for UV outside the box), and the Circle-identical
-  `radial_alpha = falloff_curve(style_bit, r_euclid, blur, opacity)` provides
-  the soft center-to-edge profile. The final alpha is the product
-  `radial_alpha * sdf_mask`. For Glyph='●' the SDF is a filled disk so the
+  shape mask via `sdf_mask = smoothstep(-edge_softness, edge_softness * 0.5,
+  signed_unit)` (with mask=0 for UV outside the box), and the
+  Circle-identical `radial_alpha = falloff_curve(style_bit, r_euclid, blur,
+  opacity)` provides the soft center-to-edge profile. The final alpha is the
+  product `radial_alpha * sdf_mask`. The smoothstep half-width was originally
+  hard-coded at ±0.05; **#205** replaced it with the
+  `u_glyph_edge_softness` uniform driven by `SoftnessPreset::edge_softness()`
+  (Low=0.3 / Mid=0.6 / High=1.0). The lower bound is wide, the upper bound is
+  pulled back to half that value so the mask still pinches off inside the
+  SDF box (no mask=1 leaking far past the silhouette) while the outer
+  fall-off broadens proportionally with softness. For Glyph='●' the SDF is a filled disk so the
   mask is 1 inside the silhouette and alpha collapses to
   `falloff_curve(r_euclid)` — visually very close to `shape=Circle` (the
   outermost ~10% fade ring is omitted because the glyph's SDF radius is
@@ -533,9 +555,11 @@ speed / softness without dropping to the terminal.
   counterpart to the CLI-side bleed pass added in #195/#199: separate
   implementations, same visual goal of matching Glyph/image softness to Circle.
 - `get_render_data`'s 16-word header schema reserves words 9 and 10 for
-  `alpha_mul` and `shape_id` (previously zero-filled reserved words). The
-  per-orb 16-word slots now also use words 11 and 12 for `base_angle` and
-  `rot_speed_signed` (the remaining tail words stay reserved).
+  `alpha_mul` and `shape_id` (previously zero-filled reserved words), word 11
+  for `glyph_rotate` (#136), and word 12 for `edge_softness` (#205, drives
+  the Glyph/image smoothstep). The per-orb 16-word slots use words 11 and 12
+  for `base_angle` and `rot_speed_signed` (the remaining tail words stay
+  reserved).
 - Studio UI (#131): the collapsible Advanced section is gone. Instead, the
   four axes are always visible as flat control rows directly under the aspect
   toggles. Every control immediately re-runs the batch:

--- a/web/src/lib/orberGl.test.ts
+++ b/web/src/lib/orberGl.test.ts
@@ -14,10 +14,20 @@ import { _FS_FOR_TEST, GLYPH_SDF_SIZE } from './orberGl';
 
 describe('orberGl fragment shader (#203 mask × profile)', () => {
   test('Glyph アームで SDF を smoothstep マスクに変換している', () => {
-    // SDF マスクの宣言と smoothstep 適用が両方残っていること。0.05 の閾値は
-    // SDF 解像度 256 に対する経験則値で、これが書き換えられたらレビュー対象。
+    // SDF マスクの宣言と smoothstep 適用が両方残っていること。
+    // #205: 旧 ±0.05 ハードコードを廃止し、smoothstep 幅を u_glyph_edge_softness
+    // (softness preset 連動) で駆動する。下限が広く、上限は半分の比率で控えめ。
     expect(_FS_FOR_TEST).toContain('float sdf_mask;');
-    expect(_FS_FOR_TEST).toContain('smoothstep(-0.05, 0.05, signed_unit);');
+    expect(_FS_FOR_TEST).toContain(
+      'smoothstep(-u_glyph_edge_softness, u_glyph_edge_softness * 0.5, signed_unit);',
+    );
+    // 旧式 (±0.05 ハードコード) は復活していない。
+    expect(_FS_FOR_TEST).not.toContain('smoothstep(-0.05, 0.05, signed_unit);');
+  });
+
+  test('#205: u_glyph_edge_softness uniform が shader に宣言されている', () => {
+    // softness preset 連動の smoothstep 幅。Circle アームは参照しない。
+    expect(_FS_FOR_TEST).toContain('uniform float u_glyph_edge_softness;');
   });
 
   test('Glyph アームの radial_alpha は Circle と同じ falloff_curve(r_euclid)', () => {

--- a/web/src/lib/orberGl.ts
+++ b/web/src/lib/orberGl.ts
@@ -3,6 +3,12 @@
 // orber#198 → #201 → #203 で Glyph/image アームの softening 合成を最終的に
 // 「SDF マスク × Circle profile」の乗算形に確定。過去の試行履歴は shader 本体
 // のコメントブロックを参照。
+// orber#205 — Glyph/image アームの smoothstep 幅を softness 連動に変更。
+// u_glyph_edge_softness uniform (header[12] 経由) を softness preset の
+// edge_softness() (Low=0.3 / Mid=0.6 / High=1.0) で駆動し、ハードコード ±0.05 を
+// `smoothstep(-u_glyph_edge_softness, u_glyph_edge_softness * 0.5, signed_unit)`
+// に置き換える。下限を広く・上限を控えめにすることで、SDF を「形状ゲート」として
+// 残しつつ縁を blurry にする。
 //
 // `orber-wasm` の `get_render_data` で得た Float32Array をそのまま uniform に
 // 流し、fragment shader 1 pass で全 orb の Source-Over 合成を行う。
@@ -93,12 +99,16 @@ uniform float u_direction;     // 0=LR, 1=RL, 2=TB, 3=BT
 uniform float u_cycle;         // 1=VerySlow, 2=Slow, 3=Mid, 4=Fast
 uniform int u_n_orbs;
 // Phase B (#55):
-uniform float u_alpha_mul;     // softness.alpha_mul (Mid=1.0)
+uniform float u_alpha_mul;     // softness.alpha_mul (Mid=0.55 after #205)
 uniform int u_shape_id;        // 0=Circle, 1=Glyph
 uniform sampler2D u_glyph_sdf;
 // #136: glyph 回転 ON/OFF。1.0 = ON (legacy), 0.0 = OFF (静止)。
 // OFF でも base_angle は乗るので glyph 文字の初期向きは保たれる。
 uniform float u_glyph_rotate;
+// #205: Glyph/image アーム smoothstep 幅 (softness 連動)。Low=0.3 / Mid=0.6 / High=1.0。
+// smoothstep(-u_glyph_edge_softness, u_glyph_edge_softness * 0.5, signed_unit) で SDF を
+// 形状ゲートに変換する。Circle アームは Euclidean distance + falloff_curve なので参照しない。
+uniform float u_glyph_edge_softness;
 
 // per-orb uniforms (length MAX_ORBS = 64). Float で詰める。
 uniform vec4 u_orb_color[${MAX_ORBS}];     // (r, g, b, weight)
@@ -243,20 +253,22 @@ void main() {
       vec2 uv = rotated / (2.0 * radius) * GLYPH_SDF_CONTENT_SPAN + 0.5;
 
       // SDF -> smooth shape mask. signed_unit > 0 inside, < 0 outside.
-      // The 0.05 half-width is an empirical edge-softness tuning constant for
-      // the 256x256 SDF resolution; widen for a softer outline, narrow for a
-      // crisper one. UV outside the SDF box is forced to mask=0 so no
-      // texture lookup leaks outside the silhouette.
+      // #205: the smoothstep half-width is now driven by u_glyph_edge_softness
+      // (softness preset edge_softness(), 0.3..=1.0). The lower bound is wide
+      // and the upper bound is held back at u_glyph_edge_softness * 0.5 so
+      // the mask still pinches off well inside the SDF box (avoiding mask=1
+      // far beyond the silhouette) while the outer fall-off broadens
+      // proportionally with softness. UV outside the SDF box is forced to
+      // mask=0 so no texture lookup leaks beyond the silhouette.
       //
-      // Screen-space transition width is roughly 0.85% of orb radius (e.g.
-      // ~1.3 px at radius=150). If GLYPH_SDF_MAX_DIST_FACTOR
-      // (crates/core/src/glyph.rs) is changed, this value shifts
-      // proportionally and the on-screen edge softness scales with it.
+      // Screen-space transition width is roughly 4% (Low) to 17% (High) of orb
+      // radius — visibly orb-like at Mid/High, still close to the legacy
+      // +/-0.05 baseline near Low. Previously a hard-coded 0.05 half-width.
       float sdf_mask;
       if (uv.x >= 0.0 && uv.x <= 1.0 && uv.y >= 0.0 && uv.y <= 1.0) {
         float sdf01 = texture(u_glyph_sdf, uv).r;
         float signed_unit = sdf01 * 2.0 - 1.0;
-        sdf_mask = smoothstep(-0.05, 0.05, signed_unit);
+        sdf_mask = smoothstep(-u_glyph_edge_softness, u_glyph_edge_softness * 0.5, signed_unit);
       } else {
         sdf_mask = 0.0;
       }
@@ -385,6 +397,8 @@ export function createGlRenderer(canvas: AnyCanvas): GlRenderer {
     shapeId: gl.getUniformLocation(prog, 'u_shape_id'),
     glyphMask: gl.getUniformLocation(prog, 'u_glyph_sdf'),
     glyphRotate: gl.getUniformLocation(prog, 'u_glyph_rotate'),
+    // #205: softness 連動の Glyph/image smoothstep 幅。
+    glyphEdgeSoftness: gl.getUniformLocation(prog, 'u_glyph_edge_softness'),
     orbColor: gl.getUniformLocation(prog, 'u_orb_color'),
     orbPhase: gl.getUniformLocation(prog, 'u_orb_phase'),
     orbMisc: gl.getUniformLocation(prog, 'u_orb_misc'),
@@ -455,9 +469,14 @@ export function createGlRenderer(canvas: AnyCanvas): GlRenderer {
     const nOrbs = data[8] | 0;
     // Phase B (#55): header[9] = alpha_mul, header[10] = shape_id (0=Circle, 1=Glyph)。
     // #136: header[11] = glyph_rotate (1.0=ON / 既定, 0.0=OFF)。
+    // #205: header[12] = edge_softness (Glyph/image smoothstep 幅、0.3..=1.0)。
+    // 旧 wasm から呼ばれた場合は header[12] = 0 になりうるが、その場合 smoothstep
+    // 幅が 0 に縮退して mask が hard-edge になるだけで shader compile は通る。
+    // 現行 wasm は必ず edge_softness を詰めるので実害なし。
     const alphaMul = data[9];
     const shapeId = data[10] | 0;
     const glyphRotate = data[11];
+    const glyphEdgeSoftness = data[12];
 
     if (nOrbs > MAX_ORBS) {
       throw new Error(`n_orbs ${nOrbs} exceeds MAX_ORBS=${MAX_ORBS}`);
@@ -478,6 +497,9 @@ export function createGlRenderer(canvas: AnyCanvas): GlRenderer {
     gl!.uniform1f(uLoc.alphaMul, alphaMul);
     gl!.uniform1i(uLoc.shapeId, shapeId);
     gl!.uniform1f(uLoc.glyphRotate, glyphRotate);
+    // #205: softness 連動 smoothstep 幅。Circle 経路では参照されない uniform だが
+    // 毎フレーム書く必要は無く、setRenderData が呼ばれたタイミングで一度書けば足りる。
+    gl!.uniform1f(uLoc.glyphEdgeSoftness, glyphEdgeSoftness);
 
     // per-orb を 3 本の vec4 配列に詰め直す。余り (i >= nOrbs) は 0 詰め
     // のままで shader 側で `i >= u_n_orbs` ガードしているので使われない。

--- a/web/src/lib/orberGl.ts
+++ b/web/src/lib/orberGl.ts
@@ -261,9 +261,13 @@ void main() {
       // proportionally with softness. UV outside the SDF box is forced to
       // mask=0 so no texture lookup leaks beyond the silhouette.
       //
-      // Screen-space transition width is roughly 4% (Low) to 17% (High) of orb
-      // radius — visibly orb-like at Mid/High, still close to the legacy
-      // +/-0.05 baseline near Low. Previously a hard-coded 0.05 half-width.
+      // Screen-space full transition width is 1.5 * edge_softness in
+      // signed_unit space, which projects to roughly:
+      //   Low  (edge_softness=0.3) — full ~7.5% / half ~3.75% of orb radius
+      //   Mid  (edge_softness=0.6) — full ~15%  / half ~7.5%  of orb radius
+      //   High (edge_softness=1.0) — full ~25%  / half ~12.5% of orb radius
+      // Visibly orb-like at Mid/High; Low stays close to the legacy
+      // +/-0.05 half-width baseline. Previously a hard-coded 0.05 half-width.
       float sdf_mask;
       if (uv.x >= 0.0 && uv.x <= 1.0 && uv.y >= 0.0 && uv.y <= 1.0) {
         float sdf01 = texture(u_glyph_sdf, uv).r;


### PR DESCRIPTION
## 関連 Issue
closes #205

## 変更

### SoftnessPreset スケールシフト
| 新プリセット | alpha_mul | blur_offset | edge_softness | 由来 |
|---|---|---|---|---|
| Low | 1.0 | 0.0 | 0.3 | = 旧 Mid |
| **Mid (新デフォルト)** | 0.55 | +0.25 | 0.6 | = 旧 High |
| High | 0.35 | +0.5 | 1.0 | 新規 (blur max) |

旧 Low (alpha=1.0, blur_offset=-0.25, sharp 描画用) は**廃止**。デフォルト挙動が今より一段 blurry になる。

### Glyph/image 輪郭の softness 連動
- `SoftnessPreset::edge_softness()` を新規追加
- wasm `get_render_data` の `header[12]` に edge_softness を pack
- shader uniform `u_glyph_edge_softness` 経由で smoothstep に流す:
  ```glsl
  sdf_mask = smoothstep(-u_glyph_edge_softness, u_glyph_edge_softness * 0.5, signed_unit);
  ```
- 値域 0.3〜1.0 でスクリーン幅 ~5%〜17% 程度の soft edge

### 影響範囲
- Circle / Glyph / image 3 shape すべて、Web GUI と CLI の両方で blurry になる
- 既存の output ファイルは新ビルド後すべて変わる
- CLI \`--softness low\` の挙動が変わる (旧 Mid 相当)
- 旧 Low の sharp 描画は到達不能

## 動作確認
- cargo build / test (206/206) / clippy --all-targets / fmt --check 全 green
- cd web && npm run build 成功
- vitest 12/12 PASS

## 視覚確認 (kako-jun)
マージ後 Linux Edge で:
- Circle が今より blurry
- Glyph='●' が Circle と区別つかない
- Glyph='A' が A 形 + Circle 風 soft fade + soft 輪郭
- 四角芋画像が「シルエット + 内側 blurry + 輪郭 soft」

## 経緯
#198 → #201 → #203 → #205 の試行履歴。前 3 PR で構造は固まり、本 PR で SoftnessPreset 全体の blurry 方向シフト + Glyph 輪郭の softness 連動を入れて仕上げ。