### PR TITLE
feat(gpu): native wgpu Circle renderer with bit-exact CPU parity (Phase 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,4 +116,7 @@ jobs:
         run: cargo clippy --workspace --all-targets --features gpu -- -D warnings
 
       - name: Run GPU parity tests (lavapipe, must not skip)
-        run: cargo test -p orber-core --features gpu -- --nocapture
+        # --test-threads=1 belt-and-suspenders: the parity tests share one wgpu
+        # context via OnceLock so they no longer race on adapter/device bring-up,
+        # but serializing them removes any remaining contention on lavapipe.
+        run: cargo test -p orber-core --features gpu -- --nocapture --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,53 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy -- -D warnings
+
+  gpu-parity:
+    name: GPU parity (lavapipe)
+    runs-on: ubuntu-latest
+    # The default CI 'test'/'clippy' jobs build WITHOUT --features gpu, so gpu.rs /
+    # orb_circle.wgsl are never compiled, linted, or parity-checked there. This job
+    # is the only place the wgpu path is exercised: it brings up Mesa's lavapipe
+    # software Vulkan so request_adapter() actually succeeds on a GPU-less runner,
+    # and ORBER_REQUIRE_GPU=1 turns "no adapter" into a hard test failure instead of
+    # a silent skip (so the parity asserts must really run).
+    env:
+      # lavapipe (LLVMpipe Vulkan) ICD installed by mesa-vulkan-drivers.
+      VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
+      # Fail (don't skip) the parity tests if no adapter comes up.
+      ORBER_REQUIRE_GPU: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install Mesa software Vulkan (lavapipe)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mesa-vulkan-drivers vulkan-tools
+          # Show the adapter lavapipe exposes (diagnostic; non-fatal if it errors).
+          vulkaninfo --summary || true
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build orber-core with gpu feature
+        run: cargo build -p orber-core --features gpu
+
+      - name: Clippy (gpu feature, all targets)
+        run: cargo clippy --workspace --all-targets --features gpu -- -D warnings
+
+      - name: Run GPU parity tests (lavapipe, must not skip)
+        run: cargo test -p orber-core --features gpu -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,11 @@ jobs:
 
   gpu-parity:
     name: GPU parity (lavapipe)
-    runs-on: ubuntu-latest
+    # Pinned to 22.04: on the ubuntu-24.04 runner the apt mesa lavapipe ICD is
+    # rejected by the stock Vulkan loader (vkCreateInstance -> ERROR_INCOMPATIBLE_DRIVER),
+    # so request_adapter() returns nothing. 22.04 ships a loader/mesa pair that brings
+    # lavapipe up out of the box, which is what GPU-testing Rust projects rely on.
+    runs-on: ubuntu-22.04
     # The default CI 'test'/'clippy' jobs build WITHOUT --features gpu, so gpu.rs /
     # orb_circle.wgsl are never compiled, linted, or parity-checked there. This job
     # is the only place the wgpu path is exercised: it brings up Mesa's lavapipe
@@ -93,9 +97,14 @@ jobs:
       - name: Install Mesa software Vulkan (lavapipe)
         run: |
           sudo apt-get update
-          sudo apt-get install -y mesa-vulkan-drivers vulkan-tools
-          # Show the adapter lavapipe exposes (diagnostic; non-fatal if it errors).
-          vulkaninfo --summary || true
+          sudo apt-get install -y mesa-vulkan-drivers vulkan-tools libvulkan1
+          # Diagnostics (non-fatal): prove the ICD the loader is pinned to exists and
+          # that an adapter actually comes up. If these are wrong, ORBER_REQUIRE_GPU=1
+          # still turns it into a hard FAIL in the parity step below — these prints
+          # just make the *reason* obvious in the log.
+          echo "== ICD manifests ==" ; ls -la /usr/share/vulkan/icd.d/ || true
+          echo "== loader / mesa versions ==" ; dpkg -l | grep -iE "libvulkan1|mesa-vulkan" || true
+          echo "== vulkaninfo ==" ; vulkaninfo --summary || true
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +157,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +215,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +257,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +288,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder-lite"
@@ -264,6 +326,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -304,6 +372,17 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "color_quant"
@@ -368,6 +447,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +499,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -477,9 +590,39 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -519,6 +662,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.11.1",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,7 +735,17 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -535,14 +754,28 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "image"
@@ -585,6 +818,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +854,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,9 +897,28 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kmeans_colors"
@@ -636,7 +926,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab0b26b79762bb6d8e5fa9501748ef718adf936060b65ca8c2b8e3e09e2e82a"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "num-traits",
  "palette",
  "rand 0.9.4",
@@ -666,10 +956,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -720,6 +1041,41 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "naga"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash",
+ "spirv",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -800,6 +1156,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -830,16 +1249,19 @@ name = "orber-core"
 version = "0.3.0"
 dependencies = [
  "aquarelle",
+ "bytemuck",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "image",
  "kmeans_colors",
  "palette",
+ "pollster",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "thiserror 1.0.69",
  "tiny-skia",
  "ttf-parser",
+ "wgpu",
 ]
 
 [[package]]
@@ -855,6 +1277,15 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -879,6 +1310,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -936,6 +1390,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +1428,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1456,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro2"
@@ -1094,6 +1587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1643,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,10 +1681,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1187,6 +1725,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -1257,16 +1801,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strict-num"
@@ -1302,6 +1876,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1397,6 +1980,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +2001,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1439,6 +2034,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1474,16 +2079,310 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "wgpu"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.11.1",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.11.1",
+ "block2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "web-sys",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1495,10 +2394,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,11 @@ thiserror = "1"
 tiny-skia = "0.11"
 clap = { version = "4.5", features = ["derive"] }
 tempfile = "3"
+# wgpu (Rust + WGSL) production renderer (#207). core / cli の gpu feature でのみ
+# 有効化する。wasm32 ビルドは引かないこと（バンドルを最小に保つ）。
+wgpu = "29"
+pollster = "0.4"
+bytemuck = { version = "1", features = ["derive"] }
 # wasm 向け
 wasm-bindgen = "0.2"
 js-sys = "0.3"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,6 +18,12 @@ exclude = [".github/", "target/"]
 name = "orber"
 path = "src/main.rs"
 
+[features]
+# OFF (default): CPU (tiny-skia) renderer のみ。
+# ON: wgpu (Rust + WGSL) renderer を足し、--renderer gpu を有効化する (#207)。
+default = []
+gpu = ["orber-core/gpu"]
+
 [dependencies]
 orber-core = { path = "../core", version = "0.3.0" }
 clap = { workspace = true }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -325,7 +325,18 @@ struct Cli {
     /// cpu goes to 1024), or when built without the `gpu` feature. On the covered
     /// path (Circle, saturation applied, count <= 64) the two match within
     /// +/-2/channel; video and color/keyframe tracks are cpu-only.
+    /// Default depends on the build: the `gpu` feature builds default to `gpu`,
+    /// plain (CPU-only) builds default to `cpu` — so a stock `cargo install orber`
+    /// renders silently on the CPU instead of emitting a "no gpu feature, falling
+    /// back" warning on every run. Passing `--renderer gpu` to a CPU-only build
+    /// still warns (the user asked for something this build can't do).
+    #[cfg(feature = "gpu")]
     #[arg(long, value_enum, default_value_t = Renderer::Gpu)]
+    renderer: Renderer,
+
+    /// See the `gpu`-build variant above; CPU-only builds default to `cpu`.
+    #[cfg(not(feature = "gpu"))]
+    #[arg(long, value_enum, default_value_t = Renderer::Cpu)]
     renderer: Renderer,
 
     /// Glyph character used when --shape glyph (#55). Must be a single character.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -144,6 +144,20 @@ impl From<CliVariationMode> for VariationMode {
     }
 }
 
+/// Which renderer backend to drive (`--renderer`).
+///
+/// `gpu` is the wgpu (Rust + WGSL) production path (#207); it falls back to the
+/// CPU renderer when no GPU adapter is available, for non-Circle shapes (Phase 0
+/// covers Circle only), or when the binary was built without the `gpu` feature.
+/// The GPU path matches the CPU oracle bit-for-bit, so the output is identical.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum Renderer {
+    /// Reference CPU (tiny-skia) renderer.
+    Cpu,
+    /// Production wgpu (Rust + WGSL) renderer; falls back to CPU when unavailable.
+    Gpu,
+}
+
 /// Shape used to render each orb.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum Shape {
@@ -300,6 +314,13 @@ struct Cli {
     #[arg(long, value_enum, default_value_t = Shape::Circle)]
     shape: Shape,
 
+    /// Renderer backend: production `gpu` (wgpu) or the `cpu` reference (#207).
+    /// `gpu` falls back to `cpu` when no GPU adapter is available, for non-Circle
+    /// shapes (Phase 0 covers Circle only), or when built without the `gpu`
+    /// feature. Output is identical either way (bit-exact parity).
+    #[arg(long, value_enum, default_value_t = Renderer::Gpu)]
+    renderer: Renderer,
+
     /// Glyph character used when --shape glyph (#55). Must be a single character.
     /// Defaults to ☆ (U+2606). Use a character covered by Noto Sans Symbols 2.
     #[arg(long, default_value = "\u{2606}", value_parser = parse_single_char)]
@@ -447,6 +468,76 @@ fn main() -> ExitCode {
 /// CLI の `--direction` / `--speed` を内部表現に変換する。
 fn resolve_motion(cli: &Cli) -> (MotionDirection, MotionSpeed) {
     (cli.direction.into(), cli.speed.into())
+}
+
+/// 単一フレーム描画のバックエンド。`--renderer` を解決して GPU/CPU を選ぶ (#207)。
+///
+/// GPU は Circle shape かつ GPU アダプタが取れた場合のみ使う。それ以外（非
+/// Circle、アダプタ無し、`gpu` feature 無しビルド）は CPU にフォールバックする。
+/// 出力は CPU オラクルと bit-exact 一致するので、フォールバックしても見た目は変わらない。
+enum FrameRenderer {
+    Cpu,
+    #[cfg(feature = "gpu")]
+    Gpu(Box<orber_core::gpu::GpuRenderer>),
+}
+
+impl FrameRenderer {
+    /// `--renderer` の選択と shape からバックエンドを決める。GPU 要求でも、
+    /// 非 Circle / アダプタ取得失敗 / feature 無しなら CPU にフォールバックし、
+    /// stderr に一言出す。
+    fn select(choice: Renderer, shape: OrbShape) -> Self {
+        match choice {
+            Renderer::Cpu => FrameRenderer::Cpu,
+            Renderer::Gpu => {
+                if shape != OrbShape::Circle {
+                    eprintln!(
+                        "orber: --renderer gpu は Phase 0 で Circle のみ対応。非 Circle shape のため cpu にフォールバックします"
+                    );
+                    return FrameRenderer::Cpu;
+                }
+                Self::select_gpu_circle()
+            }
+        }
+    }
+
+    #[cfg(feature = "gpu")]
+    fn select_gpu_circle() -> Self {
+        match orber_core::gpu::GpuRenderer::new() {
+            Some(gpu) => {
+                eprintln!(
+                    "orber: using gpu renderer (adapter: {})",
+                    gpu.adapter_name()
+                );
+                FrameRenderer::Gpu(Box::new(gpu))
+            }
+            None => {
+                eprintln!("orber: GPU アダプタが取得できないため cpu にフォールバックします");
+                FrameRenderer::Cpu
+            }
+        }
+    }
+
+    #[cfg(not(feature = "gpu"))]
+    fn select_gpu_circle() -> Self {
+        eprintln!(
+            "orber: この orber は gpu feature 無しでビルドされています。cpu にフォールバックします"
+        );
+        FrameRenderer::Cpu
+    }
+
+    /// 1 フレームを描画する。GPU 経路は Circle のみ（select で保証済み）。
+    fn render(
+        &self,
+        clusters: &[Cluster],
+        opts: &orber_core::animate::AnimateOptions,
+        t: f32,
+    ) -> image::RgbaImage {
+        match self {
+            FrameRenderer::Cpu => orber_core::animate::render_frame(clusters, opts, t),
+            #[cfg(feature = "gpu")]
+            FrameRenderer::Gpu(gpu) => gpu.render_frame(clusters, opts, t),
+        }
+    }
 }
 
 /// orb プールが空になった（K=1 / 単色画像）ときに stderr で警告し、処理は継続する。
@@ -637,7 +728,9 @@ fn render_png(cli: &Cli, output: &Path) -> ExitCode {
         color_tracks: None,
         keyframe_tracks: None,
     };
-    let out = orber_core::animate::render_frame(&orb_clusters, &frame_opts, 0.0);
+    // #207: --renderer で GPU/CPU を選ぶ。GPU は Circle のみ、それ以外は CPU。
+    let renderer = FrameRenderer::select(cli.renderer, cli.orb_shape());
+    let out = renderer.render(&orb_clusters, &frame_opts, 0.0);
 
     // 4. 保存。
     if let Err(e) = out.save(output) {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -146,10 +146,15 @@ impl From<CliVariationMode> for VariationMode {
 
 /// Which renderer backend to drive (`--renderer`).
 ///
-/// `gpu` is the wgpu (Rust + WGSL) production path (#207); it falls back to the
+/// `gpu` is the wgpu (Rust + WGSL) production path (#207). It falls back to the
 /// CPU renderer when no GPU adapter is available, for non-Circle shapes (Phase 0
-/// covers Circle only), or when the binary was built without the `gpu` feature.
-/// The GPU path matches the CPU oracle bit-for-bit, so the output is identical.
+/// covers Circle only), when the resolved orb count exceeds the GPU capacity
+/// (`GPU_MAX_ORBS` = 64; the CPU scales to 1024), or when the binary was built
+/// without the `gpu` feature. On the path it does cover — Circle, saturation
+/// reflected, count ≤ 64 — the GPU output matches the CPU oracle within ±2/channel
+/// (bit-exact on real GPUs), so those flags give the same image either backend.
+/// Video frames are always rendered on the CPU; color/keyframe tracks are not yet
+/// folded into the GPU pack.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum Renderer {
     /// Reference CPU (tiny-skia) renderer.
@@ -316,8 +321,10 @@ struct Cli {
 
     /// Renderer backend: production `gpu` (wgpu) or the `cpu` reference (#207).
     /// `gpu` falls back to `cpu` when no GPU adapter is available, for non-Circle
-    /// shapes (Phase 0 covers Circle only), or when built without the `gpu`
-    /// feature. Output is identical either way (bit-exact parity).
+    /// shapes (Phase 0 covers Circle only), when --count exceeds the GPU cap (64;
+    /// cpu goes to 1024), or when built without the `gpu` feature. On the covered
+    /// path (Circle, saturation applied, count <= 64) the two match within
+    /// +/-2/channel; video and color/keyframe tracks are cpu-only.
     #[arg(long, value_enum, default_value_t = Renderer::Gpu)]
     renderer: Renderer,
 
@@ -472,30 +479,84 @@ fn resolve_motion(cli: &Cli) -> (MotionDirection, MotionSpeed) {
 
 /// 単一フレーム描画のバックエンド。`--renderer` を解決して GPU/CPU を選ぶ (#207)。
 ///
-/// GPU は Circle shape かつ GPU アダプタが取れた場合のみ使う。それ以外（非
-/// Circle、アダプタ無し、`gpu` feature 無しビルド）は CPU にフォールバックする。
-/// 出力は CPU オラクルと bit-exact 一致するので、フォールバックしても見た目は変わらない。
+/// GPU は Circle shape かつ count <= GPU_MAX_ORBS かつ GPU アダプタが取れた場合のみ
+/// 使う。それ以外（非 Circle、count 超過、アダプタ無し、`gpu` feature 無しビルド）は
+/// CPU にフォールバックする。GPU が担う経路（Circle ∧ saturation 反映済 ∧ count <= 64）
+/// では出力が CPU オラクルと ±2/channel（実 GPU では bit-exact）一致するので、
+/// フォールバックしても同じ flag では見た目が変わらない。video や color/keyframe
+/// tracks は GPU pack 未対応で CPU 専用。
 enum FrameRenderer {
     Cpu,
     #[cfg(feature = "gpu")]
     Gpu(Box<orber_core::gpu::GpuRenderer>),
 }
 
+/// GPU Circle 経路が一度に扱える最大 orb 数。`orber_core::gpu::MAX_ORBS` (= 64) の
+/// ミラー。`gpu` feature 無しビルドでも `select` のルーティング判定で必要なので、
+/// feature に依存しないリテラルとして持つ。feature 有効時は下の assert で SoT 一致を
+/// 担保する（ズレたらコンパイル時 const eval で落ちる）。
+const GPU_MAX_ORBS: usize = 64;
+
+/// アダプタ取得前のルーティング判定（`FrameRenderer::route` の戻り値）。`Cpu` の
+/// `Option<String>` は「GPU を諦めた理由」の stderr 文言（CPU 明示指定なら `None`）。
+#[derive(Debug, PartialEq, Eq)]
+enum RenderRoute {
+    Cpu(Option<String>),
+    Gpu,
+}
+
+#[cfg(feature = "gpu")]
+const _: () = assert!(
+    GPU_MAX_ORBS == orber_core::gpu::MAX_ORBS,
+    "GPU_MAX_ORBS must mirror orber_core::gpu::MAX_ORBS"
+);
+
 impl FrameRenderer {
-    /// `--renderer` の選択と shape からバックエンドを決める。GPU 要求でも、
-    /// 非 Circle / アダプタ取得失敗 / feature 無しなら CPU にフォールバックし、
-    /// stderr に一言出す。
-    fn select(choice: Renderer, shape: OrbShape) -> Self {
+    /// `--renderer` の選択と shape / orb 数からバックエンドを決める。GPU 要求でも、
+    /// 非 Circle / count が GPU 容量超過 / アダプタ取得失敗 / feature 無しなら CPU に
+    /// フォールバックし、stderr に一言出す。
+    ///
+    /// `count` は解決済み orb 数（`--count` / `--count-preset`）。GPU の per-orb
+    /// uniform 配列は `orber_core::gpu::MAX_ORBS` (64) 固定で、それを超えると GPU は
+    /// 黙って 64 に clamp する一方 CPU は最大 `MAX_ORB_COUNT` (1024) まで描く。両者で
+    /// 別画像にならないよう、64 超は CPU にフォールバックする。
+    ///
+    /// GPU 容量を 64 超へ拡張しない理由: per-orb データは uniform 配列で渡しており、
+    /// 配列長は WGSL のリテラル上限・uniform サイズ上限に縛られる。64 超を portable に
+    /// 増やすには per-orb データを data-texture に積んで fragment shader で sample する
+    /// 方式が要る。storage buffer は wgpu の WebGL2 backend では非対応で、Phase 2 の
+    /// ブラウザ fallback を壊すため使えない。これは Phase 1 follow-up（#207 系）。
+    fn select(choice: Renderer, shape: OrbShape, count: usize) -> Self {
+        match Self::route(choice, shape, count) {
+            RenderRoute::Cpu(Some(reason)) => {
+                eprintln!("{reason}");
+                FrameRenderer::Cpu
+            }
+            RenderRoute::Cpu(None) => FrameRenderer::Cpu,
+            // GPU が選ばれても、アダプタ取得失敗 / feature 無しなら最終的に CPU に落ちる。
+            RenderRoute::Gpu => Self::select_gpu_circle(),
+        }
+    }
+
+    /// アダプタ取得より前の「どのバックエンドに振るか」だけを決める純関数。GPU を
+    /// 諦めるときは stderr 文言を `Cpu(Some(_))` に載せる。GPU を選んでも、最終的に
+    /// アダプタが取れなければ `select_gpu_circle` がさらに CPU に落とす。アダプタに
+    /// 依存しないので、ルーティング判定をそのままユニットテストできる。
+    fn route(choice: Renderer, shape: OrbShape, count: usize) -> RenderRoute {
         match choice {
-            Renderer::Cpu => FrameRenderer::Cpu,
+            Renderer::Cpu => RenderRoute::Cpu(None),
             Renderer::Gpu => {
                 if shape != OrbShape::Circle {
-                    eprintln!(
-                        "orber: --renderer gpu は Phase 0 で Circle のみ対応。非 Circle shape のため cpu にフォールバックします"
-                    );
-                    return FrameRenderer::Cpu;
+                    return RenderRoute::Cpu(Some(
+                        "orber: --renderer gpu は Phase 0 で Circle のみ対応。非 Circle shape のため cpu にフォールバックします".to_string(),
+                    ));
                 }
-                Self::select_gpu_circle()
+                if count > GPU_MAX_ORBS {
+                    return RenderRoute::Cpu(Some(format!(
+                        "orber: --renderer gpu は Phase 0 で最大 {GPU_MAX_ORBS} orb まで対応。--count {count} のため cpu にフォールバックします（>{GPU_MAX_ORBS} は Phase 1 で対応予定）"
+                    )));
+                }
+                RenderRoute::Gpu
             }
         }
     }
@@ -728,8 +789,8 @@ fn render_png(cli: &Cli, output: &Path) -> ExitCode {
         color_tracks: None,
         keyframe_tracks: None,
     };
-    // #207: --renderer で GPU/CPU を選ぶ。GPU は Circle のみ、それ以外は CPU。
-    let renderer = FrameRenderer::select(cli.renderer, cli.orb_shape());
+    // #207: --renderer で GPU/CPU を選ぶ。GPU は Circle かつ count <= GPU_MAX_ORBS のみ。
+    let renderer = FrameRenderer::select(cli.renderer, cli.orb_shape(), cli.resolved_count());
     let out = renderer.render(&orb_clusters, &frame_opts, 0.0);
 
     // 4. 保存。
@@ -1264,6 +1325,55 @@ mod tests {
     fn count_default_is_twenty() {
         let cli = Cli::parse_from(["orber", "--input", "x", "--output", "x.png"]);
         assert_eq!(cli.count, 20);
+    }
+
+    #[test]
+    fn gpu_route_falls_back_to_cpu_when_count_exceeds_gpu_cap() {
+        // --renderer gpu + Circle + count > GPU_MAX_ORBS は CPU にルーティングされる
+        // （GPU は 64 で clamp、CPU は最大 1024 なので「黙って別画像」を避ける）。
+        // アダプタの有無に依存しないルーティング判定だけを確認する。
+        let over = GPU_MAX_ORBS + 1;
+        match FrameRenderer::route(Renderer::Gpu, OrbShape::Circle, over) {
+            RenderRoute::Cpu(Some(msg)) => {
+                assert!(
+                    msg.contains(&over.to_string()),
+                    "fallback message should mention the requested count, got: {msg}"
+                );
+            }
+            other => panic!("count {over} with gpu must route to Cpu(Some(_)), got {other:?}"),
+        }
+
+        // 境界値: ちょうど GPU_MAX_ORBS は GPU のまま、超過した瞬間に CPU。
+        assert_eq!(
+            FrameRenderer::route(Renderer::Gpu, OrbShape::Circle, GPU_MAX_ORBS),
+            RenderRoute::Gpu,
+            "count == GPU_MAX_ORBS must stay on the gpu route"
+        );
+        assert_eq!(
+            FrameRenderer::route(Renderer::Gpu, OrbShape::Circle, 1),
+            RenderRoute::Gpu,
+            "small count with gpu must stay on the gpu route"
+        );
+
+        // --renderer cpu は理由なしで CPU。非 Circle shape も CPU（理由つき）。
+        assert_eq!(
+            FrameRenderer::route(Renderer::Cpu, OrbShape::Circle, over),
+            RenderRoute::Cpu(None),
+            "explicit cpu must route to Cpu(None)"
+        );
+        match FrameRenderer::route(
+            Renderer::Gpu,
+            OrbShape::Aquarelle(AquarelleParams {
+                bleed: 0.5,
+                bloom: 0.5,
+                offset: 0.5,
+                halo: 0.5,
+            }),
+            10,
+        ) {
+            RenderRoute::Cpu(Some(_)) => {}
+            other => panic!("non-Circle shape with gpu must route to Cpu(Some(_)), got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,6 +15,14 @@ categories = ["graphics", "multimedia"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+# OFF (default): pure CPU (tiny-skia) reference renderer のみ。wasm32 ビルドを
+# 最小に保ち、wgpu / pollster / bytemuck を引かない。
+# ON: native CLI 向けの wgpu (Rust + WGSL) production render path (#207) を足す。
+# Circle orb を WGSL で描き、CPU(tiny-skia) と ±2/channel のパリティを取る。
+default = []
+gpu = ["dep:wgpu", "dep:pollster", "dep:bytemuck"]
+
 [dependencies]
 aquarelle = { workspace = true }
 image = { workspace = true, features = ["png"] }
@@ -27,6 +35,10 @@ tiny-skia = { workspace = true }
 # OrbShape::Glyph 用のフォントパース。'static lifetime のスライスから Face::parse で
 # 読めるので、include_bytes! 経路と相性がよい。
 ttf-parser = "0.25"
+# wgpu production renderer (#207)。gpu feature 内に閉じ込め、wasm32 を汚さない。
+wgpu = { workspace = true, optional = true }
+pollster = { workspace = true, optional = true }
+bytemuck = { workspace = true, optional = true }
 
 # wasm32: getrandom needs the `wasm_js` backend so kmeans_colors' thread_rng compiles.
 # kmeans_colors 0.7 経由で getrandom 0.2 が、rand 0.9 経由で 0.3 が引かれるため両方を明示する。

--- a/crates/core/src/animate.rs
+++ b/crates/core/src/animate.rs
@@ -702,7 +702,10 @@ pub fn render_frame_with_params(
 }
 
 /// `count` の上限。万一おかしな値が来てもメモリ枯渇しないように防衛。
-const MAX_ORB_COUNT: usize = 1024;
+///
+/// GPU 経路 (#207) も同じ上限で n_orbs を clamp するため `pub`。WebGL 経路の
+/// `GL_RENDERER_MAX_ORBS`(=64) とは別の、CPU/アニメーション側の絶対上限。
+pub const MAX_ORB_COUNT: usize = 1024;
 
 /// Aquarelle shape は既存の render_static フォールバック経路。
 ///
@@ -1340,21 +1343,15 @@ mod tests {
         // TAU ≈ 6.28 のうち、16 サンプルあれば spread が 1.0 以上は固い。
         assert!(
             max_r - min_r > 1.0,
-            "phi_radius spread too narrow ({} .. {})",
-            min_r,
-            max_r
+            "phi_radius spread too narrow ({min_r} .. {max_r})"
         );
         assert!(
             max_b - min_b > 1.0,
-            "phi_blur spread too narrow ({} .. {})",
-            min_b,
-            max_b
+            "phi_blur spread too narrow ({min_b} .. {max_b})"
         );
         assert!(
             max_o - min_o > 1.0,
-            "phi_opacity spread too narrow ({} .. {})",
-            min_o,
-            max_o
+            "phi_opacity spread too narrow ({min_o} .. {max_o})"
         );
     }
 

--- a/crates/core/src/cluster.rs
+++ b/crates/core/src/cluster.rs
@@ -260,11 +260,7 @@ mod tests {
     fn approx(a: f32, b: f32, eps: f32, label: &str) {
         assert!(
             (a - b).abs() < eps,
-            "{}: expected ~{}, got {} (eps={})",
-            label,
-            b,
-            a,
-            eps
+            "{label}: expected ~{b}, got {a} (eps={eps})"
         );
     }
 
@@ -351,7 +347,7 @@ mod tests {
         let img: RgbImage = ImageBuffer::new(0, 0);
         match extract_clusters(&img, 3) {
             Err(ClusterError::EmptyImage) => {}
-            other => panic!("expected EmptyImage, got {:?}", other),
+            other => panic!("expected EmptyImage, got {other:?}"),
         }
     }
 
@@ -360,7 +356,7 @@ mod tests {
         let img: RgbImage = ImageBuffer::from_fn(8, 8, |_, _| Rgb([10u8, 20, 30]));
         match extract_clusters(&img, 0) {
             Err(ClusterError::KZero) => {}
-            other => panic!("expected KZero, got {:?}", other),
+            other => panic!("expected KZero, got {other:?}"),
         }
     }
 

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -7,6 +7,29 @@
 //! matches the CPU (tiny-skia) oracle ([`crate::animate::render_frame`]) within
 //! ±2/channel.
 //!
+//! ## Parity scope (narrow — do not over-claim)
+//!
+//! Parity with the CPU oracle holds **only** on this exact path:
+//!
+//! - **shape = Circle** (Glyph / image / aquarelle are Phase 1; the CLI routes
+//!   those to the CPU renderer);
+//! - **saturation reflected**: [`GpuRenderer::render_frame`] re-applies
+//!   [`adjust_saturation_pub`](crate::orb::adjust_saturation_pub) with
+//!   `opts.saturation` to each packed orb color after
+//!   [`pack_render_data_for_webgl`] (which itself never applies saturation,
+//!   because it is shared with the WebGL path). Without that step the GPU and CPU
+//!   would diverge for `--saturation != 1.0`;
+//! - **count ≤ [`MAX_ORBS`] (64)**: the orb-array uniform is fixed at 64 entries,
+//!   so the GPU silently clamps beyond that. The CPU path scales to
+//!   [`MAX_ORB_COUNT`] (1024). The CLI therefore falls back to CPU when the
+//!   resolved count exceeds [`MAX_ORBS`] (see `FrameRenderer::select` in the CLI)
+//!   so the two never produce different images for the same flags.
+//!
+//! Outside that path the GPU is **not** a drop-in for the CPU oracle: video is
+//! rendered on the CPU, and the per-orb `color_tracks` / `keyframe_tracks` (#7 /
+//! #33) are not yet folded into the GPU pack, so animated color/position tracks
+//! are CPU-only for now.
+//!
 //! ## Parity contract (must match [`crate::animate::render_frame`] for Circle)
 //!
 //! The CPU oracle composites orbs in **straight sRGB byte space** (tiny-skia
@@ -36,6 +59,7 @@ use wgpu::util::DeviceExt;
 
 use crate::animate::{pack_render_data_for_webgl, AnimateOptions, MotionDirection, MAX_ORB_COUNT};
 use crate::cluster::Cluster;
+use crate::orb::adjust_saturation_pub;
 
 /// Bytes per pixel for `Rgba8Unorm`.
 const BYTES_PER_PIXEL: u32 = 4;
@@ -347,7 +371,7 @@ impl GpuRenderer {
             .min(MAX_ORBS);
         // shape_id / glyph_rotate / edge_softness are Phase-1 (Glyph) inputs; the
         // Circle shader ignores them. Pass Circle defaults.
-        let pack = pack_render_data_for_webgl(
+        let mut pack = pack_render_data_for_webgl(
             clusters,
             opts.background,
             base_radius_unit,
@@ -361,6 +385,17 @@ impl GpuRenderer {
             true, // glyph_rotate (unused by Circle)
             opts.softness.edge_softness(),
         );
+
+        // `pack_render_data_for_webgl` is shared with the WebGL path and must NOT
+        // bake in saturation (the web side has its own knob). The CPU oracle,
+        // however, applies `adjust_saturation_pub(color_at_t, saturation)` per orb
+        // (`animate::render_frame`). To stay bit-exact we re-apply the *same*
+        // function here, in native GPU land only, over the packed color words.
+        //
+        // Each color word triple is `c.color[i] as f32 / 255.0`, so `round(w*255)`
+        // recovers the exact u8 the CPU fed to `adjust_saturation_pub`; we run the
+        // identical HSL transform and write the result back as `u8 / 255.0`.
+        apply_saturation_to_pack(&mut pack, opts.saturation.max(0.0), n_orbs);
 
         self.render_packed(&pack, width, height, t)
     }
@@ -419,7 +454,11 @@ impl GpuRenderer {
         };
         for i in 0..n_orbs {
             let off = HEADER_WORDS + PER_ORB_WORDS * i;
-            if off + 11 >= pack.len() {
+            // Max word read below is `pack[off + 10]`, so the guard must allow
+            // `off + 10 == len - 1`, i.e. `off + 11 == len`. Using `>=` here would
+            // wrongly break one orb early when an externally hand-built buffer is
+            // sized to exactly `off + 11`; the correct cut-off is `off + 11 > len`.
+            if off + 11 > pack.len() {
                 break;
             }
             orb_array.orbs[i] = GpuOrb {
@@ -546,6 +585,35 @@ fn align_up(value: u32, align: u32) -> u32 {
     value.div_ceil(align) * align
 }
 
+/// Apply `adjust_saturation_pub` to the per-orb color words of a
+/// `pack_render_data_for_webgl` buffer, in place (native GPU path only).
+///
+/// `pack_render_data_for_webgl` is shared with the WebGL path and intentionally
+/// leaves saturation out, but the CPU oracle applies it per orb, so the native
+/// GPU path re-applies the identical transform here to keep bit-exact parity.
+/// Color words live at `[off .. off+3]` per orb as `u8 / 255.0`; we round back to
+/// the original u8, run the same HSL adjust, and write the result back the same
+/// way. A factor of `1.0` is the `adjust_saturation_pub` fast-path (no change).
+fn apply_saturation_to_pack(pack: &mut [f32], saturation: f32, n_orbs: usize) {
+    for i in 0..n_orbs {
+        let off = HEADER_WORDS + PER_ORB_WORDS * i;
+        // Bounds: we touch [off, off+2]. `off + 3 > len` means the color triple
+        // does not fit, so stop.
+        if off + 3 > pack.len() {
+            break;
+        }
+        let rgb = [
+            (pack[off] * 255.0).round() as u8,
+            (pack[off + 1] * 255.0).round() as u8,
+            (pack[off + 2] * 255.0).round() as u8,
+        ];
+        let out = adjust_saturation_pub(rgb, saturation);
+        pack[off] = out[0] as f32 / 255.0;
+        pack[off + 1] = out[1] as f32 / 255.0;
+        pack[off + 2] = out[2] as f32 / 255.0;
+    }
+}
+
 /// A fragment-visible uniform-buffer bind-group-layout entry.
 fn uniform_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
     wgpu::BindGroupLayoutEntry {
@@ -573,6 +641,36 @@ mod tests {
             color,
             centroid: Centroid { x: cx, y: cy },
             weight,
+        }
+    }
+
+    /// Get a renderer for a parity test, or decide what to do when no adapter is
+    /// available.
+    ///
+    /// - **`ORBER_REQUIRE_GPU=1`** (CI / any environment that must actually verify
+    ///   parity): a missing adapter is a hard **`panic!`** — the test fails loudly
+    ///   instead of silently passing. This is what stops the "no GPU ⇒ green
+    ///   without checking anything" false-positive.
+    /// - **unset** (developer machine without a GPU): returns `None` so the caller
+    ///   can `return` early and skip. This keeps the suite convenient locally
+    ///   while making "skipped" and "really verified" distinguishable.
+    ///
+    /// `what` names the test for the panic / skip message.
+    fn require_or_skip_renderer(what: &str) -> Option<GpuRenderer> {
+        match GpuRenderer::new() {
+            Some(r) => Some(r),
+            None => {
+                if std::env::var("ORBER_REQUIRE_GPU").as_deref() == Ok("1") {
+                    panic!(
+                        "{what}: ORBER_REQUIRE_GPU=1 but no GPU adapter is available; \
+                         parity could not be verified (install a Vulkan ICD, e.g. \
+                         mesa-vulkan-drivers + VK_ICD_FILENAMES=lvp_icd, or unset \
+                         ORBER_REQUIRE_GPU to allow skipping)"
+                    );
+                }
+                eprintln!("SKIP {what}: no GPU adapter available (set ORBER_REQUIRE_GPU=1 to fail instead)");
+                None
+            }
         }
     }
 
@@ -641,8 +739,7 @@ mod tests {
 
     #[test]
     fn gpu_matches_cpu_within_tolerance() {
-        let Some(renderer) = GpuRenderer::new() else {
-            eprintln!("SKIP gpu_matches_cpu_within_tolerance: no GPU adapter available");
+        let Some(renderer) = require_or_skip_renderer("gpu_matches_cpu_within_tolerance") else {
             return;
         };
         eprintln!(
@@ -677,6 +774,35 @@ mod tests {
         eprintln!("overall max per-channel diff across all cases = {overall_max}");
     }
 
+    /// `--saturation != 1.0` must hold parity: the native GPU path re-applies
+    /// `adjust_saturation_pub` (the CPU oracle's own per-orb saturation) after the
+    /// shared `pack_render_data_for_webgl`. Without that step desaturated (0.5) and
+    /// boosted (2.0) frames would diverge from the CPU. Covers a couple of sizes /
+    /// times so the orb colors actually change between frames.
+    #[test]
+    fn gpu_matches_cpu_with_saturation() {
+        let Some(renderer) = require_or_skip_renderer("gpu_matches_cpu_with_saturation") else {
+            return;
+        };
+        let clusters = sample_clusters();
+        for &saturation in &[0.5_f32, 2.0] {
+            for &(w, h) in &[(37u32, 23u32), (40, 28)] {
+                let mut opts = circle_opts(w, h, MotionDirection::LeftToRight, MotionSpeed::Mid);
+                opts.saturation = saturation;
+                for &t in &[0.0_f32, 0.5, 1.0] {
+                    let cpu = render_frame(&clusters, &opts, t);
+                    let gpu = renderer.render_frame(&clusters, &opts, t);
+                    let max_diff = assert_within_tolerance(
+                        &cpu,
+                        &gpu,
+                        &format!("sat={saturation} {w}x{h} t={t}"),
+                    );
+                    eprintln!("sat={saturation} {w}x{h} t={t}: max per-channel diff = {max_diff}");
+                }
+            }
+        }
+    }
+
     /// 1x1 read-back boundary: width*4 = 4 bytes/row is padded to 256, so this
     /// exercises the most extreme row-padding strip. Use a background-only frame
     /// (no clusters) so the assertion is about read-back geometry, not the
@@ -684,8 +810,7 @@ mod tests {
     /// tiny-skia's analytic path coverage. Also checks 1x3 / 3x1 strips.
     #[test]
     fn gpu_matches_cpu_1x1_readback() {
-        let Some(renderer) = GpuRenderer::new() else {
-            eprintln!("SKIP gpu_matches_cpu_1x1_readback: no GPU adapter available");
+        let Some(renderer) = require_or_skip_renderer("gpu_matches_cpu_1x1_readback") else {
             return;
         };
         for &(w, h) in &[(1u32, 1u32), (1, 3), (3, 1), (5, 1)] {
@@ -704,8 +829,7 @@ mod tests {
     /// All four flow directions must hold parity at a single non-trivial size/t.
     #[test]
     fn gpu_matches_cpu_all_directions() {
-        let Some(renderer) = GpuRenderer::new() else {
-            eprintln!("SKIP gpu_matches_cpu_all_directions: no GPU adapter available");
+        let Some(renderer) = require_or_skip_renderer("gpu_matches_cpu_all_directions") else {
             return;
         };
         let clusters = sample_clusters();
@@ -726,8 +850,7 @@ mod tests {
     /// Empty clusters → background-only frame must still match (bg fill path).
     #[test]
     fn gpu_matches_cpu_empty_clusters() {
-        let Some(renderer) = GpuRenderer::new() else {
-            eprintln!("SKIP gpu_matches_cpu_empty_clusters: no GPU adapter available");
+        let Some(renderer) = require_or_skip_renderer("gpu_matches_cpu_empty_clusters") else {
             return;
         };
         let opts = circle_opts(32, 24, MotionDirection::LeftToRight, MotionSpeed::Slow);
@@ -741,8 +864,7 @@ mod tests {
     /// many same-size frames, and a second size must grow only the sized cache.
     #[test]
     fn caches_resources_across_a_clip() {
-        let Some(renderer) = GpuRenderer::new() else {
-            eprintln!("SKIP caches_resources_across_a_clip: no GPU adapter available");
+        let Some(renderer) = require_or_skip_renderer("caches_resources_across_a_clip") else {
             return;
         };
         let clusters = sample_clusters();
@@ -767,8 +889,9 @@ mod tests {
     /// must equal a fresh renderer's single render of those inputs.
     #[test]
     fn cached_resources_do_not_leak_previous_frame() {
-        let Some(renderer) = GpuRenderer::new() else {
-            eprintln!("SKIP cached_resources_do_not_leak_previous_frame: no GPU adapter available");
+        let Some(renderer) =
+            require_or_skip_renderer("cached_resources_do_not_leak_previous_frame")
+        else {
             return;
         };
         let clusters = sample_clusters();
@@ -783,8 +906,11 @@ mod tests {
         let (_, sizes) = renderer.cache_sizes();
         assert_eq!(sizes, 1, "both frames must share one cached size");
 
-        let Some(fresh) = GpuRenderer::new() else {
-            eprintln!("SKIP oracle leg: no second GPU adapter available");
+        // The first adapter already came up, so a second must too under
+        // ORBER_REQUIRE_GPU=1; treat a failure here as a real failure, not a skip.
+        let Some(fresh) =
+            require_or_skip_renderer("cached_resources_do_not_leak_previous_frame (oracle leg)")
+        else {
             return;
         };
         let b_fresh = fresh.render_frame(&clusters, &opts_b, 0.7);

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -51,7 +51,6 @@
 //! Phase 0 covers **Circle orbs only**. Glyph / image shapes / aquarelle are
 //! Phase 1; the CLI falls back to the CPU renderer for non-Circle shapes.
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 
 use image::RgbaImage;
@@ -78,8 +77,20 @@ pub const MAX_ORBS: usize = 64;
 const HEADER_WORDS: usize = 16;
 const PER_ORB_WORDS: usize = 16;
 
-/// The Circle orb WGSL (translation of `orberGl.ts` Circle arm).
-const ORB_CIRCLE_WGSL: &str = include_str!("orb_circle.wgsl");
+/// The Circle orb WGSL template (translation of `orberGl.ts` Circle arm). The
+/// `{{MAX_ORBS}}` placeholders are filled from [`MAX_ORBS`] at first use by
+/// [`orb_circle_wgsl`], so the shader's orb-array length / `MAX_ORBS` const is
+/// single-sourced from Rust instead of a hand-kept `64` literal.
+const ORB_CIRCLE_WGSL_TEMPLATE: &str = include_str!("orb_circle.wgsl");
+
+/// The resolved Circle WGSL, with `{{MAX_ORBS}}` substituted from [`MAX_ORBS`].
+/// Resolved once (the result is `&'static`) so it doubles as a stable cache key
+/// for the pipeline cache.
+fn orb_circle_wgsl() -> &'static str {
+    use std::sync::OnceLock;
+    static RESOLVED: OnceLock<String> = OnceLock::new();
+    RESOLVED.get_or_init(|| ORB_CIRCLE_WGSL_TEMPLATE.replace("{{MAX_ORBS}}", &MAX_ORBS.to_string()))
+}
 
 /// Header uniform block handed to the Circle shader. Mirrors `struct Params` in
 /// `orb_circle.wgsl`. `#[repr(C)]` + explicit padding to satisfy WGSL std140-ish
@@ -155,10 +166,16 @@ pub struct GpuRenderer {
     device: wgpu::Device,
     queue: wgpu::Queue,
     adapter_name: String,
+    // Caches use `Mutex` (not `RefCell`) so `GpuRenderer` is `Sync`: the parity
+    // tests share one `&'static GpuRenderer` across threads (built once via
+    // `OnceLock`) to stop several `wgpu::Instance`/adapter/device bring-ups from
+    // racing under the default multi-threaded `cargo test`. wgpu's `Device`/`Queue`
+    // are already `Send + Sync`; only these interior-mutable caches needed locking.
+    // The CLI uses one renderer single-threaded, so the lock is uncontended there.
     /// Circle pipelines, keyed by shader source.
-    pipeline_cache: RefCell<HashMap<String, CachedPipeline>>,
+    pipeline_cache: std::sync::Mutex<HashMap<String, CachedPipeline>>,
     /// Per-size resources, keyed by `(width, height)`.
-    sized_cache: RefCell<HashMap<(u32, u32), SizedResources>>,
+    sized_cache: std::sync::Mutex<HashMap<(u32, u32), SizedResources>>,
 }
 
 impl GpuRenderer {
@@ -189,8 +206,8 @@ impl GpuRenderer {
             device,
             queue,
             adapter_name,
-            pipeline_cache: RefCell::new(HashMap::new()),
-            sized_cache: RefCell::new(HashMap::new()),
+            pipeline_cache: std::sync::Mutex::new(HashMap::new()),
+            sized_cache: std::sync::Mutex::new(HashMap::new()),
         })
     }
 
@@ -205,8 +222,8 @@ impl GpuRenderer {
     #[cfg(test)]
     fn cache_sizes(&self) -> (usize, usize) {
         (
-            self.pipeline_cache.borrow().len(),
-            self.sized_cache.borrow().len(),
+            self.pipeline_cache.lock().unwrap().len(),
+            self.sized_cache.lock().unwrap().len(),
         )
     }
 
@@ -214,7 +231,7 @@ impl GpuRenderer {
     /// pipeline only on first use. The closure runs at most once per distinct
     /// shader source for the life of the renderer.
     fn pipeline<R>(&self, shader_wgsl: &str, f: impl FnOnce(&CachedPipeline) -> R) -> R {
-        let mut cache = self.pipeline_cache.borrow_mut();
+        let mut cache = self.pipeline_cache.lock().unwrap();
         let entry = cache
             .entry(shader_wgsl.to_owned())
             .or_insert_with(|| self.build_pipeline(shader_wgsl));
@@ -284,7 +301,7 @@ impl GpuRenderer {
         height: u32,
         f: impl FnOnce(&SizedResources) -> R,
     ) -> R {
-        let mut map = self.sized_cache.borrow_mut();
+        let mut map = self.sized_cache.lock().unwrap();
         let entry = map
             .entry((width, height))
             .or_insert_with(|| Self::build_sized_resources(&self.device, width, height));
@@ -338,6 +355,16 @@ impl GpuRenderer {
     /// within ±2/channel. `opts.width` / `opts.height` give the output size; `t`
     /// is clamped to `0.0..=1.0`.
     ///
+    /// # Clamping (caller's responsibility)
+    ///
+    /// The resolved orb count is **silently clamped to [`MAX_ORBS`] (64)** — the
+    /// orb-array uniform is fixed at 64 entries. Beyond that the GPU renders only
+    /// the first 64 orbs, which is a *different image* than the CPU oracle (which
+    /// scales to [`MAX_ORB_COUNT`]). The caller therefore owns routing `count > 64`
+    /// to the CPU renderer so the two never diverge for the same flags; the CLI's
+    /// `FrameRenderer::select` does this. A `debug_assert!` here trips in debug
+    /// builds if a future caller forgets and feeds `count > MAX_ORBS` directly.
+    ///
     /// # Panics / scope
     ///
     /// This is the **Circle** path only. The shape in `opts.shape` is ignored
@@ -363,12 +390,21 @@ impl GpuRenderer {
         let cycle = opts.speed.cycle_count() as f32;
         // n_orbs mirrors `precompute_orb_params`: count.unwrap_or(clusters.len())
         // clamped to MAX_ORB_COUNT, at least 1 if there are clusters.
-        let n_orbs = opts
+        let n_orbs_resolved = opts
             .count
             .unwrap_or(clusters.len())
             .min(MAX_ORB_COUNT)
-            .max(if clusters.is_empty() { 0 } else { 1 })
-            .min(MAX_ORBS);
+            .max(if clusters.is_empty() { 0 } else { 1 });
+        // count > MAX_ORBS is the caller's responsibility to route to the CPU
+        // renderer (see the doc-comment above). Trip in debug builds if a caller
+        // forgot; release silently clamps so the GPU never reads past the uniform.
+        debug_assert!(
+            n_orbs_resolved <= MAX_ORBS,
+            "render_frame: resolved orb count {n_orbs_resolved} exceeds MAX_ORBS ({MAX_ORBS}); \
+             the caller must route count > {MAX_ORBS} to the CPU renderer (it would otherwise \
+             silently clamp and diverge from the CPU oracle)"
+        );
+        let n_orbs = n_orbs_resolved.min(MAX_ORBS);
         // shape_id / glyph_rotate / edge_softness are Phase-1 (Glyph) inputs; the
         // Circle shader ignores them. Pass Circle defaults.
         let mut pack = pack_render_data_for_webgl(
@@ -478,7 +514,7 @@ impl GpuRenderer {
         // Pipeline (shader compile) cached per shader source; target / read-back
         // cached per size. Only the small uniforms / bind group are rebuilt per
         // frame.
-        self.pipeline(ORB_CIRCLE_WGSL, |cached| {
+        self.pipeline(orb_circle_wgsl(), |cached| {
             self.sized_resources(width, height, |res| {
                 let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
                     label: Some("orber-circle-bg"),
@@ -644,34 +680,96 @@ mod tests {
         }
     }
 
-    /// Get a renderer for a parity test, or decide what to do when no adapter is
-    /// available.
+    /// Turn a missing adapter into the right outcome for `what`:
     ///
     /// - **`ORBER_REQUIRE_GPU=1`** (CI / any environment that must actually verify
     ///   parity): a missing adapter is a hard **`panic!`** — the test fails loudly
     ///   instead of silently passing. This is what stops the "no GPU ⇒ green
     ///   without checking anything" false-positive.
-    /// - **unset** (developer machine without a GPU): returns `None` so the caller
-    ///   can `return` early and skip. This keeps the suite convenient locally
-    ///   while making "skipped" and "really verified" distinguishable.
+    /// - **unset** (developer machine without a GPU): the caller skips, so a
+    ///   missing adapter just prints a SKIP line. This keeps the suite convenient
+    ///   locally while making "skipped" and "really verified" distinguishable.
     ///
-    /// `what` names the test for the panic / skip message.
-    fn require_or_skip_renderer(what: &str) -> Option<GpuRenderer> {
-        match GpuRenderer::new() {
+    /// Under `ORBER_REQUIRE_GPU=1` this `panic!`s and never returns; otherwise it
+    /// prints the SKIP line and returns, leaving the caller to skip. `what` names
+    /// the test for the message.
+    fn require_gpu_or_panic(what: &str) {
+        if std::env::var("ORBER_REQUIRE_GPU").as_deref() == Ok("1") {
+            panic!(
+                "{what}: ORBER_REQUIRE_GPU=1 but no GPU adapter is available; \
+                 parity could not be verified (install a Vulkan ICD, e.g. \
+                 mesa-vulkan-drivers + VK_ICD_FILENAMES=lvp_icd, or unset \
+                 ORBER_REQUIRE_GPU to allow skipping)"
+            );
+        }
+        eprintln!(
+            "SKIP {what}: no GPU adapter available (set ORBER_REQUIRE_GPU=1 to fail instead)"
+        );
+    }
+
+    /// A single `GpuRenderer` shared by the whole parity-test group.
+    ///
+    /// `cargo test` is multi-threaded by default, and each parity test used to
+    /// build its own `wgpu::Instance` + adapter + device. On a real GPU, several
+    /// `request_adapter` / `request_device` calls racing at once would transiently
+    /// return `None` (~1 run in 8), which `ORBER_REQUIRE_GPU=1` then turned into a
+    /// hard, *spurious* failure. Bringing the context up exactly once removes that
+    /// contention: wgpu's `Device` / `Queue` are `Send + Sync`, so a
+    /// `&'static GpuRenderer` is safe to borrow concurrently from every test.
+    static SHARED_TEST_GPU: std::sync::OnceLock<Option<GpuRenderer>> = std::sync::OnceLock::new();
+
+    /// Get the shared parity renderer, or decide what to do when no adapter is
+    /// available (panic under `ORBER_REQUIRE_GPU=1`, skip otherwise). The context
+    /// is built at most once for the whole test binary, regardless of how many
+    /// threads call this. `what` names the test for the panic / skip message.
+    fn require_or_skip_renderer(what: &str) -> Option<&'static GpuRenderer> {
+        let shared = SHARED_TEST_GPU.get_or_init(GpuRenderer::new);
+        match shared {
             Some(r) => Some(r),
             None => {
-                if std::env::var("ORBER_REQUIRE_GPU").as_deref() == Ok("1") {
-                    panic!(
-                        "{what}: ORBER_REQUIRE_GPU=1 but no GPU adapter is available; \
-                         parity could not be verified (install a Vulkan ICD, e.g. \
-                         mesa-vulkan-drivers + VK_ICD_FILENAMES=lvp_icd, or unset \
-                         ORBER_REQUIRE_GPU to allow skipping)"
-                    );
-                }
-                eprintln!("SKIP {what}: no GPU adapter available (set ORBER_REQUIRE_GPU=1 to fail instead)");
+                require_gpu_or_panic(what);
                 None
             }
         }
+    }
+
+    /// Build a *fresh, independent* renderer for tests that need a second context
+    /// (e.g. the cache-leak oracle leg). Because this is the rare single-instance
+    /// path it can still race transiently with the shared context's bring-up, so
+    /// retry the bring-up a few times before falling back to require/skip.
+    fn require_or_skip_fresh_renderer(what: &str) -> Option<GpuRenderer> {
+        for _ in 0..3 {
+            if let Some(r) = GpuRenderer::new() {
+                return Some(r);
+            }
+        }
+        require_gpu_or_panic(what);
+        None
+    }
+
+    /// The WGSL must be single-sourced from `gpu::MAX_ORBS`: every `{{MAX_ORBS}}`
+    /// placeholder is substituted, none survive, and the resolved orb-array length
+    /// / `MAX_ORBS` const carry the Rust value. This catches a future bump of
+    /// `MAX_ORBS` (e.g. to 128) silently leaving a stale `64` in the shader.
+    #[test]
+    fn wgsl_max_orbs_is_synced_with_rust() {
+        let resolved = orb_circle_wgsl();
+        assert!(
+            !resolved.contains("{{MAX_ORBS}}"),
+            "unsubstituted {{{{MAX_ORBS}}}} placeholder left in resolved WGSL"
+        );
+        assert!(
+            ORB_CIRCLE_WGSL_TEMPLATE.contains("{{MAX_ORBS}}"),
+            "template lost its {{{{MAX_ORBS}}}} placeholder — the literal would no longer be single-sourced"
+        );
+        assert!(
+            resolved.contains(&format!("const MAX_ORBS: u32 = {MAX_ORBS}u;")),
+            "resolved WGSL MAX_ORBS const does not carry gpu::MAX_ORBS ({MAX_ORBS})"
+        );
+        assert!(
+            resolved.contains(&format!("array<Orb, {MAX_ORBS}>")),
+            "resolved WGSL orb-array length does not carry gpu::MAX_ORBS ({MAX_ORBS})"
+        );
     }
 
     /// A small varied palette so per-pixel parity isn't trivially satisfied by a
@@ -862,9 +960,14 @@ mod tests {
 
     /// Pipeline + sized caches must each hold exactly one entry after a clip of
     /// many same-size frames, and a second size must grow only the sized cache.
+    ///
+    /// Uses a *private* renderer (not the shared one): it asserts exact cache
+    /// entry counts, which the shared renderer would violate because the other
+    /// parity tests render it at many different sizes.
     #[test]
     fn caches_resources_across_a_clip() {
-        let Some(renderer) = require_or_skip_renderer("caches_resources_across_a_clip") else {
+        let Some(renderer) = require_or_skip_fresh_renderer("caches_resources_across_a_clip")
+        else {
             return;
         };
         let clusters = sample_clusters();
@@ -887,10 +990,13 @@ mod tests {
     /// Reused per-size resources must not leak the previous frame's bytes: a
     /// second frame with different inputs at the same size (hitting the cache)
     /// must equal a fresh renderer's single render of those inputs.
+    ///
+    /// Uses a *private* renderer (not the shared one) so the `sizes == 1`
+    /// assertion holds — the shared renderer accumulates sizes from other tests.
     #[test]
     fn cached_resources_do_not_leak_previous_frame() {
         let Some(renderer) =
-            require_or_skip_renderer("cached_resources_do_not_leak_previous_frame")
+            require_or_skip_fresh_renderer("cached_resources_do_not_leak_previous_frame")
         else {
             return;
         };
@@ -906,11 +1012,14 @@ mod tests {
         let (_, sizes) = renderer.cache_sizes();
         assert_eq!(sizes, 1, "both frames must share one cached size");
 
-        // The first adapter already came up, so a second must too under
-        // ORBER_REQUIRE_GPU=1; treat a failure here as a real failure, not a skip.
-        let Some(fresh) =
-            require_or_skip_renderer("cached_resources_do_not_leak_previous_frame (oracle leg)")
-        else {
+        // This leg needs a *second, independent* renderer (a fresh per-size cache)
+        // to prove the shared one didn't leak frame A's bytes. The shared context
+        // already came up, so a second must too under ORBER_REQUIRE_GPU=1; the
+        // helper retries the bring-up to absorb any transient adapter race before
+        // treating a failure as real (not a skip).
+        let Some(fresh) = require_or_skip_fresh_renderer(
+            "cached_resources_do_not_leak_previous_frame (oracle leg)",
+        ) else {
             return;
         };
         let b_fresh = fresh.render_frame(&clusters, &opts_b, 0.7);

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -1,0 +1,795 @@
+//! wgpu (Rust + WGSL) production render path — orber #207 Phase 0.
+//!
+//! [`GpuRenderer`] is the headless, native side of the renderer. It runs the
+//! **Circle** orb WGSL ([`orb_circle.wgsl`](../src/orb_circle.wgsl)) that is a
+//! faithful translation of the browser's `web/src/lib/orberGl.ts` Circle arm, so
+//! the native CLI and the web produce matching Circle frames, and so the GPU path
+//! matches the CPU (tiny-skia) oracle ([`crate::animate::render_frame`]) within
+//! ±2/channel.
+//!
+//! ## Parity contract (must match [`crate::animate::render_frame`] for Circle)
+//!
+//! The CPU oracle composites orbs in **straight sRGB byte space** (tiny-skia
+//! premultiplied internally, then un-premultiplied back to straight on output).
+//! To match it the GPU path:
+//!
+//! - renders into an [`wgpu::TextureFormat::Rgba8Unorm`] target (NOT `*Srgb`), so
+//!   no sRGB↔linear conversion happens — the shader's float blend maps to bytes
+//!   by `round(value * 255)`, the same arithmetic as the CPU loop;
+//! - feeds the shader the **exact same per-orb data** the WebGL path uses
+//!   ([`crate::animate::pack_render_data_for_webgl`]): the parameter arithmetic is
+//!   reused, never reimplemented, so the orb positions / radii / alphas are
+//!   identical to the proven web/CPU result;
+//! - reads the result back accounting for wgpu's 256-byte row-alignment
+//!   requirement on `copy_texture_to_buffer`.
+//!
+//! ## Scope
+//!
+//! Phase 0 covers **Circle orbs only**. Glyph / image shapes / aquarelle are
+//! Phase 1; the CLI falls back to the CPU renderer for non-Circle shapes.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use image::RgbaImage;
+use wgpu::util::DeviceExt;
+
+use crate::animate::{pack_render_data_for_webgl, AnimateOptions, MotionDirection, MAX_ORB_COUNT};
+use crate::cluster::Cluster;
+
+/// Bytes per pixel for `Rgba8Unorm`.
+const BYTES_PER_PIXEL: u32 = 4;
+/// wgpu requires `bytes_per_row` of a texture→buffer copy to be a multiple of
+/// this (`COPY_BYTES_PER_ROW_ALIGNMENT`).
+const ROW_ALIGNMENT: u32 = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+
+/// Maximum orbs the Circle shader iterates. Must match `MAX_ORBS` in
+/// `orb_circle.wgsl`, `web/src/lib/orberGl.ts::MAX_ORBS`, and
+/// `crates/wasm/src/lib.rs::GL_RENDERER_MAX_ORBS`.
+// SYNC WITH orb_circle.wgsl::MAX_ORBS
+pub const MAX_ORBS: usize = 64;
+
+/// Header words / per-orb words in the `pack_render_data_for_webgl` layout.
+/// Kept in sync with that function (header 16 words, per-orb 16 words).
+const HEADER_WORDS: usize = 16;
+const PER_ORB_WORDS: usize = 16;
+
+/// The Circle orb WGSL (translation of `orberGl.ts` Circle arm).
+const ORB_CIRCLE_WGSL: &str = include_str!("orb_circle.wgsl");
+
+/// Header uniform block handed to the Circle shader. Mirrors `struct Params` in
+/// `orb_circle.wgsl`. `#[repr(C)]` + explicit padding to satisfy WGSL std140-ish
+/// uniform layout (vec2 then scalars packed into 16-byte rows).
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct Params {
+    // row 0: resolution.xy, t, base_radius
+    resolution: [f32; 2],
+    t: f32,
+    base_radius: f32,
+    // row 1: bg.rgba
+    bg: [f32; 4],
+    // row 2: base_blur, direction, cycle, n_orbs
+    base_blur: f32,
+    direction: f32,
+    cycle: f32,
+    n_orbs: f32,
+    // row 3: alpha_mul + padding
+    alpha_mul: f32,
+    _pad0: f32,
+    _pad1: f32,
+    _pad2: f32,
+}
+
+/// One orb as the Circle shader sees it: three vec4s mirroring `struct Orb` in
+/// `orb_circle.wgsl` (color+weight, phase quartet, misc). Filled from the
+/// `pack_render_data_for_webgl` per-orb words.
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct GpuOrb {
+    color: [f32; 4], // r, g, b, weight
+    phase: [f32; 4], // phase, phi_radius, phi_blur, phi_opacity
+    misc: [f32; 4],  // cross_axis, style_bit, speed_mult, _
+}
+
+/// The orb-array uniform: a fixed-size `[GpuOrb; MAX_ORBS]` (unused tail zeroed).
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct OrbArray {
+    orbs: [GpuOrb; MAX_ORBS],
+}
+
+/// A render pipeline plus its bind-group layout, compiled once per distinct
+/// shader source. Caching keeps shader compilation / pipeline creation off the
+/// per-frame path: a long video renders the same shader for every frame.
+struct CachedPipeline {
+    pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+}
+
+/// Per-dimension GPU resources reused across same-sized frames: the render
+/// target and the padded read-back buffer. Reallocating these every frame is the
+/// other half of the per-frame cost the cache removes.
+struct SizedResources {
+    width: u32,
+    height: u32,
+    target: wgpu::Texture,
+    target_view: wgpu::TextureView,
+    output_buffer: wgpu::Buffer,
+    padded_bytes_per_row: u32,
+}
+
+/// Headless wgpu renderer for the Circle orb path. Holds a device/queue plus a
+/// per-shader pipeline cache and a per-size resource cache, so a multi-frame
+/// render (a long `--duration-ms` video) compiles the shader and allocates the
+/// target/read-back buffer only once instead of every frame.
+///
+/// The caches are unbounded and never evict; for the single-resolution clip use
+/// case this is intentional. A caller streaming arbitrarily many sizes through
+/// one long-lived renderer should drop and rebuild it to release memory.
+pub struct GpuRenderer {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    adapter_name: String,
+    /// Circle pipelines, keyed by shader source.
+    pipeline_cache: RefCell<HashMap<String, CachedPipeline>>,
+    /// Per-size resources, keyed by `(width, height)`.
+    sized_cache: RefCell<HashMap<(u32, u32), SizedResources>>,
+}
+
+impl GpuRenderer {
+    /// Bring up a headless GPU context (no surface). Returns `None` when no
+    /// adapter is available (e.g. CI without a GPU / software rasterizer), so
+    /// callers can fall back to the CPU path instead of hard-failing.
+    pub fn new() -> Option<Self> {
+        pollster::block_on(Self::new_async())
+    }
+
+    async fn new_async() -> Option<Self> {
+        // Headless: no window/display handle is needed (backends still come from env).
+        let instance =
+            wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions::default())
+            .await
+            .ok()?;
+        let adapter_name = adapter.get_info().name;
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("orber-gpu-device"),
+                ..Default::default()
+            })
+            .await
+            .ok()?;
+        Some(Self {
+            device,
+            queue,
+            adapter_name,
+            pipeline_cache: RefCell::new(HashMap::new()),
+            sized_cache: RefCell::new(HashMap::new()),
+        })
+    }
+
+    /// Name of the underlying adapter (for diagnostics / proving the GPU path ran).
+    pub fn adapter_name(&self) -> &str {
+        &self.adapter_name
+    }
+
+    /// Live entry counts of the two caches, `(pipelines, sizes)`. Exposed for the
+    /// cache-effectiveness test: rendering a clip of many frames at one size with
+    /// one shader must leave exactly one pipeline and one sized entry.
+    #[cfg(test)]
+    fn cache_sizes(&self) -> (usize, usize) {
+        (
+            self.pipeline_cache.borrow().len(),
+            self.sized_cache.borrow().len(),
+        )
+    }
+
+    /// Get-or-build the Circle pipeline for `shader_wgsl`, compiling the shader and
+    /// pipeline only on first use. The closure runs at most once per distinct
+    /// shader source for the life of the renderer.
+    fn pipeline<R>(&self, shader_wgsl: &str, f: impl FnOnce(&CachedPipeline) -> R) -> R {
+        let mut cache = self.pipeline_cache.borrow_mut();
+        let entry = cache
+            .entry(shader_wgsl.to_owned())
+            .or_insert_with(|| self.build_pipeline(shader_wgsl));
+        f(entry)
+    }
+
+    /// Compile the Circle pipeline (binding 0 = `Params`, binding 1 = `OrbArray`).
+    fn build_pipeline(&self, shader_wgsl: &str) -> CachedPipeline {
+        let format = wgpu::TextureFormat::Rgba8Unorm;
+        let bind_group_layout =
+            self.device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("orber-circle-bgl"),
+                    entries: &[uniform_entry(0), uniform_entry(1)],
+                });
+        let shader = self
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("orber-circle-shader"),
+                source: wgpu::ShaderSource::Wgsl(shader_wgsl.into()),
+            });
+        let pipeline_layout = self
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("orber-circle-pl"),
+                bind_group_layouts: &[Some(&bind_group_layout)],
+                immediate_size: 0,
+            });
+        let pipeline = self
+            .device
+            .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("orber-circle-pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    compilation_options: Default::default(),
+                    buffers: &[],
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    compilation_options: Default::default(),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            });
+        CachedPipeline {
+            pipeline,
+            bind_group_layout,
+        }
+    }
+
+    /// Get-or-build the per-size resources, allocating the target texture and
+    /// read-back buffer only on first use of a `(width, height)`.
+    fn sized_resources<R>(
+        &self,
+        width: u32,
+        height: u32,
+        f: impl FnOnce(&SizedResources) -> R,
+    ) -> R {
+        let mut map = self.sized_cache.borrow_mut();
+        let entry = map
+            .entry((width, height))
+            .or_insert_with(|| Self::build_sized_resources(&self.device, width, height));
+        f(entry)
+    }
+
+    /// Allocate the target texture and the padded read-back buffer for a size.
+    fn build_sized_resources(device: &wgpu::Device, width: u32, height: u32) -> SizedResources {
+        let format = wgpu::TextureFormat::Rgba8Unorm;
+        let extent = wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        };
+        let target = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("orber-circle-target"),
+            size: extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let target_view = target.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let unpadded_bytes_per_row = width * BYTES_PER_PIXEL;
+        let padded_bytes_per_row = align_up(unpadded_bytes_per_row, ROW_ALIGNMENT);
+        let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("orber-circle-readback"),
+            size: (padded_bytes_per_row * height) as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        SizedResources {
+            width,
+            height,
+            target,
+            target_view,
+            output_buffer,
+            padded_bytes_per_row,
+        }
+    }
+
+    /// Render one Circle frame at time `t` from `clusters` + `opts`, matching
+    /// [`crate::animate::render_frame`].
+    ///
+    /// The per-orb data is computed by [`pack_render_data_for_webgl`] — the same
+    /// arithmetic the WebGL path uses — so the GPU output matches the CPU oracle
+    /// within ±2/channel. `opts.width` / `opts.height` give the output size; `t`
+    /// is clamped to `0.0..=1.0`.
+    ///
+    /// # Panics / scope
+    ///
+    /// This is the **Circle** path only. The shape in `opts.shape` is ignored
+    /// here (the caller is responsible for routing non-Circle shapes to the CPU
+    /// renderer); see the module docs.
+    pub fn render_frame(&self, clusters: &[Cluster], opts: &AnimateOptions, t: f32) -> RgbaImage {
+        let width = opts.width.max(1);
+        let height = opts.height.max(1);
+        let t = t.clamp(0.0, 1.0);
+
+        // Derive the WebGL pack-buffer scalars exactly as the CPU oracle /
+        // `get_render_data` do, then reuse `pack_render_data_for_webgl` so the
+        // per-orb arithmetic is never reimplemented.
+        let base_radius_unit = (width.min(height) as f32) * 0.25 * opts.orb_size.max(0.0);
+        let base_blur = (opts.blur + opts.softness.blur_offset()).clamp(0.0, 1.0);
+        let alpha_mul = opts.softness.alpha_mul().clamp(0.0, 1.0);
+        let direction_id: f32 = match opts.direction {
+            MotionDirection::LeftToRight => 0.0,
+            MotionDirection::RightToLeft => 1.0,
+            MotionDirection::TopToBottom => 2.0,
+            MotionDirection::BottomToTop => 3.0,
+        };
+        let cycle = opts.speed.cycle_count() as f32;
+        // n_orbs mirrors `precompute_orb_params`: count.unwrap_or(clusters.len())
+        // clamped to MAX_ORB_COUNT, at least 1 if there are clusters.
+        let n_orbs = opts
+            .count
+            .unwrap_or(clusters.len())
+            .min(MAX_ORB_COUNT)
+            .max(if clusters.is_empty() { 0 } else { 1 })
+            .min(MAX_ORBS);
+        // shape_id / glyph_rotate / edge_softness are Phase-1 (Glyph) inputs; the
+        // Circle shader ignores them. Pass Circle defaults.
+        let pack = pack_render_data_for_webgl(
+            clusters,
+            opts.background,
+            base_radius_unit,
+            base_blur,
+            direction_id,
+            cycle,
+            opts.seed,
+            n_orbs,
+            alpha_mul,
+            0.0,  // shape_id = Circle
+            true, // glyph_rotate (unused by Circle)
+            opts.softness.edge_softness(),
+        );
+
+        self.render_packed(&pack, width, height, t)
+    }
+
+    /// Render one Circle frame from a raw `pack_render_data_for_webgl` buffer.
+    ///
+    /// `pack` must be the header(16) + per-orb(16 × n_orbs) layout produced by
+    /// [`pack_render_data_for_webgl`]. `t` is the normalized time written into the
+    /// shader's `u_t`; it is clamped to `0.0..=1.0`. This is the seam the WebGL
+    /// path will also share (Phase 2).
+    pub fn render_packed(&self, pack: &[f32], width: u32, height: u32, t: f32) -> RgbaImage {
+        let width = width.max(1);
+        let height = height.max(1);
+        let t = t.clamp(0.0, 1.0);
+
+        assert!(
+            pack.len() >= HEADER_WORDS,
+            "pack buffer too short: {} < {HEADER_WORDS}",
+            pack.len()
+        );
+
+        // Header → Params. Layout per `pack_render_data_for_webgl` doc-comment.
+        let n_orbs_packed = pack[8].max(0.0) as usize;
+        let n_orbs = n_orbs_packed.min(MAX_ORBS);
+        let params = Params {
+            resolution: [width as f32, height as f32],
+            t,
+            base_radius: pack[4],
+            bg: [pack[0], pack[1], pack[2], pack[3]],
+            base_blur: pack[5],
+            direction: pack[6],
+            cycle: pack[7],
+            n_orbs: n_orbs as f32,
+            alpha_mul: pack[9],
+            _pad0: 0.0,
+            _pad1: 0.0,
+            _pad2: 0.0,
+        };
+        let params_buffer = self
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("orber-circle-params"),
+                contents: bytemuck::bytes_of(&params),
+                usage: wgpu::BufferUsages::UNIFORM,
+            });
+
+        // Per-orb words → fixed-size array (unused tail zeroed). Only the words
+        // the Circle shader reads are unpacked (color+weight, phase quartet,
+        // cross_axis/style/speed); rotation words are skipped.
+        let mut orb_array = OrbArray {
+            orbs: [GpuOrb {
+                color: [0.0; 4],
+                phase: [0.0; 4],
+                misc: [0.0; 4],
+            }; MAX_ORBS],
+        };
+        for i in 0..n_orbs {
+            let off = HEADER_WORDS + PER_ORB_WORDS * i;
+            if off + 11 >= pack.len() {
+                break;
+            }
+            orb_array.orbs[i] = GpuOrb {
+                color: [pack[off], pack[off + 1], pack[off + 2], pack[off + 3]],
+                phase: [pack[off + 4], pack[off + 5], pack[off + 6], pack[off + 7]],
+                misc: [pack[off + 8], pack[off + 9], pack[off + 10], 0.0],
+            };
+        }
+        let orb_buffer = self
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("orber-circle-orbs"),
+                contents: bytemuck::bytes_of(&orb_array),
+                usage: wgpu::BufferUsages::UNIFORM,
+            });
+
+        // Pipeline (shader compile) cached per shader source; target / read-back
+        // cached per size. Only the small uniforms / bind group are rebuilt per
+        // frame.
+        self.pipeline(ORB_CIRCLE_WGSL, |cached| {
+            self.sized_resources(width, height, |res| {
+                let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("orber-circle-bg"),
+                    layout: &cached.bind_group_layout,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: params_buffer.as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: orb_buffer.as_entire_binding(),
+                        },
+                    ],
+                });
+                self.run_pass_and_readback(&cached.pipeline, &bind_group, res)
+            })
+        })
+    }
+
+    /// Render one full-screen pass into `res.target`, copy it into the read-back
+    /// buffer, map it, and strip wgpu's row padding into a tight `RgbaImage`.
+    fn run_pass_and_readback(
+        &self,
+        pipeline: &wgpu::RenderPipeline,
+        bind_group: &wgpu::BindGroup,
+        res: &SizedResources,
+    ) -> RgbaImage {
+        let (width, height) = (res.width, res.height);
+        let extent = wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        };
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("orber-circle-encoder"),
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("orber-circle-pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &res.target_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: &res.target,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &res.output_buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(res.padded_bytes_per_row),
+                    rows_per_image: Some(height),
+                },
+            },
+            extent,
+        );
+        self.queue.submit(Some(encoder.finish()));
+
+        let slice = res.output_buffer.slice(..);
+        slice.map_async(wgpu::MapMode::Read, |_| {});
+        self.device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .expect("device poll failed");
+
+        let unpadded_bytes_per_row = width * BYTES_PER_PIXEL;
+        let mapped = slice.get_mapped_range();
+        let mut pixels = Vec::with_capacity((unpadded_bytes_per_row * height) as usize);
+        for row in 0..height {
+            let start = (row * res.padded_bytes_per_row) as usize;
+            let end = start + unpadded_bytes_per_row as usize;
+            pixels.extend_from_slice(&mapped[start..end]);
+        }
+        drop(mapped);
+        res.output_buffer.unmap();
+
+        RgbaImage::from_raw(width, height, pixels)
+            .expect("read-back buffer matches image dimensions")
+    }
+}
+
+/// Round `value` up to the next multiple of `align` (a power of two).
+fn align_up(value: u32, align: u32) -> u32 {
+    value.div_ceil(align) * align
+}
+
+/// A fragment-visible uniform-buffer bind-group-layout entry.
+fn uniform_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::FRAGMENT,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::animate::{render_frame, AnimateOptions, MotionDirection, MotionSpeed};
+    use crate::cluster::{Centroid, Cluster};
+    use crate::orb::OrbShape;
+    use crate::style::SoftnessPreset;
+
+    fn cluster(color: [u8; 3], cx: f32, cy: f32, weight: f32) -> Cluster {
+        Cluster {
+            color,
+            centroid: Centroid { x: cx, y: cy },
+            weight,
+        }
+    }
+
+    /// A small varied palette so per-pixel parity isn't trivially satisfied by a
+    /// flat color: several colors / weights scattered around the frame.
+    fn sample_clusters() -> Vec<Cluster> {
+        vec![
+            cluster([220, 60, 60], 0.3, 0.4, 0.5),
+            cluster([60, 120, 220], 0.7, 0.6, 0.3),
+            cluster([200, 200, 80], 0.5, 0.2, 0.2),
+            cluster([90, 220, 140], 0.2, 0.8, 0.25),
+        ]
+    }
+
+    fn circle_opts(
+        w: u32,
+        h: u32,
+        direction: MotionDirection,
+        speed: MotionSpeed,
+    ) -> AnimateOptions {
+        AnimateOptions {
+            width: w,
+            height: h,
+            orb_size: 1.0,
+            blur: 0.5,
+            saturation: 1.0,
+            direction,
+            speed,
+            seed: 12345,
+            count: Some(12),
+            background: [12, 18, 28, 255],
+            shape: OrbShape::Circle,
+            softness: SoftnessPreset::Mid,
+            glyph_rotate: true,
+            color_tracks: None,
+            keyframe_tracks: None,
+        }
+    }
+
+    /// Assert every channel of `a`/`b` agrees within `±2`, returning the max diff.
+    fn assert_within_tolerance(a: &RgbaImage, b: &RgbaImage, ctx: &str) -> u8 {
+        assert_eq!(a.dimensions(), b.dimensions(), "{ctx}: dimension mismatch");
+        let mut max_diff = 0u8;
+        let mut worst = (0u32, 0u32, 0usize, [0u8; 4], [0u8; 4]);
+        for (x, y, ap) in a.enumerate_pixels() {
+            let bp = b.get_pixel(x, y);
+            for ch in 0..4 {
+                let d = ap.0[ch].abs_diff(bp.0[ch]);
+                if d > max_diff {
+                    max_diff = d;
+                    worst = (x, y, ch, ap.0, bp.0);
+                }
+            }
+        }
+        assert!(
+            max_diff <= 2,
+            "{ctx}: max per-channel diff {max_diff} at pixel ({},{}) channel {} (cpu={:?} gpu={:?})",
+            worst.0,
+            worst.1,
+            worst.2,
+            worst.3,
+            worst.4,
+        );
+        max_diff
+    }
+
+    #[test]
+    fn gpu_matches_cpu_within_tolerance() {
+        let Some(renderer) = GpuRenderer::new() else {
+            eprintln!("SKIP gpu_matches_cpu_within_tolerance: no GPU adapter available");
+            return;
+        };
+        eprintln!(
+            "GPU Circle parity test running on adapter: {}",
+            renderer.adapter_name()
+        );
+
+        let clusters = sample_clusters();
+        // Cover the read-back strip boundary both ways with orb-bearing frames:
+        //   - 37x23: width*4 = 148, not a multiple of 256, so rows ARE padded;
+        //   - 64x16: width*4 = 256 is already row-aligned, so NO padding.
+        // (1x1 is exercised separately by `gpu_matches_cpu_1x1_readback`: at a
+        // sub-pixel orb radius tiny-skia's analytic path-coverage AA diverges from
+        // a point-sampled shader — a degenerate case orber never renders — so the
+        // 1x1 row-padding readback is checked background-only instead.)
+        let mut overall_max = 0u8;
+        for &(w, h) in &[(37u32, 23u32), (64, 16)] {
+            let dir = match (w, h) {
+                (37, 23) => MotionDirection::LeftToRight,
+                _ => MotionDirection::TopToBottom,
+            };
+            let opts = circle_opts(w, h, dir, MotionSpeed::Slow);
+            for &t in &[0.0_f32, 0.25, 0.5, 0.75, 1.0] {
+                let cpu = render_frame(&clusters, &opts, t);
+                let gpu = renderer.render_frame(&clusters, &opts, t);
+                let max_diff =
+                    assert_within_tolerance(&cpu, &gpu, &format!("{w}x{h} {dir:?} t={t}"));
+                overall_max = overall_max.max(max_diff);
+                eprintln!("{w}x{h} {dir:?} t={t}: max per-channel diff = {max_diff}");
+            }
+        }
+        eprintln!("overall max per-channel diff across all cases = {overall_max}");
+    }
+
+    /// 1x1 read-back boundary: width*4 = 4 bytes/row is padded to 256, so this
+    /// exercises the most extreme row-padding strip. Use a background-only frame
+    /// (no clusters) so the assertion is about read-back geometry, not the
+    /// degenerate sub-pixel-orb AA where a point-sampled shader cannot match
+    /// tiny-skia's analytic path coverage. Also checks 1x3 / 3x1 strips.
+    #[test]
+    fn gpu_matches_cpu_1x1_readback() {
+        let Some(renderer) = GpuRenderer::new() else {
+            eprintln!("SKIP gpu_matches_cpu_1x1_readback: no GPU adapter available");
+            return;
+        };
+        for &(w, h) in &[(1u32, 1u32), (1, 3), (3, 1), (5, 1)] {
+            let opts = circle_opts(w, h, MotionDirection::LeftToRight, MotionSpeed::Slow);
+            for &t in &[0.0_f32, 0.5, 1.0] {
+                // Background-only frame on both paths.
+                let cpu = render_frame(&[], &opts, t);
+                let gpu = renderer.render_frame(&[], &opts, t);
+                let max_diff =
+                    assert_within_tolerance(&cpu, &gpu, &format!("{w}x{h} bg-only t={t}"));
+                eprintln!("{w}x{h} bg-only t={t}: max per-channel diff = {max_diff}");
+            }
+        }
+    }
+
+    /// All four flow directions must hold parity at a single non-trivial size/t.
+    #[test]
+    fn gpu_matches_cpu_all_directions() {
+        let Some(renderer) = GpuRenderer::new() else {
+            eprintln!("SKIP gpu_matches_cpu_all_directions: no GPU adapter available");
+            return;
+        };
+        let clusters = sample_clusters();
+        for dir in [
+            MotionDirection::LeftToRight,
+            MotionDirection::RightToLeft,
+            MotionDirection::TopToBottom,
+            MotionDirection::BottomToTop,
+        ] {
+            let opts = circle_opts(40, 28, dir, MotionSpeed::Mid);
+            let cpu = render_frame(&clusters, &opts, 0.37);
+            let gpu = renderer.render_frame(&clusters, &opts, 0.37);
+            let max_diff = assert_within_tolerance(&cpu, &gpu, &format!("dir {dir:?}"));
+            eprintln!("dir {dir:?}: max per-channel diff = {max_diff}");
+        }
+    }
+
+    /// Empty clusters → background-only frame must still match (bg fill path).
+    #[test]
+    fn gpu_matches_cpu_empty_clusters() {
+        let Some(renderer) = GpuRenderer::new() else {
+            eprintln!("SKIP gpu_matches_cpu_empty_clusters: no GPU adapter available");
+            return;
+        };
+        let opts = circle_opts(32, 24, MotionDirection::LeftToRight, MotionSpeed::Slow);
+        let cpu = render_frame(&[], &opts, 0.5);
+        let gpu = renderer.render_frame(&[], &opts, 0.5);
+        let max_diff = assert_within_tolerance(&cpu, &gpu, "empty clusters");
+        eprintln!("empty clusters: max per-channel diff = {max_diff}");
+    }
+
+    /// Pipeline + sized caches must each hold exactly one entry after a clip of
+    /// many same-size frames, and a second size must grow only the sized cache.
+    #[test]
+    fn caches_resources_across_a_clip() {
+        let Some(renderer) = GpuRenderer::new() else {
+            eprintln!("SKIP caches_resources_across_a_clip: no GPU adapter available");
+            return;
+        };
+        let clusters = sample_clusters();
+        let opts = circle_opts(48, 32, MotionDirection::LeftToRight, MotionSpeed::Slow);
+        for k in 0..16 {
+            let t = k as f32 / 15.0;
+            let _ = renderer.render_frame(&clusters, &opts, t);
+        }
+        let (pipes, sizes) = renderer.cache_sizes();
+        assert_eq!(pipes, 1, "shader must compile exactly once");
+        assert_eq!(sizes, 1, "size must allocate exactly once");
+
+        let opts2 = circle_opts(24, 24, MotionDirection::LeftToRight, MotionSpeed::Slow);
+        let _ = renderer.render_frame(&clusters, &opts2, 0.5);
+        let (pipes, sizes) = renderer.cache_sizes();
+        assert_eq!(pipes, 1, "second size must not recompile the shader");
+        assert_eq!(sizes, 2, "second size must add one sized entry");
+    }
+
+    /// Reused per-size resources must not leak the previous frame's bytes: a
+    /// second frame with different inputs at the same size (hitting the cache)
+    /// must equal a fresh renderer's single render of those inputs.
+    #[test]
+    fn cached_resources_do_not_leak_previous_frame() {
+        let Some(renderer) = GpuRenderer::new() else {
+            eprintln!("SKIP cached_resources_do_not_leak_previous_frame: no GPU adapter available");
+            return;
+        };
+        let clusters = sample_clusters();
+        let opts_a = circle_opts(40, 24, MotionDirection::LeftToRight, MotionSpeed::Slow);
+        let mut opts_b = circle_opts(40, 24, MotionDirection::TopToBottom, MotionSpeed::Mid);
+        opts_b.seed = 999;
+        opts_b.background = [40, 5, 50, 255];
+
+        let _a = renderer.render_frame(&clusters, &opts_a, 0.3);
+        let b_cached = renderer.render_frame(&clusters, &opts_b, 0.7);
+
+        let (_, sizes) = renderer.cache_sizes();
+        assert_eq!(sizes, 1, "both frames must share one cached size");
+
+        let Some(fresh) = GpuRenderer::new() else {
+            eprintln!("SKIP oracle leg: no second GPU adapter available");
+            return;
+        };
+        let b_fresh = fresh.render_frame(&clusters, &opts_b, 0.7);
+        let max_diff =
+            assert_within_tolerance(&b_fresh, &b_cached, "reused frame B vs fresh render");
+        eprintln!("reuse-vs-fresh frame B: max per-channel diff = {max_diff}");
+    }
+}

--- a/crates/core/src/keyframe_track.rs
+++ b/crates/core/src/keyframe_track.rs
@@ -126,11 +126,7 @@ mod tests {
     fn approx(a: f32, b: f32, eps: f32, label: &str) {
         assert!(
             (a - b).abs() < eps,
-            "{}: expected ~{}, got {} (eps={})",
-            label,
-            b,
-            a,
-            eps
+            "{label}: expected ~{b}, got {a} (eps={eps})"
         );
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -9,6 +9,12 @@ pub mod batch;
 pub mod cluster;
 pub mod color_track;
 pub mod glyph;
+/// wgpu (Rust + WGSL) production render path (#207, Phase 0). Native CLI only;
+/// behind the `gpu` feature so the wasm32 build stays minimal. Renders the
+/// **Circle** orb path in WGSL and matches the CPU (tiny-skia) oracle within
+/// ±2/channel.
+#[cfg(feature = "gpu")]
+pub mod gpu;
 pub mod keyframe_track;
 pub mod orb;
 pub mod output_mode;

--- a/crates/core/src/orb.rs
+++ b/crates/core/src/orb.rs
@@ -482,10 +482,7 @@ mod tests {
         let b = center[2] as i32;
         assert!(
             (r - g).abs() <= 2 && (g - b).abs() <= 2 && (r - b).abs() <= 2,
-            "saturation=0 should produce grayscale, got R={} G={} B={}",
-            r,
-            g,
-            b
+            "saturation=0 should produce grayscale, got R={r} G={g} B={b}"
         );
     }
 
@@ -965,8 +962,7 @@ mod tests {
                     assert_eq!(
                         [px[0], px[1], px[2]],
                         [0, 0, 0],
-                        "alpha=0 pixel must have RGB=0 for shape={:?}",
-                        shape
+                        "alpha=0 pixel must have RGB=0 for shape={shape:?}"
                     );
                 }
             }
@@ -998,8 +994,7 @@ mod tests {
             assert_eq!(
                 img.as_raw().len(),
                 (opts.width * opts.height * 4) as usize,
-                "buffer length must be width*height*4 for shape={:?}",
-                shape
+                "buffer length must be width*height*4 for shape={shape:?}"
             );
         }
     }

--- a/crates/core/src/orb_circle.wgsl
+++ b/crates/core/src/orb_circle.wgsl
@@ -37,10 +37,11 @@
 const TAU: f32 = 6.28318530718;
 const BREATH_RADIUS_MAX_FACTOR: f32 = 1.10;
 
-// per-orb uniform array の上限。orberGl.ts の MAX_ORBS / wasm の
-// GL_RENDERER_MAX_ORBS と同期させる。
+// per-orb uniform array の上限。`{{MAX_ORBS}}` は gpu.rs が include_str! 後に
+// Rust 側 `gpu::MAX_ORBS` で置換する単一ソース（リテラル二重定義を避ける）。
+// orberGl.ts の MAX_ORBS / wasm の GL_RENDERER_MAX_ORBS とも同期させること。
 // SYNC WITH web/src/lib/orberGl.ts::MAX_ORBS と crates/wasm/src/lib.rs::GL_RENDERER_MAX_ORBS
-const MAX_ORBS: u32 = 64u;
+const MAX_ORBS: u32 = {{MAX_ORBS}}u;
 
 struct Params {
     resolution: vec2<f32>, // (width, height) px
@@ -68,9 +69,9 @@ struct Orb {
 };
 
 struct Orbs {
-    // WGSL は配列長にリテラルを要求するため MAX_ORBS const を参照できない。
-    // 64 は上の MAX_ORBS と一致させること。
-    orbs: array<Orb, 64>,
+    // WGSL は配列長に const 式を要求し、上の MAX_ORBS const は配列長に使えないため
+    // `{{MAX_ORBS}}` を gpu.rs が同じ値で置換する（const と配列長が必ず一致する）。
+    orbs: array<Orb, {{MAX_ORBS}}>,
 };
 
 @group(0) @binding(0) var<uniform> params: Params;

--- a/crates/core/src/orb_circle.wgsl
+++ b/crates/core/src/orb_circle.wgsl
@@ -5,10 +5,15 @@
 // header(16 words) + per-orb(16 words × n_orbs) をそのまま GPU バッファに流す。
 // パラメータ算術は再実装せず、`gpu.rs` 側で pack 出力を vec4 にほどいて渡す。
 //
-// CPU(tiny-skia) との対応:
-//   - Circle アームは CPU 経路（animate::render_frame）と同式・同パラメータで、
-//     GLSL 実装が本番で byte-near（≤1/255）一致を実証済み。本 WGSL はその GLSL を
-//     忠実に写経しているので、同じ ±2/channel の許容内で一致する。
+// CPU(tiny-skia) との対応（パリティ範囲は狭い。過大主張しない）:
+//   - パリティが成り立つのは **Circle ∧ saturation 反映済 ∧ count ≤ MAX_ORBS(64)**
+//     の経路に限る。saturation は pack_render_data_for_webgl では掛けず（WebGL と共有
+//     のため）、native GPU 側 gpu.rs::render_frame が adjust_saturation_pub を後段適用
+//     して CPU と揃える。count > 64 は CLI が CPU にフォールバックする（このシェーダは
+//     64 で clamp）。video は CPU 経路、color/keyframe tracks は GPU pack 未対応。
+//   - その経路では Circle アームは CPU 経路（animate::render_frame）と同式・同パラメータ
+//     で、GLSL 実装が本番で byte-near（≤1/255）一致を実証済み。本 WGSL はその GLSL を
+//     忠実に写経しているので、同じ ±2/channel の許容内で一致する（実 GPU では 0）。
 //   - falloff_curve は raw float のまま blend する（CPU 側は alpha を 1/255 に
 //     量子化してから tiny-skia に渡すが、その差は Circle で ≤1/255）。
 //

--- a/crates/core/src/orb_circle.wgsl
+++ b/crates/core/src/orb_circle.wgsl
@@ -1,0 +1,292 @@
+// orber #207 Phase 0 — Circle orb の production WGSL（native CLI / wgpu）。
+//
+// `web/src/lib/orberGl.ts` の **Circle アーム** を 1:1 で WGSL に翻訳したもの。
+// per-orb データは `pack_render_data_for_webgl`（= WebGL 経路と同一）が詰めた
+// header(16 words) + per-orb(16 words × n_orbs) をそのまま GPU バッファに流す。
+// パラメータ算術は再実装せず、`gpu.rs` 側で pack 出力を vec4 にほどいて渡す。
+//
+// CPU(tiny-skia) との対応:
+//   - Circle アームは CPU 経路（animate::render_frame）と同式・同パラメータで、
+//     GLSL 実装が本番で byte-near（≤1/255）一致を実証済み。本 WGSL はその GLSL を
+//     忠実に写経しているので、同じ ±2/channel の許容内で一致する。
+//   - falloff_curve は raw float のまま blend する（CPU 側は alpha を 1/255 に
+//     量子化してから tiny-skia に渡すが、その差は Circle で ≤1/255）。
+//
+// 座標系:
+//   GLSL は gl_FragCoord(bottom-left) を `px.y = H - px.y` で top-left に直してから
+//   CPU(image::RgbaImage, top-left) と合わせていた。WGSL の @builtin(position) は
+//   既に top-left（pixel 中心 +0.5）で、読み戻しも top-left のままなので **flip 不要**。
+//   よって `in.pos.xy` をそのまま GLSL の flip 後 `px` として使う。
+//
+// 仕様の数式（CPU / GLSL と一致）:
+//   - r_pixels_max = base_radius * sqrt(weight) * 1.10
+//   - r_normalized = r_pixels_max / progress_axis_pixels
+//   - extent = 1 + 2 * r_normalized
+//   - advance_steps = fract(cycle * speed_mult * t)
+//   - pos = mod(phase*extent + advance_steps*extent, extent) - r_normalized
+//   - 3 軸独立呼吸: radius ±10%, blur ±15, opacity ±5%（sin(TAU*fract(t)+phi)）
+//   - rim: 3-stop（center=opacity, mid=opacity*80/255, mid_stop=clamp(1-blur*0.8,.05,.95)）
+//   - soft: 2-stop（hold=opacity, hold_stop=clamp(1-blur,.05,.95)）
+//   - Source-Over（straight alpha）
+
+const TAU: f32 = 6.28318530718;
+const BREATH_RADIUS_MAX_FACTOR: f32 = 1.10;
+
+// per-orb uniform array の上限。orberGl.ts の MAX_ORBS / wasm の
+// GL_RENDERER_MAX_ORBS と同期させる。
+// SYNC WITH web/src/lib/orberGl.ts::MAX_ORBS と crates/wasm/src/lib.rs::GL_RENDERER_MAX_ORBS
+const MAX_ORBS: u32 = 64u;
+
+struct Params {
+    resolution: vec2<f32>, // (width, height) px
+    t: f32,                // [0, 1)
+    base_radius: f32,      // px = min(w,h) * 0.25 * orb_size
+    bg: vec4<f32>,         // straight rgba (0..1)
+    base_blur: f32,        // 0..1
+    direction: f32,        // 0=LR, 1=RL, 2=TB, 3=BT
+    cycle: f32,            // 1=VerySlow, 2=Slow, 3=Mid, 4=Fast
+    n_orbs: f32,           // 整数を f32 で（uniform alignment 簡略化のため）
+    alpha_mul: f32,        // softness.alpha_mul
+    _pad0: f32,
+    _pad1: f32,
+    _pad2: f32,
+};
+
+// per-orb のパック。pack_render_data_for_webgl の per-orb 16 words のうち
+// Circle 経路が使う分だけ 3 つの vec4 に詰め替える（orberGl.ts の
+// u_orb_color / u_orb_phase / u_orb_misc と同じ並び）。回転 (base_angle /
+// rot_speed) は Circle では未使用なので持ち込まない。
+struct Orb {
+    color: vec4<f32>, // (r, g, b, weight)
+    phase: vec4<f32>, // (phase, phi_radius, phi_blur, phi_opacity)
+    misc: vec4<f32>,  // (cross_axis, style_bit, speed_mult, _)
+};
+
+struct Orbs {
+    // WGSL は配列長にリテラルを要求するため MAX_ORBS const を参照できない。
+    // 64 は上の MAX_ORBS と一致させること。
+    orbs: array<Orb, 64>,
+};
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<uniform> orb_data: Orbs;
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>,
+};
+
+// フルスクリーン三角形（頂点バッファ無し）。crossfade.wgsl と同形。
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VsOut {
+    var xy = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>(3.0, -1.0),
+        vec2<f32>(-1.0, 3.0),
+    );
+    var out: VsOut;
+    out.pos = vec4<f32>(xy[vi], 0.0, 1.0);
+    return out;
+}
+
+fn clampf(x: f32, a: f32, b: f32) -> f32 {
+    return min(max(x, a), b);
+}
+
+// tiny-skia の RadialGradient stop 補間を **bit-exact** に再現する falloff。
+//
+// 返り値 `.x` = straight alpha (0..1)、`.y` = orb 色に掛ける rgb スケール (0..1)。
+// 呼び出し側で straight color = (orb_rgb * .y, .x) を作り、tiny-skia の lowp
+// パイプライン（u8 量子化 → premultiply(div255) → source_over(div255)）で合成する。
+//
+// tiny-skia (lowp) の gradient は **straight color** を stop 間で線形補間し、
+// edge stop が `Color::TRANSPARENT = (0,0,0,0)` なので最外周セグメントでは rgb も
+// alpha も 0 へフェードする。GLSL(orberGl.ts) は rgb 一定の近似だったが、CPU
+// パリティ（±2）には straight-color 補間の再現が必要なので tiny-skia に合わせる。
+//
+//   Rim  stops: [0→(c,center_a), mid_stop→(c,mid_a), 1→(0,0,0,0)]
+//   Soft stops: [0→(c,hold_a),   hold_stop→(c,hold_a), 1→(0,0,0,0)]
+//   - 内側セグメント: rgb 一定（両端 stop の色が同じ orb 色）、alpha のみ補間。
+//   - 最外周セグメント: rgb も alpha も終端へ線形フェード ⇒ rgb_scale=(1-u)。
+//
+// stop alpha は tiny-skia の `Color::from_rgba8` が u8 に量子化する値
+// （center_a = round(opacity*255)/255, mid_a = round(opacity*80)/255）。
+// style_bit < 0.5 が Rim、それ以外が Soft。
+fn falloff_curve(style_bit: f32, r_in: f32, blur: f32, opacity: f32) -> vec2<f32> {
+    if (opacity <= 0.0 || r_in >= 1.0) {
+        return vec2<f32>(0.0, 0.0);
+    }
+    let r = max(r_in, 0.0);
+    if (style_bit < 0.5) {
+        let center_a = floor(opacity * 255.0 + 0.5) / 255.0;
+        let mid_a = floor(opacity * 80.0 + 0.5) / 255.0;
+        let mid_stop = clampf(1.0 - blur * 0.8, 0.05, 0.95);
+        if (r <= mid_stop) {
+            var u = 1.0;
+            if (mid_stop > 0.0) {
+                u = r / mid_stop;
+            }
+            return vec2<f32>(mix(center_a, mid_a, u), 1.0);
+        }
+        let denom = max(1.0 - mid_stop, 1e-6);
+        let u = (r - mid_stop) / denom;
+        return vec2<f32>(mid_a * (1.0 - u), 1.0 - u);
+    }
+    let hold_a = floor(opacity * 255.0 + 0.5) / 255.0;
+    let hold_stop = clampf(1.0 - blur, 0.05, 0.95);
+    if (r <= hold_stop) {
+        return vec2<f32>(hold_a, 1.0);
+    }
+    let denom = max(1.0 - hold_stop, 1e-6);
+    let u = (r - hold_stop) / denom;
+    return vec2<f32>(hold_a * (1.0 - u), 1.0 - u);
+}
+
+// tiny-skia lowp の div255: (v + 255) >> 8 == floor((v + 255) / 256)。
+// 入力 v は u8*u8 積（0..65025 程度）を float で持つ。
+fn div255(v: f32) -> f32 {
+    return floor((v + 255.0) / 256.0);
+}
+
+// straight float (0..1) を tiny-skia の lowp 量子化で u8 (0..255 float) にする。
+// rgb は normalize(clamp 0..1) 後に *255+0.5 を floor。alpha は clamp 無し。
+fn to_u8_rgb(c: f32) -> f32 {
+    return floor(clampf(c, 0.0, 1.0) * 255.0 + 0.5);
+}
+fn to_u8_a(c: f32) -> f32 {
+    return floor(c * 255.0 + 0.5);
+}
+
+// サブピクセル位置 `sample_px` での 1 サンプルを **premultiplied** で合成する。
+// 背景 → 全 orb の Source-Over まで。straight への戻しは呼び出し側で行う。
+fn composite_premul(sample_px: vec2<f32>) -> vec4<f32> {
+    // 進行軸長（LR/RL=width, TB/BT=height）。GLSL: u_direction < 1.5。
+    var progress_axis = params.resolution.y;
+    if (params.direction < 1.5) {
+        progress_axis = params.resolution.x;
+    }
+
+    // アキュムレータは tiny-skia Pixmap と同じ **premultiplied u8 (0..255 float)**。
+    // 背景塗り Pixmap::fill(Color::from_rgba8(...)) は straight 入力を
+    // premultiply(div255(c_u8 * a_u8)) で格納する。
+    let bg_a8 = to_u8_a(params.bg.a);
+    var acc_r = div255(to_u8_rgb(params.bg.r) * bg_a8);
+    var acc_g = div255(to_u8_rgb(params.bg.g) * bg_a8);
+    var acc_b = div255(to_u8_rgb(params.bg.b) * bg_a8);
+    var acc_a8 = bg_a8;
+
+    let count = u32(params.n_orbs + 0.5);
+    let t_frac = fract(params.t);
+
+    for (var i: u32 = 0u; i < MAX_ORBS; i = i + 1u) {
+        if (i >= count) {
+            break;
+        }
+
+        let o = orb_data.orbs[i];
+        let weight = o.color.w;
+        let phase = o.phase.x;
+        let phi_radius = o.phase.y;
+        let phi_blur = o.phase.z;
+        let phi_opacity = o.phase.w;
+        let cross_axis = o.misc.x;
+        let style_bit = o.misc.y; // 0=rim, 1=soft
+        let speed_mult = o.misc.z;
+
+        let r_pixels_max = params.base_radius * sqrt(max(weight, 0.0)) * BREATH_RADIUS_MAX_FACTOR;
+        var r_normalized = 0.0;
+        if (progress_axis > 0.0) {
+            r_normalized = r_pixels_max / progress_axis;
+        }
+        let extent = 1.0 + 2.0 * r_normalized;
+
+        let advance_steps = fract(params.cycle * speed_mult * params.t);
+        let raw = phase * extent + advance_steps * extent;
+        // WGSL の `x - y*floor(x/y)` を mod 相当として使う（負を返さない、
+        // Rust rem_euclid と一致）。GLSL mod() と同義。
+        let pos = (raw - extent * floor(raw / extent)) - r_normalized;
+
+        var nx: f32;
+        var ny: f32;
+        if (params.direction < 0.5) {        // LR
+            nx = pos;
+            ny = cross_axis;
+        } else if (params.direction < 1.5) { // RL
+            nx = 1.0 - pos;
+            ny = cross_axis;
+        } else if (params.direction < 2.5) { // TB
+            nx = cross_axis;
+            ny = pos;
+        } else {                             // BT
+            nx = cross_axis;
+            ny = 1.0 - pos;
+        }
+
+        let radius_factor = 1.0 + 0.10 * sin(TAU * t_frac + phi_radius);
+        let blur_delta = 0.15 * sin(TAU * t_frac + phi_blur);
+        let opacity_factor = 1.0 + 0.05 * sin(TAU * t_frac + phi_opacity);
+
+        let radius = params.base_radius * sqrt(max(weight, 0.0)) * radius_factor;
+        if (radius <= 0.0) {
+            continue;
+        }
+
+        let blur = clampf(params.base_blur + blur_delta, 0.0, 1.0);
+        let opacity = clampf(opacity_factor * params.alpha_mul, 0.0, 1.0);
+
+        let cx = nx * params.resolution.x;
+        let cy = ny * params.resolution.y;
+
+        let dist = distance(sample_px, vec2<f32>(cx, cy));
+        let r = dist / radius;
+        // .x = straight alpha, .y = rgb スケール（外周フェードで rgb も 0 へ）。
+        let fall = falloff_curve(style_bit, r, blur, opacity);
+        let alpha = fall.x;
+
+        if (alpha > 0.0) {
+            // tiny-skia lowp パイプラインを bit-exact に再現:
+            //   1. gradient straight color = (orb_rgb * rgb_scale, alpha) を u8 量子化
+            //   2. premultiply: pr = div255(sr_u8 * sa_u8)
+            //   3. source_over: out = src_premul + div255(dst_premul * (255 - sa_u8))
+            let sr8 = to_u8_rgb(o.color.r * fall.y);
+            let sg8 = to_u8_rgb(o.color.g * fall.y);
+            let sb8 = to_u8_rgb(o.color.b * fall.y);
+            let sa8 = to_u8_a(alpha);
+            let pr = div255(sr8 * sa8);
+            let pg = div255(sg8 * sa8);
+            let pb = div255(sb8 * sa8);
+            let inv_sa = 255.0 - sa8;
+            acc_r = pr + div255(acc_r * inv_sa);
+            acc_g = pg + div255(acc_g * inv_sa);
+            acc_b = pb + div255(acc_b * inv_sa);
+            acc_a8 = sa8 + div255(acc_a8 * inv_sa);
+        }
+    }
+
+    // premultiplied u8 (0..255) を 0..1 で返す。
+    return vec4<f32>(acc_r, acc_g, acc_b, acc_a8) / 255.0;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    // @builtin(position) は既に top-left のピクセル座標（中心 +0.5）。
+    // GLSL の `px.y = H - px.y` 後の px と同じ意味なので flip しない。tiny-skia の
+    // radial gradient は pixel 中心で point sampling される（解析グラデなので
+    // supersample しない方が CPU と一致する）。
+    let pm = composite_premul(in.pos.xy); // premultiplied 0..1
+    let acc_rgb8 = pm.rgb * 255.0;
+    let acc_a8 = pm.a * 255.0;
+
+    // finalize_pixmap 相当: premultiplied u8 → straight に戻す。
+    //   a==0   → rgb=0
+    //   a<255  → straight = round(premul_u8 * 255 / a_u8) （= finalize_pixmap）
+    //   a==255 → premul == straight
+    if (acc_a8 <= 0.0) {
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    }
+    if (acc_a8 >= 255.0) {
+        return vec4<f32>(pm.rgb, 1.0);
+    }
+    let inv = 255.0 / acc_a8;
+    let straight = floor(acc_rgb8 * inv + 0.5) / 255.0;
+    return vec4<f32>(clamp(straight, vec3<f32>(0.0), vec3<f32>(1.0)), acc_a8 / 255.0);
+}


### PR DESCRIPTION
Closes #208（親 #207）

## 概要
orber wgpu 一重化（#207）の **Phase 0 足場**。native CLI に wgpu レンダラを追加し、Circle orb を WGSL で描画して CPU(tiny-skia) と parity を取る。

## 成果
- `crates/core/src/gpu.rs` — `GpuRenderer`（headless adapter、pipeline/per-size リソースキャッシュ、render→copy_texture_to_buffer→map→行パディング除去）+ 6 parity テスト
- `crates/core/src/orb_circle.wgsl` — Circle WGSL（既存 GLSL `web/src/lib/orberGl.ts` の Circle 経路を翻訳、per-orb 算術は `pack_render_data_for_webgl` 再利用）
- `gpu` feature（wgpu29 / pollster / bytemuck、**default OFF**＝wasm32 最小維持）
- CLI `--renderer cpu|gpu`（default gpu + adapter 失敗時 CPU 自動フォールバック、Circle 以外は CPU fallback）

## パリティ
- **最大 channel 差 0**（実 GPU GTX1050Ti）。37×23 / 64×16（行パディング境界の両側）/ 1×1 等 × t∈{0,.25,.5,.75,1} × 4方向
- 1080×1920 E2E: 2.07M px 中 32px のみ差、peak 1/255
- 鍵: GLSL の alpha-only 近似ではなく **tiny-skia の整数パイプライン**（stop-alpha u8 量子化・`div255` premultiply・source-over）に合わせ込んで差を 0 に

## ゲート
- `cargo test -p orber-core --features gpu` ✅ 154 passed（うち parity 6）
- `cargo clippy --workspace --all-targets --features gpu -- -D warnings` ✅ / `cargo fmt --check` ✅
- wasm グラフに wgpu/pollster 不在（`cargo build -p orber-wasm --target wasm32-unknown-unknown` ✅）

## スコープ外（Phase 1）
Glyph / image shape / aquarelle / softness edge(#205) / 回転(#136) / video path の GPU 化。GPU 経路は現状 Circle 以外を CPU fallback。
