### PR TITLE
feat(gpu): Glyph orb を WGSL 化（SDF fill + 回転#136） (Phase 1b)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -491,12 +491,13 @@ fn resolve_motion(cli: &Cli) -> (MotionDirection, MotionSpeed) {
 
 /// 単一フレーム描画のバックエンド。`--renderer` を解決して GPU/CPU を選ぶ (#207)。
 ///
-/// GPU は Circle shape かつ GPU アダプタが取れた場合に使う。count は 1024 まで GPU が
-/// data-texture 経路で直接描く（#210 Phase 1a で 64 制限を撤去）。それ以外（非 Circle、
-/// アダプタ無し、`gpu` feature 無しビルド）は CPU にフォールバックする。GPU が担う経路
-/// （Circle ∧ saturation 反映済）では出力が CPU オラクルと ±2/channel（実 GPU では
-/// bit-exact）一致するので、フォールバックしても同じ flag では見た目が変わらない。
-/// video や color/keyframe tracks は GPU pack 未対応で CPU 専用。
+/// GPU は Circle / Glyph shape かつ GPU アダプタが取れた場合に使う。count は 1024 まで
+/// GPU が data-texture 経路で直接描く（#210 Phase 1a で 64 制限を撤去）。Glyph は #212
+/// Phase 1b で WGSL 化（SDF fill + 回転）。aquarelle 等の他 shape、アダプタ無し、`gpu`
+/// feature 無しビルドは CPU にフォールバックする。Circle 経路は CPU オラクルと
+/// ±2/channel（実 GPU では bit-exact）一致。Glyph は CPU の bleed 前塗りと構造一致だが、
+/// per-frame の aquarelle bleed pass は当面 CPU 専用（既知の見た目差）。video や
+/// color/keyframe tracks も GPU pack 未対応で CPU 専用。
 enum FrameRenderer {
     Cpu,
     #[cfg(feature = "gpu")]
@@ -528,7 +529,7 @@ impl FrameRenderer {
             }
             RenderRoute::Cpu(None) => FrameRenderer::Cpu,
             // GPU が選ばれても、アダプタ取得失敗 / feature 無しなら最終的に CPU に落ちる。
-            RenderRoute::Gpu => Self::select_gpu_circle(),
+            RenderRoute::Gpu => Self::select_gpu(),
         }
     }
 
@@ -540,18 +541,22 @@ impl FrameRenderer {
         match choice {
             Renderer::Cpu => RenderRoute::Cpu(None),
             Renderer::Gpu => {
-                if shape != OrbShape::Circle {
-                    return RenderRoute::Cpu(Some(
-                        "orber: --renderer gpu は Phase 0 で Circle のみ対応。非 Circle shape のため cpu にフォールバックします".to_string(),
-                    ));
+                // Circle (#210) and Glyph (#212 Phase 1b) render in WGSL. Glyph
+                // matches the CPU pre-bleed fill (the per-frame aquarelle bleed
+                // pass is CPU-only for now, a known visual difference). Aquarelle
+                // and any other shape still fall back to the CPU renderer.
+                match shape {
+                    OrbShape::Circle | OrbShape::Glyph { .. } => RenderRoute::Gpu,
+                    _ => RenderRoute::Cpu(Some(
+                        "orber: --renderer gpu は Circle / Glyph のみ対応。aquarelle 等のため cpu にフォールバックします".to_string(),
+                    )),
                 }
-                RenderRoute::Gpu
             }
         }
     }
 
     #[cfg(feature = "gpu")]
-    fn select_gpu_circle() -> Self {
+    fn select_gpu() -> Self {
         match orber_core::gpu::GpuRenderer::new() {
             Some(gpu) => {
                 eprintln!(
@@ -568,14 +573,14 @@ impl FrameRenderer {
     }
 
     #[cfg(not(feature = "gpu"))]
-    fn select_gpu_circle() -> Self {
+    fn select_gpu() -> Self {
         eprintln!(
             "orber: この orber は gpu feature 無しでビルドされています。cpu にフォールバックします"
         );
         FrameRenderer::Cpu
     }
 
-    /// 1 フレームを描画する。GPU 経路は Circle のみ（select で保証済み）。
+    /// 1 フレームを描画する。GPU 経路は Circle / Glyph（select / route で保証済み）。
     fn render(
         &self,
         clusters: &[Cluster],
@@ -585,7 +590,13 @@ impl FrameRenderer {
         match self {
             FrameRenderer::Cpu => orber_core::animate::render_frame(clusters, opts, t),
             #[cfg(feature = "gpu")]
-            FrameRenderer::Gpu(gpu) => gpu.render_frame(clusters, opts, t),
+            FrameRenderer::Gpu(gpu) => match opts.shape {
+                // Glyph uses the dedicated WGSL glyph path (#212); Circle the
+                // default. (Aquarelle never reaches the GPU branch — `route`
+                // sends it to the CPU renderer.)
+                OrbShape::Glyph { .. } => gpu.render_frame_glyph(clusters, opts, t),
+                _ => gpu.render_frame(clusters, opts, t),
+            },
         }
     }
 }
@@ -1344,12 +1355,13 @@ mod tests {
         );
     }
 
-    /// C2 (#210): 非 Circle shape の CPU フォールバック（理由つき）は温存する。
-    /// #210 は count による分岐だけを撤去した。route が count 引数を失っても、
-    /// --renderer gpu + 非 Circle は今まで通り `Cpu(Some(非 Circle 文言))` に落ちる。
-    /// あわせて --renderer cpu は理由なし `Cpu(None)` のままであることも確認する。
+    /// C2 (#210 → #212): Aquarelle（および将来の非 Circle/非 Glyph shape）は GPU 要求でも
+    /// 理由つき CPU フォールバックを温存する。#212 で Glyph が GPU 経路に乗ったので、
+    /// route(Gpu, Glyph) は `Gpu` になることもあわせて確認する。
+    /// --renderer cpu は理由なし `Cpu(None)` のまま。
     #[test]
-    fn gpu_route_falls_back_for_non_circle_unchanged() {
+    fn gpu_route_falls_back_for_aquarelle_but_not_glyph() {
+        // Aquarelle は CPU フォールバック（理由つき）。
         match FrameRenderer::route(
             Renderer::Gpu,
             OrbShape::Aquarelle(AquarelleParams {
@@ -1361,12 +1373,25 @@ mod tests {
         ) {
             RenderRoute::Cpu(Some(msg)) => {
                 assert!(
-                    msg.contains("Circle"),
-                    "non-Circle fallback message should mention the Circle-only limitation, got: {msg}"
+                    msg.contains("aquarelle") || msg.contains("Circle"),
+                    "aquarelle fallback message should explain the limitation, got: {msg}"
                 );
             }
-            other => panic!("non-Circle shape with gpu must route to Cpu(Some(_)), got {other:?}"),
+            other => panic!("aquarelle + gpu must route to Cpu(Some(_)), got {other:?}"),
         }
+
+        // Glyph (#212) は GPU 経路に乗る（フォールバック文言なし）。
+        assert_eq!(
+            FrameRenderer::route(
+                Renderer::Gpu,
+                OrbShape::Glyph {
+                    ch: '☆',
+                    font: GlyphFontId::NotoSymbols2,
+                },
+            ),
+            RenderRoute::Gpu,
+            "glyph + gpu must route to the gpu path (#212)"
+        );
 
         // --renderer cpu は理由なしで CPU（明示指定なので警告は出さない）。
         assert_eq!(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1546,4 +1546,109 @@ mod tests {
         assert!(try_parse(&["--aquarelle-offset", "0.7"]).is_ok());
         assert!(try_parse(&["--aquarelle-halo", "0.0"]).is_ok());
     }
+
+    /// #212 (#11): `FrameRenderer::Gpu::render()` must dispatch by `opts.shape` —
+    /// Glyph opts go to `render_frame_glyph`, Circle opts to `render_frame`. This
+    /// pins the `render()` match arm (main.rs) that picks the GPU sub-path: the two
+    /// sub-paths produce visibly different images for the same parameters (a star
+    /// SDF fill vs round orbs), so the dispatch is observable.
+    ///
+    /// GPU-gated and GPU-required-aware: with `ORBER_REQUIRE_GPU=1` a missing
+    /// adapter is a hard failure (matching the core parity tests); otherwise it
+    /// SKIPs. Default multi-threaded `cargo test --features gpu` exercises it.
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn frame_renderer_render_dispatches_glyph_vs_circle() {
+        use orber_core::cluster::{Centroid, Cluster};
+        use orber_core::gpu::GpuRenderer;
+
+        let what = "frame_renderer_render_dispatches_glyph_vs_circle";
+        let Some(gpu) = GpuRenderer::new() else {
+            if std::env::var("ORBER_REQUIRE_GPU").as_deref() == Ok("1") {
+                panic!("{what}: ORBER_REQUIRE_GPU=1 but no GPU adapter available");
+            }
+            eprintln!("SKIP {what}: no GPU adapter available");
+            return;
+        };
+        eprintln!("{what} running on adapter: {}", gpu.adapter_name());
+
+        let clusters = vec![
+            Cluster {
+                color: [220, 60, 60],
+                centroid: Centroid { x: 0.3, y: 0.4 },
+                weight: 0.5,
+            },
+            Cluster {
+                color: [60, 120, 220],
+                centroid: Centroid { x: 0.7, y: 0.6 },
+                weight: 0.3,
+            },
+            Cluster {
+                color: [200, 200, 80],
+                centroid: Centroid { x: 0.5, y: 0.2 },
+                weight: 0.2,
+            },
+        ];
+
+        // Shared parameters; only `shape` differs between the two cases.
+        let base = AnimateOptions {
+            width: 96,
+            height: 72,
+            orb_size: 1.0,
+            blur: 0.5,
+            saturation: 1.0,
+            direction: MotionDirection::LeftToRight,
+            speed: MotionSpeed::Slow,
+            seed: 7,
+            count: Some(6),
+            background: [10, 12, 20, 255],
+            shape: OrbShape::Circle,
+            softness: SoftnessPreset::Mid,
+            glyph_rotate: true,
+            color_tracks: None,
+            keyframe_tracks: None,
+        };
+
+        let glyph_opts = AnimateOptions {
+            shape: OrbShape::Glyph {
+                ch: '☆',
+                font: GlyphFontId::NotoSymbols2,
+            },
+            ..base.clone()
+        };
+
+        // Reference sub-path outputs computed directly off the GpuRenderer.
+        let glyph_ref = gpu.render_frame_glyph(&clusters, &glyph_opts, 0.0);
+        let circle_ref_for_glyph_params = gpu.render_frame(&clusters, &glyph_opts, 0.0);
+        let circle_ref = gpu.render_frame(&clusters, &base, 0.0);
+
+        // Sanity: the two GPU sub-paths really differ for these glyph params, so the
+        // dispatch assertion below is meaningful (not trivially satisfied).
+        assert_ne!(
+            glyph_ref, circle_ref_for_glyph_params,
+            "glyph and circle GPU sub-paths must differ for the same params \
+             (otherwise the dispatch test proves nothing)"
+        );
+
+        let renderer = FrameRenderer::Gpu(Box::new(gpu));
+
+        // Glyph opts → render() must equal the glyph sub-path, not the circle one.
+        let glyph_dispatched = renderer.render(&clusters, &glyph_opts, 0.0);
+        assert_eq!(
+            glyph_dispatched, glyph_ref,
+            "FrameRenderer::render must dispatch Glyph opts to render_frame_glyph"
+        );
+        assert_ne!(
+            glyph_dispatched, circle_ref_for_glyph_params,
+            "FrameRenderer::render must NOT send Glyph opts to the circle render_frame"
+        );
+
+        // Circle opts → render() must equal the circle sub-path.
+        let circle_dispatched = renderer.render(&clusters, &base, 0.0);
+        assert_eq!(
+            circle_dispatched, circle_ref,
+            "FrameRenderer::render must dispatch Circle opts to render_frame"
+        );
+        eprintln!("{what}: glyph→glyph, circle→circle dispatch confirmed");
+    }
 }

--- a/crates/core/src/animate.rs
+++ b/crates/core/src/animate.rs
@@ -1270,6 +1270,53 @@ mod tests {
         }
     }
 
+    /// #212: WGSL の turns 式 `x - floor(x)` は Rust の `rem_euclid(x, 1.0)` と
+    /// 一致しなければならない。`orb_glyph.wgsl::glyph_rotation_angle` は
+    /// `turns = x - floor(x)` で turns を出すが、CPU 側 `glyph_rotation_angle` は
+    /// `rem_euclid(1.0)` を使う。両者は **負の speed** で wrap の挙動が割れやすい
+    /// （`rem_euclid` は非負を返す一方、素朴な `%` は負を返しうる）。WGSL の式を
+    /// Rust に移植し、cycle∈1..=4 × 複数 t × **符号付き speed（負を含む）**で
+    /// CPU 実装と完全一致することを assert し、回転角が WGSL と CPU で乖離しない
+    /// ことを固定する。`floor` 版は 1.0 が正なので負入力でも非負 turns を返し、
+    /// `rem_euclid` と一致するのが期待値。
+    #[test]
+    fn wgsl_glyph_rotation_angle_matches_rust_rem_euclid() {
+        // orb_glyph.wgsl の turns 式（`let x = cycle * rot_speed_signed * t;
+        // let turns = x - floor(x);`）をそのまま Rust に移植したもの。
+        fn wgsl_turns(cycle: u32, rot_speed_signed: f32, t: f32) -> f32 {
+            let x = cycle as f32 * rot_speed_signed * t;
+            x - x.floor()
+        }
+
+        // base_angle を載せた WGSL 側の最終角（`base_angle + turns * TAU`）。
+        fn wgsl_angle(cycle: u32, t: f32, base_angle: f32, rot_speed_signed: f32) -> f32 {
+            base_angle + wgsl_turns(cycle, rot_speed_signed, t) * TAU
+        }
+
+        // 符号付き speed: 正・負の両方を直接ピンする（負速度の wrap 乖離を狙う）。
+        let base_angles = [0.0_f32, 0.3, 1.7, std::f32::consts::PI];
+        let speeds = [-2.0_f32, -1.0, -0.5, 0.5, 1.0, 2.0, 3.0];
+        let times = [0.0_f32, 0.1, 0.25, 0.4999, 0.5, 0.7777, 0.9, 1.0];
+        for cycle in 1u32..=4 {
+            for &base_angle in &base_angles {
+                for &speed in &speeds {
+                    for &t in &times {
+                        // CPU 実装（rem_euclid(_, 1.0)）。glyph_rotate=true。
+                        let rust = glyph_rotation_angle(cycle, t, base_angle, speed, true);
+                        // WGSL 移植（x - floor(x)）。
+                        let wgsl = wgsl_angle(cycle, t, base_angle, speed);
+                        assert!(
+                            (rust - wgsl).abs() < 1e-5,
+                            "WGSL turns (x - floor(x)) must match Rust rem_euclid(_, 1.0): \
+                             cycle={cycle} base={base_angle} speed={speed} t={t} \
+                             rust={rust} wgsl={wgsl}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
     fn glyph_rotation_does_not_perturb_legacy_rng_sequence() {
         let seed = 42;

--- a/crates/core/src/glyph.rs
+++ b/crates/core/src/glyph.rs
@@ -331,6 +331,36 @@ fn cached_glyph_sdf(font: GlyphFontId, ch: char, size: u32) -> Arc<[u8]> {
     sdf
 }
 
+/// GPU (#212) entry point: return the cached SDF bytes **and** the chosen square
+/// size for an orb of pixel `radius`, picking the same size the CPU
+/// [`render_glyph_orb`] would (`glyph_sdf_size_for_radius`). The GPU path uploads
+/// these bytes as an `R8Unorm` texture and samples them with a bilinear sampler,
+/// exactly mirroring the CPU `sample_sdf_bilinear` so the two fills agree
+/// (pre-bleed) within a loose tolerance.
+///
+/// Returns `None` for a non-positive radius or an unknown/empty glyph (all-zero
+/// SDF), so the caller can skip GPU glyph upload and leave the frame
+/// background-only — matching the CPU "draw nothing for tofu" contract.
+pub fn cached_glyph_sdf_for_radius(
+    font: GlyphFontId,
+    ch: char,
+    radius: f32,
+) -> Option<(Arc<[u8]>, u32)> {
+    if radius <= 0.0 {
+        return None;
+    }
+    let size = glyph_sdf_size_for_radius(radius);
+    let sdf = cached_glyph_sdf(font, ch, size);
+    if sdf.iter().all(|&b| b == 0) {
+        return None;
+    }
+    Some((sdf, size))
+}
+
+/// The glyph SDF content-span constant (`1/√2`), exposed for the GPU shader so the
+/// UV mapping in `orb_glyph.wgsl` matches the CPU `render_glyph_orb` exactly.
+pub const GLYPH_SDF_CONTENT_SPAN_PUB: f32 = GLYPH_SDF_CONTENT_SPAN;
+
 #[inline]
 fn glyph_sdf_size_for_radius(radius: f32) -> u32 {
     if radius <= 0.0 {

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -67,6 +67,11 @@ use crate::orb::adjust_saturation_pub;
 
 /// Bytes per pixel for `Rgba8Unorm`.
 const BYTES_PER_PIXEL: u32 = 4;
+
+/// Upper bound of the radius breath factor (`1.0 + 0.10`), mirroring
+/// `animate::BREATH_RADIUS_MAX_FACTOR` / the WGSL constant. Used only to size the
+/// glyph SDF for the frame from the largest possible orb radius.
+const BREATH_RADIUS_MAX_FACTOR: f32 = 1.10;
 /// wgpu requires `bytes_per_row` of a texture→buffer copy to be a multiple of
 /// this (`COPY_BYTES_PER_ROW_ALIGNMENT`). This applies to the read-back
 /// (texture→buffer) only — `write_texture` (buffer/CPU→texture) is exempt, so the
@@ -74,11 +79,14 @@ const BYTES_PER_PIXEL: u32 = 4;
 const ROW_ALIGNMENT: u32 = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
 
 /// Width, in texels, of the per-orb data-texture: one texel each for the color,
-/// phase, and misc `vec4`s (see `orb_circle.wgsl::load_orb`).
-const ORB_TEX_WIDTH: u32 = 3;
+/// phase, misc, and rotation `vec4`s (see `orb_circle.wgsl::load_orb` /
+/// `orb_glyph.wgsl::load_orb`). Widened 3→4 in Phase 1b (#212) so the Glyph
+/// shader can read the per-orb rotation (`base_angle`, `rot_speed_signed`); the
+/// Circle shader ignores texel x=3 and stays bit-exact.
+const ORB_TEX_WIDTH: u32 = 4;
 /// Bytes per texel of the `Rgba32Float` orb data-texture (4 × f32).
 const ORB_TEX_BYTES_PER_TEXEL: u32 = 16;
-/// Bytes per row of the orb data-texture (`3 × 16 = 48`). `write_texture` has no
+/// Bytes per row of the orb data-texture (`4 × 16 = 64`). `write_texture` has no
 /// row-alignment requirement, so this tight value is used as-is.
 const ORB_TEX_BYTES_PER_ROW: u32 = ORB_TEX_WIDTH * ORB_TEX_BYTES_PER_TEXEL;
 
@@ -93,6 +101,14 @@ const PER_ORB_WORDS: usize = 16;
 /// The `&'static str` doubles as a stable cache key for the pipeline cache.
 fn orb_circle_wgsl() -> &'static str {
     include_str!("orb_circle.wgsl")
+}
+
+/// The Glyph orb WGSL (#212 Phase 1b). Same data-texture orb layout as the Circle
+/// shader, plus an `R8Unorm` glyph SDF texture + bilinear sampler (bindings 2/3),
+/// and reads the per-orb rotation texel (x=3). It reproduces the CPU
+/// `glyph::render_glyph_orb` fill (pre-bleed), not the WebGL mask×profile arm.
+fn orb_glyph_wgsl() -> &'static str {
+    include_str!("orb_glyph.wgsl")
 }
 
 /// Header uniform block handed to the Circle shader. Mirrors `struct Params` in
@@ -112,24 +128,41 @@ struct Params {
     direction: f32,
     cycle: f32,
     n_orbs: f32,
-    // row 3: alpha_mul + padding
+    // row 3: alpha_mul, glyph_rotate, edge_softness, padding
     alpha_mul: f32,
-    _pad0: f32,
-    _pad1: f32,
-    _pad2: f32,
+    /// Glyph rotation toggle (#136): `1.0` = animate per-orb rotation, `0.0` =
+    /// hold `base_angle`. Circle ignores this. Lives in the former padding so the
+    /// uniform buffer size is unchanged (Circle's WGSL `Params` struct stays
+    /// valid; it simply names the slots `_pad0`/`_pad1`).
+    glyph_rotate: f32,
+    /// Glyph edge softness (#205): unused by the current Glyph fill (it uses
+    /// `falloff_curve` like the CPU `render_glyph_orb`), reserved for the future
+    /// SDF-mask path; kept so the header layout mirrors the WebGL one.
+    edge_softness: f32,
+    /// Glyph SDF square side in texels. The Glyph shader uses it to reproduce the
+    /// CPU `sample_sdf_bilinear` convention (`coord = u*(size-1)`) when remapping
+    /// UVs to the wgpu sampler's texel space. Circle ignores this slot (its WGSL
+    /// `Params` names it `_pad2`). `0.0` for the Circle path.
+    sdf_size: f32,
 }
 
-/// One orb as the Circle shader sees it: three `vec4`s mirroring `struct Orb` in
-/// `orb_circle.wgsl` (color+weight, phase quartet, misc). Filled from the
-/// `pack_render_data_for_webgl` per-orb words. One `GpuOrb` packs to one row of
-/// the `Rgba32Float` orb data-texture (3 texels = 48 bytes); the shader reads it
-/// back with three `textureLoad`s.
+/// One orb as the shaders see it: four `vec4`s mirroring `struct Orb` in
+/// `orb_circle.wgsl` / `orb_glyph.wgsl` (color+weight, phase quartet, misc,
+/// rotation). Filled from the `pack_render_data_for_webgl` per-orb words. One
+/// `GpuOrb` packs to one row of the `Rgba32Float` orb data-texture (4 texels =
+/// 64 bytes); the shader reads it back with `textureLoad`s.
+///
+/// The Circle shader reads only `color` / `phase` / `misc` (texels x=0..2) and
+/// ignores `rot` (x=3), so widening the row to 4 texels leaves Circle output
+/// bit-exact. The Glyph shader additionally reads `rot = (base_angle,
+/// rot_speed_signed, _, _)` for #136 rotation.
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct GpuOrb {
     color: [f32; 4], // r, g, b, weight
     phase: [f32; 4], // phase, phi_radius, phi_blur, phi_opacity
     misc: [f32; 4],  // cross_axis, style_bit, speed_mult, _
+    rot: [f32; 4],   // base_angle, rot_speed_signed, _, _
 }
 
 /// A render pipeline plus its bind-group layout, compiled once per distinct
@@ -163,6 +196,23 @@ struct OrbTexture {
     view: wgpu::TextureView,
 }
 
+/// A single glyph's SDF uploaded as an `R8Unorm` texture (square `size × size`),
+/// cached per `(char, size)` so a video reuses the upload across frames. `R8Unorm`
+/// is chosen because it is **linear-filterable on the wgpu WebGL2 backend**
+/// (unlike `Rgba32Float`), so the Glyph shader can read it with a real bilinear
+/// `sampler` and stay portable to Phase 2 (#212).
+struct GlyphSdfTexture {
+    view: wgpu::TextureView,
+}
+
+/// The glyph SDF binding passed into `render_packed_inner` for the Glyph path:
+/// the (cached) SDF texture view and its square side in texels. `None` selects
+/// the Circle path instead.
+struct GlyphBindings<'a> {
+    sdf_view: &'a wgpu::TextureView,
+    size: u32,
+}
+
 /// Headless wgpu renderer for the Circle orb path. Holds a device/queue plus a
 /// per-shader pipeline cache and a per-size resource cache, so a multi-frame
 /// render (a long `--duration-ms` video) compiles the shader and allocates the
@@ -188,6 +238,13 @@ pub struct GpuRenderer {
     /// The grow-only per-orb data-texture (reallocated only when a frame needs
     /// more rows than the cached capacity). `None` until the first frame.
     orb_texture: std::sync::Mutex<Option<OrbTexture>>,
+    /// Glyph SDF textures keyed by `(char as u32, size)`. Grow-only (never
+    /// evicts): a clip renders one glyph at one size, so this holds a single
+    /// entry; supporting several glyphs in one clip just adds entries.
+    glyph_sdf_cache: std::sync::Mutex<HashMap<(u32, u32), GlyphSdfTexture>>,
+    /// The bilinear (linear/linear, clamp-to-edge) sampler the Glyph shader uses
+    /// to read the `R8Unorm` SDF. Built once; reused for every glyph frame.
+    glyph_sampler: wgpu::Sampler,
     /// Serializes the whole GPU side of [`Self::render_packed`] (orb/params
     /// upload → pass record → `queue.submit` → map/readback) so concurrent
     /// `render_frame` calls on one shared renderer cannot alias the shared cached
@@ -225,6 +282,19 @@ impl GpuRenderer {
             })
             .await
             .ok()?;
+        // Bilinear, clamp-to-edge sampler for the glyph SDF. Clamp-to-edge mirrors
+        // the CPU `sample_sdf_bilinear` neighbor clamp (`x1 = (x0+1).min(size-1)`),
+        // and linear min/mag gives the 2×2 lerp the CPU does by hand.
+        let glyph_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("orber-glyph-sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            ..Default::default()
+        });
         Some(Self {
             device,
             queue,
@@ -232,6 +302,8 @@ impl GpuRenderer {
             pipeline_cache: std::sync::Mutex::new(HashMap::new()),
             sized_cache: std::sync::Mutex::new(HashMap::new()),
             orb_texture: std::sync::Mutex::new(None),
+            glyph_sdf_cache: std::sync::Mutex::new(HashMap::new()),
+            glyph_sampler,
             render_guard: std::sync::Mutex::new(()),
         })
     }
@@ -274,46 +346,59 @@ impl GpuRenderer {
     /// Get-or-build the Circle pipeline for `shader_wgsl`, compiling the shader and
     /// pipeline only on first use. The closure runs at most once per distinct
     /// shader source for the life of the renderer.
-    fn pipeline<R>(&self, shader_wgsl: &str, f: impl FnOnce(&CachedPipeline) -> R) -> R {
+    fn pipeline<R>(
+        &self,
+        shader_wgsl: &str,
+        glyph: bool,
+        f: impl FnOnce(&CachedPipeline) -> R,
+    ) -> R {
         let mut cache = self
             .pipeline_cache
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let entry = cache
             .entry(shader_wgsl.to_owned())
-            .or_insert_with(|| self.build_pipeline(shader_wgsl));
+            .or_insert_with(|| self.build_pipeline(shader_wgsl, glyph));
         f(entry)
     }
 
-    /// Compile the Circle pipeline (binding 0 = `Params` uniform, binding 1 = orb
-    /// data-texture). The orb texture is `Rgba32Float`, sampled with `filterable:
-    /// false` and read via `textureLoad` (no sampler) so the path never depends on
-    /// linear filtering and stays portable to wgpu's WebGL2 backend (#210).
-    fn build_pipeline(&self, shader_wgsl: &str) -> CachedPipeline {
+    /// Compile a pipeline for `shader_wgsl`. The Circle pipeline has binding 0 =
+    /// `Params` uniform, binding 1 = orb data-texture (`Rgba32Float`, read via
+    /// `textureLoad`, `filterable: false`). The Glyph pipeline (`glyph = true`)
+    /// additionally has binding 2 = glyph SDF (`R8Unorm`, `filterable: true`) and
+    /// binding 3 = a filtering sampler, so the shader can bilinear-sample the SDF.
+    /// The orb texture stays `textureLoad`-only either way, keeping the path
+    /// portable to wgpu's WebGL2 backend (#210/#212).
+    fn build_pipeline(&self, shader_wgsl: &str, glyph: bool) -> CachedPipeline {
         let format = wgpu::TextureFormat::Rgba8Unorm;
+        let mut entries = vec![uniform_entry(0), orb_texture_entry(1)];
+        if glyph {
+            entries.push(glyph_sdf_texture_entry(2));
+            entries.push(glyph_sampler_entry(3));
+        }
         let bind_group_layout =
             self.device
                 .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                    label: Some("orber-circle-bgl"),
-                    entries: &[uniform_entry(0), orb_texture_entry(1)],
+                    label: Some("orber-orb-bgl"),
+                    entries: &entries,
                 });
         let shader = self
             .device
             .create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("orber-circle-shader"),
+                label: Some("orber-orb-shader"),
                 source: wgpu::ShaderSource::Wgsl(shader_wgsl.into()),
             });
         let pipeline_layout = self
             .device
             .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("orber-circle-pl"),
+                label: Some("orber-orb-pl"),
                 bind_group_layouts: &[Some(&bind_group_layout)],
                 immediate_size: 0,
             });
         let pipeline = self
             .device
             .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("orber-circle-pipeline"),
+                label: Some("orber-orb-pipeline"),
                 layout: Some(&pipeline_layout),
                 vertex: wgpu::VertexState {
                     module: &shader,
@@ -401,12 +486,12 @@ impl GpuRenderer {
     }
 
     /// Upload the per-orb data into the grow-only `Rgba32Float` data-texture and
-    /// return a view to bind. The texture is 3 texels wide (color / phase / misc)
-    /// × `orbs.len()` tall; it is reallocated only when the orb count exceeds the
-    /// cached capacity, then `write_texture` fills the live rows each frame.
+    /// return a view to bind. The texture is 4 texels wide (color / phase / misc /
+    /// rot) × `orbs.len()` tall; it is reallocated only when the orb count exceeds
+    /// the cached capacity, then `write_texture` fills the live rows each frame.
     ///
     /// `write_texture` has no 256-byte row-alignment requirement (that is only for
-    /// buffer→texture copies), so the tight `ORB_TEX_BYTES_PER_ROW` (48) is used.
+    /// buffer→texture copies), so the tight `ORB_TEX_BYTES_PER_ROW` (64) is used.
     fn upload_orb_texture(&self, orbs: &[GpuOrb]) -> wgpu::TextureView {
         let rows = orbs.len().max(1) as u32;
         let mut guard = self
@@ -422,8 +507,8 @@ impl GpuRenderer {
         }
         let tex = guard.as_ref().expect("orb texture just ensured present");
 
-        // `write_texture` reads exactly `rows × 3 × 16` bytes from `orbs`, which is
-        // `bytemuck`-castable to a flat `&[u8]` (GpuOrb is 3 × vec4<f32> = 48 bytes,
+        // `write_texture` reads exactly `rows × 4 × 16` bytes from `orbs`, which is
+        // `bytemuck`-castable to a flat `&[u8]` (GpuOrb is 4 × vec4<f32> = 64 bytes,
         // matching one texel row).
         self.queue.write_texture(
             wgpu::TexelCopyTextureInfo {
@@ -447,12 +532,12 @@ impl GpuRenderer {
         tex.view.clone()
     }
 
-    /// Allocate the per-orb data-texture sized for `capacity` orbs (3 texels wide).
+    /// Allocate the per-orb data-texture sized for `capacity` orbs (4 texels wide).
     /// `usage = TEXTURE_BINDING | COPY_DST` (sampled in the shader, written via
     /// `write_texture`). No `RENDER_ATTACHMENT` / `COPY_SRC` — it is input only.
     fn build_orb_texture(&self, capacity: u32) -> OrbTexture {
         let texture = self.device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("orber-circle-orb-tex"),
+            label: Some("orber-orb-tex"),
             size: wgpu::Extent3d {
                 width: ORB_TEX_WIDTH,
                 height: capacity,
@@ -471,6 +556,61 @@ impl GpuRenderer {
             texture,
             view,
         }
+    }
+
+    /// Get-or-upload the glyph `sdf` (`size × size`, one byte per texel, 128≈edge)
+    /// as an `R8Unorm` texture and return a view to bind, cached per `(ch, size)`.
+    /// The cache is grow-only (mirrors the other caches): one glyph at one size
+    /// keeps a single entry across a whole clip.
+    ///
+    /// `R8Unorm` rows are 1 byte/texel; `write_texture` is exempt from the 256-byte
+    /// row-alignment requirement (that is buffer→texture only), so the tight `size`
+    /// bytes-per-row is used as-is.
+    fn upload_glyph_sdf(&self, ch: char, size: u32, sdf: &[u8]) -> wgpu::TextureView {
+        let key = (ch as u32, size);
+        let mut cache = self
+            .glyph_sdf_cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(tex) = cache.get(&key) {
+            return tex.view.clone();
+        }
+        let texture = self.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("orber-glyph-sdf-tex"),
+            size: wgpu::Extent3d {
+                width: size,
+                height: size,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::R8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        self.queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            sdf,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(size),
+                rows_per_image: Some(size),
+            },
+            wgpu::Extent3d {
+                width: size,
+                height: size,
+                depth_or_array_layers: 1,
+            },
+        );
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        cache.insert(key, GlyphSdfTexture { view: view.clone() });
+        view
     }
 
     /// Render one Circle frame at time `t` from `clusters` + `opts`, matching
@@ -550,13 +690,152 @@ impl GpuRenderer {
         self.render_packed(&pack, width, height, t)
     }
 
-    /// Render one Circle frame from a raw `pack_render_data_for_webgl` buffer.
+    /// Render one **Glyph** frame at time `t` from `clusters` + `opts`, matching
+    /// the CPU [`crate::glyph::render_glyph_orb`] fill (#212 Phase 1b).
+    ///
+    /// `opts.shape` must be [`OrbShape::Glyph`]; the glyph `ch` / `font` select the
+    /// SDF. The per-orb arithmetic reuses [`pack_render_data_for_webgl`] (so
+    /// positions / radii / rotation match the CPU path), saturation is re-applied
+    /// per orb like the CPU oracle, the glyph SDF is uploaded as an `R8Unorm`
+    /// texture, and the Glyph shader bilinear-samples it and fills with
+    /// `falloff_curve(1 - signed_unit)`.
+    ///
+    /// # Parity scope (loose — bleed is excluded)
+    ///
+    /// The CPU `render_frame` applies a per-frame aquarelle **bleed pass** after
+    /// the glyph fill (#195); this GPU path renders only the **pre-bleed** fill.
+    /// So lit coverage / edge position / softness response / rotation match the CPU
+    /// within a loose tolerance, but bleed-derived halo differences are expected and
+    /// allowed (a separate slice will add the bleed pass).
+    ///
+    /// Returns a background-only frame (no glyph fill) when the glyph is unknown /
+    /// empty in the bundled font, mirroring the CPU "draw nothing for tofu"
+    /// contract.
+    pub fn render_frame_glyph(
+        &self,
+        clusters: &[Cluster],
+        opts: &AnimateOptions,
+        t: f32,
+    ) -> RgbaImage {
+        let width = opts.width.max(1);
+        let height = opts.height.max(1);
+        let t = t.clamp(0.0, 1.0);
+
+        let (ch, font) = match opts.shape {
+            crate::orb::OrbShape::Glyph { ch, font } => (ch, font),
+            // Not a glyph shape: fall back to the Circle path so the call is total.
+            _ => return self.render_frame(clusters, opts, t),
+        };
+
+        let base_radius_unit = (width.min(height) as f32) * 0.25 * opts.orb_size.max(0.0);
+        let base_blur = (opts.blur + opts.softness.blur_offset()).clamp(0.0, 1.0);
+        let alpha_mul = opts.softness.alpha_mul().clamp(0.0, 1.0);
+        let direction_id: f32 = match opts.direction {
+            MotionDirection::LeftToRight => 0.0,
+            MotionDirection::RightToLeft => 1.0,
+            MotionDirection::TopToBottom => 2.0,
+            MotionDirection::BottomToTop => 3.0,
+        };
+        let cycle = opts.speed.cycle_count() as f32;
+        let n_orbs = opts
+            .count
+            .unwrap_or(clusters.len())
+            .min(MAX_ORB_COUNT)
+            .max(if clusters.is_empty() { 0 } else { 1 });
+
+        // SDF size: the CPU picks one per orb from its breath radius; the GPU binds
+        // one SDF for the frame, so size it from the *largest* orb radius (max
+        // weight × the breath max factor) so most orbs sample at or above the size
+        // the CPU used — bilinear sampling then matches closely.
+        let max_weight = clusters
+            .iter()
+            .map(|c| c.weight.max(0.0))
+            .fold(0.0_f32, f32::max);
+        let frame_radius = base_radius_unit * max_weight.sqrt() * BREATH_RADIUS_MAX_FACTOR;
+
+        // No glyph (radius 0 / unknown char / empty SDF) ⇒ background-only frame,
+        // matching the CPU "draw nothing" contract. Build a glyph-shaped pack with
+        // zero orbs so only the background paints.
+        let Some((sdf, sdf_size)) =
+            crate::glyph::cached_glyph_sdf_for_radius(font, ch, frame_radius)
+        else {
+            let pack = pack_render_data_for_webgl(
+                clusters,
+                opts.background,
+                base_radius_unit,
+                base_blur,
+                direction_id,
+                cycle,
+                opts.seed,
+                0, // no orbs → background only
+                alpha_mul,
+                1.0, // shape_id = Glyph
+                opts.glyph_rotate,
+                opts.softness.edge_softness(),
+            );
+            return self.render_packed(&pack, width, height, t);
+        };
+
+        let mut pack = pack_render_data_for_webgl(
+            clusters,
+            opts.background,
+            base_radius_unit,
+            base_blur,
+            direction_id,
+            cycle,
+            opts.seed,
+            n_orbs,
+            alpha_mul,
+            1.0, // shape_id = Glyph
+            opts.glyph_rotate,
+            opts.softness.edge_softness(),
+        );
+        // CPU glyph path applies per-orb saturation too (`render_frame_with_params`
+        // calls `adjust_saturation_pub(color_at_t, saturation)` before drawing).
+        apply_saturation_to_pack(&mut pack, opts.saturation.max(0.0), n_orbs);
+
+        // Upload (or reuse) the glyph SDF, then render with the Glyph pipeline.
+        // The SDF texture is keyed per `(ch, size)` and immutable once created, so
+        // (unlike the shared, overwritten orb texture) it needs no extra
+        // serialization here — `render_packed_inner` takes `render_guard` for the
+        // pass/upload/readback that actually shares mutable resources.
+        let sdf_view = self.upload_glyph_sdf(ch, sdf_size, &sdf);
+
+        self.render_packed_inner(
+            &pack,
+            width,
+            height,
+            t,
+            Some(GlyphBindings {
+                sdf_view: &sdf_view,
+                size: sdf_size,
+            }),
+        )
+    }
+
+    /// Render one **Circle** frame from a raw `pack_render_data_for_webgl` buffer.
     ///
     /// `pack` must be the header(16) + per-orb(16 × n_orbs) layout produced by
     /// [`pack_render_data_for_webgl`]. `t` is the normalized time written into the
     /// shader's `u_t`; it is clamped to `0.0..=1.0`. This is the seam the WebGL
-    /// path will also share (Phase 2).
+    /// path will also share (Phase 2). Glyph rendering uses the private
+    /// `render_packed_inner` with a glyph SDF binding instead.
     pub fn render_packed(&self, pack: &[f32], width: u32, height: u32, t: f32) -> RgbaImage {
+        self.render_packed_inner(pack, width, height, t, None)
+    }
+
+    /// Shared core of the Circle / Glyph paths. `glyph = Some(_)` selects the Glyph
+    /// pipeline (`orb_glyph.wgsl`) and binds the SDF texture + sampler; `None` is
+    /// the Circle pipeline. The orb data-texture, per-size resources, the
+    /// `render_guard` serialization, and the read-back are all shared.
+    fn render_packed_inner(
+        &self,
+        pack: &[f32],
+        width: u32,
+        height: u32,
+        t: f32,
+        glyph: Option<GlyphBindings<'_>>,
+    ) -> RgbaImage {
         // Serialize the whole GPU body below (orb/params upload → pass record →
         // submit → readback). Concurrent `render_frame` on one shared renderer
         // otherwise alias the shared cached resources (grow-only orb texture,
@@ -597,9 +876,13 @@ impl GpuRenderer {
             cycle: pack[7],
             n_orbs: n_orbs as f32,
             alpha_mul: pack[9],
-            _pad0: 0.0,
-            _pad1: 0.0,
-            _pad2: 0.0,
+            // header[11] = glyph_rotate (#136), header[12] = edge_softness (#205).
+            // Both are Glyph-only; the Circle shader never reads them. `sdf_size`
+            // comes from the Glyph binding (the shader uses it to match the CPU
+            // bilinear convention); Circle leaves it 0.
+            glyph_rotate: pack[11],
+            edge_softness: pack[12],
+            sdf_size: glyph.as_ref().map_or(0.0, |g| g.size as f32),
         };
         let params_buffer = self
             .device
@@ -609,32 +892,40 @@ impl GpuRenderer {
                 usage: wgpu::BufferUsages::UNIFORM,
             });
 
-        // Per-orb words → one `GpuOrb` (3 vec4s) per orb. Only the words the Circle
-        // shader reads are unpacked (color+weight, phase quartet,
-        // cross_axis/style/speed); rotation words are skipped. The shader iterates
-        // `params.n_orbs` rows, so the row count must equal `n_orbs` even if an
-        // (externally hand-built) `pack` runs short — short rows stay zeroed.
+        // Per-orb words → one `GpuOrb` (4 vec4s) per orb: color+weight, phase
+        // quartet, cross_axis/style/speed, and rotation (base_angle,
+        // rot_speed_signed). Circle ignores the rot texel; Glyph reads it for #136.
+        // The shader iterates `params.n_orbs` rows, so the row count must equal
+        // `n_orbs` even if an (externally hand-built) `pack` runs short — short rows
+        // stay zeroed.
         let mut orbs = vec![
             GpuOrb {
                 color: [0.0; 4],
                 phase: [0.0; 4],
                 misc: [0.0; 4],
+                rot: [0.0; 4],
             };
             n_orbs.max(1)
         ];
         for (i, slot) in orbs.iter_mut().enumerate().take(n_orbs) {
             let off = HEADER_WORDS + PER_ORB_WORDS * i;
-            // Max word read below is `pack[off + 10]`, so the guard must allow
-            // `off + 10 == len - 1`, i.e. `off + 11 == len`. Using `>=` here would
-            // wrongly break one orb early when an externally hand-built buffer is
-            // sized to exactly `off + 11`; the correct cut-off is `off + 11 > len`.
-            if off + 11 > pack.len() {
+            // Max word read below is `pack[off + 12]` (rot_speed_signed), so the
+            // guard must allow `off + 12 == len - 1`, i.e. `off + 13 == len`. Using
+            // `>=` here would wrongly break one orb early when an externally
+            // hand-built buffer is sized to exactly `off + 13`; the correct
+            // cut-off is `off + 13 > len`. (Circle only reads up to `off + 10`, but
+            // requiring the full 13 words is safe: the production packer always
+            // emits 16 per-orb words. The Circle parity tests feed full packs.)
+            if off + 13 > pack.len() {
                 break;
             }
             *slot = GpuOrb {
                 color: [pack[off], pack[off + 1], pack[off + 2], pack[off + 3]],
                 phase: [pack[off + 4], pack[off + 5], pack[off + 6], pack[off + 7]],
                 misc: [pack[off + 8], pack[off + 9], pack[off + 10], 0.0],
+                // off + 11 = base_angle, off + 12 = rot_speed_signed (#136).
+                // Glyph reads these; Circle ignores the rot texel.
+                rot: [pack[off + 11], pack[off + 12], 0.0, 0.0],
             };
         }
 
@@ -645,22 +936,38 @@ impl GpuRenderer {
 
         // Pipeline (shader compile) cached per shader source; target / read-back
         // cached per size; orb texture grows as needed. Only the small params
-        // uniform / bind group are rebuilt per frame.
-        self.pipeline(orb_circle_wgsl(), |cached| {
+        // uniform / bind group are rebuilt per frame. Glyph selects a different
+        // shader + adds the SDF texture / sampler bindings (2/3).
+        let (shader, is_glyph) = match &glyph {
+            Some(_) => (orb_glyph_wgsl(), true),
+            None => (orb_circle_wgsl(), false),
+        };
+        self.pipeline(shader, is_glyph, |cached| {
             self.sized_resources(width, height, |res| {
+                let mut entries = vec![
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: params_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::TextureView(&orb_view),
+                    },
+                ];
+                if let Some(g) = &glyph {
+                    entries.push(wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::TextureView(g.sdf_view),
+                    });
+                    entries.push(wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: wgpu::BindingResource::Sampler(&self.glyph_sampler),
+                    });
+                }
                 let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
-                    label: Some("orber-circle-bg"),
+                    label: Some("orber-orb-bg"),
                     layout: &cached.bind_group_layout,
-                    entries: &[
-                        wgpu::BindGroupEntry {
-                            binding: 0,
-                            resource: params_buffer.as_entire_binding(),
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 1,
-                            resource: wgpu::BindingResource::TextureView(&orb_view),
-                        },
-                    ],
+                    entries: &entries,
                 });
                 self.run_pass_and_readback(&cached.pipeline, &bind_group, res)
             })
@@ -810,6 +1117,34 @@ fn orb_texture_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
             view_dimension: wgpu::TextureViewDimension::D2,
             multisampled: false,
         },
+        count: None,
+    }
+}
+
+/// A fragment-visible sampled-texture entry for the glyph SDF (#212).
+/// `sample_type = Float { filterable: true }` because the Glyph shader reads it
+/// with a real bilinear `sampler`. `R8Unorm` is linear-filterable even on the
+/// wgpu WebGL2 backend, so this stays portable (unlike the `Rgba32Float` orb
+/// texture, which is `textureLoad`-only).
+fn glyph_sdf_texture_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::FRAGMENT,
+        ty: wgpu::BindingType::Texture {
+            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+            view_dimension: wgpu::TextureViewDimension::D2,
+            multisampled: false,
+        },
+        count: None,
+    }
+}
+
+/// A fragment-visible filtering-sampler entry for the glyph SDF (#212).
+fn glyph_sampler_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::FRAGMENT,
+        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
         count: None,
     }
 }
@@ -1567,5 +1902,356 @@ mod tests {
             }
         });
         eprintln!("concurrent high-count render: all threads matched their solo oracle");
+    }
+
+    // ---- Glyph (#212 Phase 1b) ----------------------------------------------
+
+    /// The `GLYPH_SDF_CONTENT_SPAN` constant hardcoded in `orb_glyph.wgsl` must
+    /// match the Rust `crate::glyph::GLYPH_SDF_CONTENT_SPAN_PUB` (= 1/√2). If the
+    /// CPU constant ever changes, this guards against the WGSL drifting out of sync
+    /// (which would shift the glyph UV mapping and break parity).
+    #[test]
+    fn glyph_wgsl_content_span_matches_rust() {
+        let wgsl = orb_glyph_wgsl();
+        // Find the literal after `GLYPH_SDF_CONTENT_SPAN: f32 = ` in the shader.
+        let needle = "GLYPH_SDF_CONTENT_SPAN: f32 = ";
+        let start = wgsl
+            .find(needle)
+            .expect("shader must declare the span const")
+            + needle.len();
+        let rest = &wgsl[start..];
+        let end = rest.find(';').expect("const decl must end with ;");
+        let lit: f32 = rest[..end].trim().parse().expect("span literal must parse");
+        assert!(
+            (lit - crate::glyph::GLYPH_SDF_CONTENT_SPAN_PUB).abs() < 1e-6,
+            "orb_glyph.wgsl GLYPH_SDF_CONTENT_SPAN ({lit}) must match Rust ({})",
+            crate::glyph::GLYPH_SDF_CONTENT_SPAN_PUB
+        );
+    }
+
+    /// A Glyph `AnimateOptions` for ☆ (U+2606), large orbs on a dark opaque bg so
+    /// the glyph fill is well-separated from the background.
+    fn glyph_opts(
+        w: u32,
+        h: u32,
+        direction: MotionDirection,
+        speed: MotionSpeed,
+        glyph_rotate: bool,
+    ) -> AnimateOptions {
+        AnimateOptions {
+            width: w,
+            height: h,
+            orb_size: 1.0,
+            blur: 0.5,
+            saturation: 1.0,
+            direction,
+            speed,
+            seed: 7,
+            count: Some(6),
+            background: [10, 12, 20, 255],
+            shape: OrbShape::Glyph {
+                ch: '☆',
+                font: crate::glyph::GlyphFontId::NotoSymbols2,
+            },
+            softness: SoftnessPreset::Mid,
+            glyph_rotate,
+            color_tracks: None,
+            keyframe_tracks: None,
+        }
+    }
+
+    /// Count pixels that differ from the (opaque) background color by more than
+    /// `thresh` on any channel — a proxy for "glyph fill is present here".
+    fn lit_vs_bg(img: &RgbaImage, bg: [u8; 4], thresh: u8) -> usize {
+        img.pixels()
+            .filter(|p| {
+                (0..3).any(|c| p.0[c].abs_diff(bg[c]) > thresh) || p.0[3].abs_diff(bg[3]) > thresh
+            })
+            .count()
+    }
+
+    /// The Glyph WGSL must compile and the fill must produce lit pixels: a known
+    /// glyph (☆) on an opaque dark background paints a non-trivial number of
+    /// foreground pixels that differ from the background.
+    #[test]
+    fn gpu_glyph_renders_lit_pixels() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_renders_lit_pixels") else {
+            return;
+        };
+        eprintln!(
+            "GPU Glyph render test running on adapter: {}",
+            renderer.adapter_name()
+        );
+        let clusters = sample_clusters();
+        let opts = glyph_opts(
+            120,
+            90,
+            MotionDirection::LeftToRight,
+            MotionSpeed::Slow,
+            true,
+        );
+        let img = renderer.render_frame_glyph(&clusters, &opts, 0.0);
+        assert_eq!(img.dimensions(), (120, 90));
+        let lit = lit_vs_bg(&img, opts.background, 8);
+        assert!(
+            lit > 200,
+            "glyph fill must paint a non-trivial number of lit pixels, got {lit}"
+        );
+        eprintln!("glyph lit pixels = {lit}");
+    }
+
+    /// Lit-pixel bounding box of `img` against the opaque background, with a
+    /// per-channel `thresh`. Returns `None` when nothing is lit.
+    fn lit_bbox(img: &RgbaImage, bg: [u8; 4], thresh: u8) -> Option<(u32, u32, u32, u32)> {
+        let (mut minx, mut miny, mut maxx, mut maxy) = (u32::MAX, u32::MAX, 0u32, 0u32);
+        let mut any = false;
+        for (x, y, p) in img.enumerate_pixels() {
+            if (0..3).any(|c| p.0[c].abs_diff(bg[c]) > thresh) {
+                any = true;
+                minx = minx.min(x);
+                miny = miny.min(y);
+                maxx = maxx.max(x);
+                maxy = maxy.max(y);
+            }
+        }
+        any.then_some((minx, miny, maxx, maxy))
+    }
+
+    /// Structural parity with the CPU oracle (loose; bleed excluded). The CPU
+    /// `render_frame` adds an aquarelle bleed pass *after* the glyph fill, which
+    /// blurs/spreads the fill and shifts many pixels above/below the lit threshold,
+    /// so exact coverage is *not* expected to match. What must match is the
+    /// **structure** of the fill (same glyph, same orb positions / scale):
+    ///   - the lit-pixel **bounding boxes** align within a few pixels (position +
+    ///     extent of the glyph fill agree, proving UV mapping / rotation / scale);
+    ///   - both paths light a non-trivial, comparable number of pixels (within a
+    ///     2× band either way — bleed can raise or lower the count vs the sharp
+    ///     pre-bleed fill);
+    ///   - the two lit sets overlap substantially (the fill is in the same place).
+    ///
+    /// Bleed-derived per-pixel differences are expected and allowed.
+    #[test]
+    fn gpu_glyph_structural_parity_with_cpu() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_structural_parity_with_cpu")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let opts = glyph_opts(
+            120,
+            90,
+            MotionDirection::LeftToRight,
+            MotionSpeed::Slow,
+            true,
+        );
+        for &t in &[0.0_f32, 0.5] {
+            let cpu = render_frame(&clusters, &opts, t);
+            let gpu = renderer.render_frame_glyph(&clusters, &opts, t);
+            assert_eq!(cpu.dimensions(), gpu.dimensions());
+
+            let bg = opts.background;
+            let cpu_lit = lit_vs_bg(&cpu, bg, 8);
+            let gpu_lit = lit_vs_bg(&gpu, bg, 8);
+            assert!(cpu_lit > 0 && gpu_lit > 0, "both paths must light pixels");
+
+            // Comparable coverage (loose 2× band either direction).
+            let ratio = gpu_lit as f32 / cpu_lit as f32;
+            assert!(
+                (0.5..=2.0).contains(&ratio),
+                "t={t}: gpu_lit={gpu_lit} / cpu_lit={cpu_lit} = {ratio:.2}, expected within [0.5, 2.0]"
+            );
+
+            // Lit bounding boxes must align within a small tolerance (the fill is
+            // in the same screen region at the same scale). Bleed grows the CPU
+            // bbox slightly; allow 6 px slack on each edge.
+            let cb = lit_bbox(&cpu, bg, 8).expect("cpu has lit pixels");
+            let gb = lit_bbox(&gpu, bg, 8).expect("gpu has lit pixels");
+            let tol = 6i64;
+            for (label, a, b) in [
+                ("minx", cb.0 as i64, gb.0 as i64),
+                ("miny", cb.1 as i64, gb.1 as i64),
+                ("maxx", cb.2 as i64, gb.2 as i64),
+                ("maxy", cb.3 as i64, gb.3 as i64),
+            ] {
+                assert!(
+                    (a - b).abs() <= tol,
+                    "t={t}: lit bbox {label} differs by {} (cpu={a} gpu={b}), tol={tol}",
+                    (a - b).abs()
+                );
+            }
+
+            // Overlap: a good fraction of the smaller lit set coincides with the
+            // larger one (the fills occupy the same pixels, not merely the same box).
+            let mut overlap = 0usize;
+            for (cp, gp) in cpu.pixels().zip(gpu.pixels()) {
+                let c_lit = (0..3).any(|c| cp.0[c].abs_diff(bg[c]) > 8);
+                let g_lit = (0..3).any(|c| gp.0[c].abs_diff(bg[c]) > 8);
+                if c_lit && g_lit {
+                    overlap += 1;
+                }
+            }
+            let overlap_frac = overlap as f32 / cpu_lit.min(gpu_lit) as f32;
+            assert!(
+                overlap_frac > 0.6,
+                "t={t}: lit overlap {:.1}% of the smaller set; expected >60%",
+                overlap_frac * 100.0
+            );
+            eprintln!(
+                "glyph parity t={t}: cpu_lit={cpu_lit} gpu_lit={gpu_lit} ratio={ratio:.2} overlap={:.1}%",
+                overlap_frac * 100.0
+            );
+        }
+    }
+
+    /// Rotation (#136): ON animates the glyph (frames at different t differ), OFF
+    /// holds the orientation (the per-orb `base_angle` is fixed, so the frame is
+    /// identical for every t — only rotation depends on t in a single-glyph,
+    /// stationary-flow check). Loop closure: ON frame at t=0 equals t=1.
+    #[test]
+    fn gpu_glyph_rotation_on_off_and_loop_closure() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_rotation_on_off_and_loop_closure")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+
+        // OFF: base_angle is fixed for all t. Conveyor advance also depends on t,
+        // so to isolate rotation use VerySlow with a single, centered orb is hard;
+        // instead assert the *rotation-only* invariant by comparing OFF frames at
+        // two times against each other is NOT valid (flow still moves). So we test
+        // OFF differently: a glyph rendered OFF must equal the same glyph rendered
+        // OFF again (determinism) and the ON/OFF frames must differ at a non-zero t
+        // (rotation visibly changes the picture).
+        let off = glyph_opts(
+            100,
+            100,
+            MotionDirection::LeftToRight,
+            MotionSpeed::Slow,
+            false,
+        );
+        let on = AnimateOptions {
+            glyph_rotate: true,
+            ..off.clone()
+        };
+
+        // Determinism for OFF.
+        let off_a = renderer.render_frame_glyph(&clusters, &off, 0.3);
+        let off_b = renderer.render_frame_glyph(&clusters, &off, 0.3);
+        assert_eq!(off_a, off_b, "OFF glyph render must be deterministic");
+
+        // ON vs OFF differ at t=0.3 (rotation changes the glyph orientation).
+        let on_t = renderer.render_frame_glyph(&clusters, &on, 0.3);
+        let diff_on_off = off_a
+            .pixels()
+            .zip(on_t.pixels())
+            .filter(|(a, b)| a.0 != b.0)
+            .count();
+        assert!(
+            diff_on_off > 100,
+            "rotation ON must differ from OFF at t=0.3, differing pixels={diff_on_off}"
+        );
+
+        // Loop closure for ON: t=0 and t=1 render identical frames.
+        let on_t0 = renderer.render_frame_glyph(&clusters, &on, 0.0);
+        let on_t1 = renderer.render_frame_glyph(&clusters, &on, 1.0);
+        let max_diff = assert_within_tolerance(&on_t0, &on_t1, "glyph ON loop closure t=0 vs t=1");
+        eprintln!(
+            "glyph rotation: on/off differ by {diff_on_off} px, loop closure max diff = {max_diff}"
+        );
+    }
+
+    /// softness preset must change the Glyph fill (alpha_mul / blur feed the same
+    /// `falloff_curve` the CPU uses): Low / Mid / High produce visibly different
+    /// frames on the GPU glyph path.
+    #[test]
+    fn gpu_glyph_softness_changes_output() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_softness_changes_output") else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let base = glyph_opts(
+            100,
+            80,
+            MotionDirection::LeftToRight,
+            MotionSpeed::Slow,
+            true,
+        );
+        let low = renderer.render_frame_glyph(
+            &clusters,
+            &AnimateOptions {
+                softness: SoftnessPreset::Low,
+                ..base.clone()
+            },
+            0.0,
+        );
+        let high = renderer.render_frame_glyph(
+            &clusters,
+            &AnimateOptions {
+                softness: SoftnessPreset::High,
+                ..base.clone()
+            },
+            0.0,
+        );
+        let diff = low
+            .pixels()
+            .zip(high.pixels())
+            .filter(|(a, b)| a.0 != b.0)
+            .count();
+        assert!(
+            diff > 100,
+            "softness Low vs High must change the glyph fill, differing pixels={diff}"
+        );
+        eprintln!("glyph softness Low vs High differing pixels = {diff}");
+    }
+
+    /// An unknown / unrenderable glyph (pizza emoji, absent from the bundled
+    /// Symbols 2 subset) must yield a background-only frame — no orb fill, matching
+    /// the CPU "draw nothing for tofu" contract.
+    #[test]
+    fn gpu_glyph_unknown_char_background_only() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_unknown_char_background_only")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let mut opts = glyph_opts(
+            48,
+            40,
+            MotionDirection::LeftToRight,
+            MotionSpeed::Slow,
+            true,
+        );
+        opts.shape = OrbShape::Glyph {
+            ch: '\u{1F355}', // pizza — not in Noto Sans Symbols 2
+            font: crate::glyph::GlyphFontId::NotoSymbols2,
+        };
+        let img = renderer.render_frame_glyph(&clusters, &opts, 0.3);
+        let bg = opts.background;
+        let lit = lit_vs_bg(&img, bg, 1);
+        assert_eq!(
+            lit, 0,
+            "unknown glyph must paint background only (no fill), got {lit} non-bg pixels"
+        );
+    }
+
+    /// `render_frame_glyph` on a non-Glyph shape falls back to the Circle path
+    /// (the call is total). A Circle-shaped opts through the glyph entry must match
+    /// the dedicated Circle `render_frame` within the ±2/channel contract.
+    #[test]
+    fn gpu_glyph_entry_circle_shape_falls_back() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_entry_circle_shape_falls_back")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let opts = circle_opts(40, 28, MotionDirection::LeftToRight, MotionSpeed::Mid);
+        let via_circle = renderer.render_frame(&clusters, &opts, 0.5);
+        let via_glyph_entry = renderer.render_frame_glyph(&clusters, &opts, 0.5);
+        let max_diff = assert_within_tolerance(
+            &via_circle,
+            &via_glyph_entry,
+            "circle-shape through glyph entry vs render_frame",
+        );
+        eprintln!("glyph-entry circle fallback: max per-channel diff = {max_diff}");
     }
 }

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -45,7 +45,7 @@
 //!   ([`crate::animate::pack_render_data_for_webgl`]): the parameter arithmetic is
 //!   reused, never reimplemented, so the orb positions / radii / alphas are
 //!   identical to the proven web/CPU result. The per-orb data goes up as a
-//!   `Rgba32Float` data-texture (3 texels wide × N orbs tall) so float precision is
+//!   `Rgba32Float` data-texture (4 texels wide × N orbs tall) so float precision is
 //!   preserved exactly — no quantization happens on the orb data itself;
 //! - reads the result back accounting for wgpu's 256-byte row-alignment
 //!   requirement on `copy_texture_to_buffer` (that alignment applies only to the
@@ -185,7 +185,7 @@ struct SizedResources {
     padded_bytes_per_row: u32,
 }
 
-/// The per-orb data-texture (`Rgba32Float`, 3 texels wide × `capacity` orbs
+/// The per-orb data-texture (`Rgba32Float`, 4 texels wide × `capacity` orbs
 /// tall) and its view, reused across frames. `capacity` is the texture's current
 /// height in orbs; it only ever grows (a frame needing more rows reallocates to
 /// the larger size), mirroring the grow-only spirit of the other caches so a long
@@ -2466,12 +2466,10 @@ mod tests {
     /// driving `alpha_mul` (header[9]) to 0 collapses every orb's contribution to 0
     /// regardless of the SDF / opacity envelope. Build a real glyph pack (so the SDF
     /// binding and orb rows are valid), then force `alpha_mul = 0` and assert the
-    /// frame paints only the background. Pins the alpha-floor → no-fill invariant.
+    /// frame paints only the background. Pins the `alpha_mul == 0` → no-fill invariant.
     #[test]
-    fn gpu_glyph_opacity_zero_softness_floor_no_fill() {
-        let Some(renderer) =
-            require_or_skip_renderer("gpu_glyph_opacity_zero_softness_floor_no_fill")
-        else {
+    fn gpu_glyph_alpha_mul_zero_no_fill() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_alpha_mul_zero_no_fill") else {
             return;
         };
         let clusters = sample_clusters();

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -343,6 +343,21 @@ impl GpuRenderer {
             .map_or(0, |tex| tex.capacity)
     }
 
+    /// Number of live entries in the grow-only glyph SDF cache (one per distinct
+    /// `(char, size)` uploaded). Exposed for the cache-reuse tests
+    /// (`gpu_glyph_sdf_cache_reuse_same_char_size` /
+    /// `gpu_glyph_sdf_cache_grows_on_new_char_or_size`): re-rendering the same
+    /// `(char, size)` must keep this at 1, while a new char / size must add an
+    /// entry. Mirrors the `cache_sizes` / `orb_capacity` test hooks (poison
+    /// recovery via `into_inner`, `#[cfg(test)]` so production API stays clean).
+    #[cfg(test)]
+    fn glyph_sdf_cache_len(&self) -> usize {
+        self.glyph_sdf_cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+
     /// Get-or-build the Circle pipeline for `shader_wgsl`, compiling the shader and
     /// pipeline only on first use. The closure runs at most once per distinct
     /// shader source for the life of the renderer.
@@ -2253,5 +2268,503 @@ mod tests {
             "circle-shape through glyph entry vs render_frame",
         );
         eprintln!("glyph-entry circle fallback: max per-channel diff = {max_diff}");
+    }
+
+    // ---- #212 Phase 1b: 4-texel widening / glyph dispatch regression guards ----
+
+    /// #212 (#1): widening the orb data-texture 3→4 texels (x=3 = rotation) must
+    /// leave the **Circle** path bit-exact — the Circle shader ignores texel x=3.
+    /// This pins the Circle bit-exact requirement after the layout change across
+    /// several frames (count / direction / t varied), proving x=3 is dead weight
+    /// for Circle. On the real GPU the diff is expected to be 0; the assertion
+    /// allows the ±2/channel contract as the other Circle parity tests do.
+    #[test]
+    fn circle_bitexact_after_4texel_widening() {
+        let Some(renderer) = require_or_skip_renderer("circle_bitexact_after_4texel_widening")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let mut overall_max = 0u8;
+        // Vary count, direction, and t so the per-orb rows (and the now-present but
+        // Circle-ignored x=3 rotation texel) take many distinct values; Circle must
+        // stay byte-for-byte on the CPU oracle regardless.
+        let cases = [
+            (8usize, MotionDirection::LeftToRight, 0.0_f32),
+            (12, MotionDirection::RightToLeft, 0.25),
+            (20, MotionDirection::TopToBottom, 0.5),
+            (33, MotionDirection::BottomToTop, 0.75),
+            (50, MotionDirection::LeftToRight, 1.0),
+        ];
+        for &(count, dir, t) in &cases {
+            let mut opts = circle_opts(40, 28, dir, MotionSpeed::Mid);
+            opts.count = Some(count);
+            let cpu = render_frame(&clusters, &opts, t);
+            let gpu = renderer.render_frame(&clusters, &opts, t);
+            let max_diff =
+                assert_within_tolerance(&cpu, &gpu, &format!("count={count} {dir:?} t={t}"));
+            // Pin the *bit-exact* contract explicitly (the Circle requirement),
+            // stronger than the ±2 band the helper enforces. On the GTX 1050 Ti
+            // round(value*255) is the same arithmetic as the CPU loop, so Circle is
+            // diff 0; if x=3 ever leaked into Circle this would break first.
+            assert_eq!(
+                max_diff, 0,
+                "Circle must stay bit-exact after the 3→4 texel widening \
+                 (x=3 rotation texel must be ignored): count={count} {dir:?} t={t}"
+            );
+            overall_max = overall_max.max(max_diff);
+        }
+        eprintln!("circle 4-texel widening bit-exact: overall max diff = {overall_max}");
+    }
+
+    /// #212 (#2): the `render_packed_inner` short-row guard changed from a per-orb
+    /// `off + 11` cut-off to `off + 13` (so the new rotation words at `off+11` /
+    /// `off+12` are read). A hand-built single-orb Circle pack sized to **exactly**
+    /// `off + 13` words must render that orb — it must NOT be cut one orb early.
+    /// This is the regression guard for the boundary change: with the old `off+11`
+    /// (or a `>=` form) the last orb would have been dropped at this exact length.
+    ///
+    /// Build a real 1-orb Circle pack via the production packer (so the per-orb
+    /// arithmetic is correct), truncate it to `HEADER_WORDS + 13` (dropping only the
+    /// 3 trailing unused padding words of the 16-word slot), render it, and assert
+    /// (a) it equals the full untruncated pack bit-exact, and (b) the orb is
+    /// actually drawn (output is not background-only).
+    #[test]
+    fn render_packed_short_pack_circle_unaffected_by_13word_guard() {
+        let Some(renderer) =
+            require_or_skip_renderer("render_packed_short_pack_circle_unaffected_by_13word_guard")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let (w, h) = (40u32, 28u32);
+        let bg = [12u8, 18, 28, 255];
+        // One orb, real packed words (header 16 + per-orb 16 = 32 words total).
+        let full = pack_render_data_for_webgl(
+            &clusters,
+            bg,
+            1.0,
+            0.5,
+            0.0, // direction_id = LeftToRight
+            MotionSpeed::Mid.cycle_count() as f32,
+            12345,
+            1,    // n_orbs = 1
+            1.0,  // alpha_mul
+            0.0,  // shape_id = Circle
+            true, // glyph_rotate (ignored by Circle)
+            0.5,  // edge_softness (ignored by Circle)
+        );
+        // The single orb lives at off = HEADER_WORDS. The shader reads up to
+        // pack[off + 12] (rot_speed_signed), so off + 13 words is the minimal length
+        // that still carries the whole orb. Truncate to exactly that.
+        let off = HEADER_WORDS; // i = 0
+        let truncated_len = off + 13;
+        assert!(
+            full.len() > truncated_len,
+            "production pack must be longer than the off+13 minimal slot"
+        );
+        let mut short = full.clone();
+        short.truncate(truncated_len);
+        assert_eq!(
+            short.len(),
+            HEADER_WORDS + 13,
+            "short pack must be exactly off+13 words (the boundary case)"
+        );
+
+        // The orb must NOT be cut early: the truncated pack must equal the full one.
+        let short_img = renderer.render_packed(&short, w, h, 0.3);
+        let full_img = renderer.render_packed(&full, w, h, 0.3);
+        assert_eq!(
+            short_img.dimensions(),
+            (w, h),
+            "off+13 short pack must still produce a {w}x{h} image"
+        );
+        let max_diff = assert_within_tolerance(
+            &full_img,
+            &short_img,
+            "off+13 truncated 1-orb pack vs full pack",
+        );
+        assert_eq!(
+            max_diff, 0,
+            "off+13 truncated pack must be bit-exact to the full pack \
+             (the trailing 3 words are unused padding)"
+        );
+
+        // And the orb must actually be drawn — a one-orb-early cut would leave a
+        // background-only frame, so confirm some pixels differ from the bg.
+        let lit = lit_vs_bg(&short_img, bg, 2);
+        assert!(
+            lit > 0,
+            "the single orb must be drawn (not cut early by the guard); \
+             got a background-only frame ({lit} non-bg pixels)"
+        );
+        eprintln!("off+13 short-pack guard: lit pixels = {lit}, max diff vs full = {max_diff}");
+    }
+
+    /// #212 (#3): the Glyph path must handle orb counts straddling the orb-texture
+    /// grow boundary (64). For {1, 64, 65, 1024} the glyph fill must light pixels,
+    /// the output dims must be correct, and there must be no panic / OOB. (Circle
+    /// covers count parity numerically; here the concern is the Glyph dispatch +
+    /// data-texture growth, not bit-exactness.)
+    #[test]
+    fn gpu_glyph_count_boundaries() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_count_boundaries") else {
+            return;
+        };
+        let clusters = sample_clusters();
+        for &count in &[1usize, 64, 65, 1024] {
+            let mut opts = glyph_opts(
+                96,
+                72,
+                MotionDirection::LeftToRight,
+                MotionSpeed::Slow,
+                true,
+            );
+            opts.count = Some(count);
+            let img = renderer.render_frame_glyph(&clusters, &opts, 0.0);
+            assert_eq!(
+                img.dimensions(),
+                (96, 72),
+                "count={count} glyph frame must be 96x72"
+            );
+            let lit = lit_vs_bg(&img, opts.background, 8);
+            assert!(
+                lit > 0,
+                "count={count} glyph fill must light some pixels (no panic/OOB), got {lit}"
+            );
+            eprintln!("glyph count={count}: lit pixels = {lit}");
+        }
+    }
+
+    /// #212 (#4): empty clusters on the Glyph path → background-only frame, correct
+    /// dims, no panic. The glyph fill has nothing to draw, so only the background
+    /// paints (mirrors the Circle empty-clusters test for the glyph dispatch).
+    #[test]
+    fn gpu_glyph_empty_clusters_background_only() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_empty_clusters_background_only")
+        else {
+            return;
+        };
+        let opts = glyph_opts(
+            48,
+            40,
+            MotionDirection::LeftToRight,
+            MotionSpeed::Slow,
+            true,
+        );
+        let img = renderer.render_frame_glyph(&[], &opts, 0.3);
+        assert_eq!(img.dimensions(), (48, 40), "empty-cluster glyph frame dims");
+        let lit = lit_vs_bg(&img, opts.background, 1);
+        assert_eq!(
+            lit, 0,
+            "empty clusters must paint background only on the glyph path, got {lit} non-bg pixels"
+        );
+    }
+
+    /// #212 (#5): when `opacity * alpha_mul == 0` the glyph fill contributes nothing,
+    /// so the frame must be background-only. The fill alpha is `opacity * alpha_mul`;
+    /// driving `alpha_mul` (header[9]) to 0 collapses every orb's contribution to 0
+    /// regardless of the SDF / opacity envelope. Build a real glyph pack (so the SDF
+    /// binding and orb rows are valid), then force `alpha_mul = 0` and assert the
+    /// frame paints only the background. Pins the alpha-floor → no-fill invariant.
+    #[test]
+    fn gpu_glyph_opacity_zero_softness_floor_no_fill() {
+        let Some(renderer) =
+            require_or_skip_renderer("gpu_glyph_opacity_zero_softness_floor_no_fill")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let bg = [10u8, 12, 20, 255];
+        // Pick a glyph + radius so cached_glyph_sdf_for_radius yields a real SDF.
+        let (w, h) = (80u32, 64u32);
+        let base_radius_unit = (w.min(h) as f32) * 0.25;
+        let frame_radius = base_radius_unit * 1.0 * BREATH_RADIUS_MAX_FACTOR;
+        let Some((sdf, sdf_size)) = crate::glyph::cached_glyph_sdf_for_radius(
+            crate::glyph::GlyphFontId::NotoSymbols2,
+            '☆',
+            frame_radius,
+        ) else {
+            panic!("expected a real SDF for ☆ at this radius");
+        };
+        // Build a real 4-orb glyph pack, then force alpha_mul (header[9]) to 0 so
+        // every orb's fill alpha = opacity * alpha_mul = 0 → no fill anywhere.
+        let mut pack = pack_render_data_for_webgl(
+            &clusters,
+            bg,
+            base_radius_unit,
+            0.5,
+            0.0,
+            MotionSpeed::Slow.cycle_count() as f32,
+            7,
+            4,
+            0.0, // alpha_mul = 0 → fill alpha collapses to 0
+            1.0, // shape_id = Glyph
+            true,
+            0.5,
+        );
+        // (header[9] is already 0.0 from the arg above; re-pin defensively in case
+        // the packer ever changes which header slot carries alpha_mul.)
+        pack[9] = 0.0;
+        let sdf_view = renderer.upload_glyph_sdf('☆', sdf_size, &sdf);
+        let img = renderer.render_packed_inner(
+            &pack,
+            w,
+            h,
+            0.4,
+            Some(GlyphBindings {
+                sdf_view: &sdf_view,
+                size: sdf_size,
+            }),
+        );
+        assert_eq!(img.dimensions(), (w, h));
+        let lit = lit_vs_bg(&img, bg, 1);
+        assert_eq!(
+            lit, 0,
+            "opacity*alpha_mul == 0 must paint background only, got {lit} non-bg pixels"
+        );
+    }
+
+    /// #212 (#6): rotation loop closure under stress — ON, MotionSpeed::Fast (high
+    /// cycle count) plus high per-orb speed multipliers — the t=0 and t=1 frames
+    /// must still match within tolerance. This stresses the WGSL `fract` / `floor`
+    /// wrap (`turns = cycle * speed * t - floor(...)`) against the CPU `rem_euclid`
+    /// at the largest `cycle * speed` products, where a float-precision mismatch in
+    /// the wrap would be most visible. (Loop closure relies on `cycle * speed_mult`
+    /// being integral so turns = 0 at t = 1.)
+    #[test]
+    fn gpu_glyph_rotation_loop_closure_fast_high_speed() {
+        let Some(renderer) =
+            require_or_skip_renderer("gpu_glyph_rotation_loop_closure_fast_high_speed")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let mut opts = glyph_opts(
+            100,
+            100,
+            MotionDirection::LeftToRight,
+            MotionSpeed::Fast,
+            true,
+        );
+        // More orbs → a wider spread of per-orb speed_mult values, maximizing the
+        // largest cycle * speed_mult product the wrap has to close.
+        opts.count = Some(24);
+        let t0 = renderer.render_frame_glyph(&clusters, &opts, 0.0);
+        let t1 = renderer.render_frame_glyph(&clusters, &opts, 1.0);
+        let max_diff = assert_within_tolerance(
+            &t0,
+            &t1,
+            "glyph rotation loop closure (Fast, high cycle×speed) t=0 vs t=1",
+        );
+        eprintln!("glyph fast loop closure: max per-channel diff = {max_diff}");
+    }
+
+    /// #212 (#8): the glyph SDF cache reuses the same `(char, size)` upload across
+    /// frames. Two frames with the same glyph at the same frame radius/size must
+    /// leave the cache at exactly one entry (the second frame reuses the first
+    /// upload, not re-uploads). Uses a *private* renderer so the count isn't
+    /// perturbed by the other glyph tests sharing the renderer.
+    #[test]
+    fn gpu_glyph_sdf_cache_reuse_same_char_size() {
+        let Some(renderer) =
+            require_or_skip_fresh_renderer("gpu_glyph_sdf_cache_reuse_same_char_size")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let opts = glyph_opts(
+            80,
+            64,
+            MotionDirection::LeftToRight,
+            MotionSpeed::Slow,
+            true,
+        );
+        assert_eq!(renderer.glyph_sdf_cache_len(), 0, "no glyph uploaded yet");
+        let _ = renderer.render_frame_glyph(&clusters, &opts, 0.0);
+        assert_eq!(
+            renderer.glyph_sdf_cache_len(),
+            1,
+            "first glyph frame must upload exactly one SDF"
+        );
+        // Same char + same size (same opts → same frame radius → same SDF size).
+        let _ = renderer.render_frame_glyph(&clusters, &opts, 0.5);
+        assert_eq!(
+            renderer.glyph_sdf_cache_len(),
+            1,
+            "same (char, size) re-render must reuse the cached SDF (still 1 entry)"
+        );
+    }
+
+    /// #212 (#9): a different char (♪) or a different size must add a new glyph SDF
+    /// cache entry — both frames must still render correctly (lit pixels). Uses a
+    /// *private* renderer so the entry count is observable in isolation.
+    #[test]
+    fn gpu_glyph_sdf_cache_grows_on_new_char_or_size() {
+        let Some(renderer) =
+            require_or_skip_fresh_renderer("gpu_glyph_sdf_cache_grows_on_new_char_or_size")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        // Frame 1: ☆ at the default size.
+        let star = glyph_opts(
+            80,
+            64,
+            MotionDirection::LeftToRight,
+            MotionSpeed::Slow,
+            true,
+        );
+        let star_img = renderer.render_frame_glyph(&clusters, &star, 0.0);
+        assert_eq!(renderer.glyph_sdf_cache_len(), 1, "first glyph → 1 entry");
+        assert!(
+            lit_vs_bg(&star_img, star.background, 8) > 0,
+            "☆ frame must light pixels"
+        );
+
+        // Frame 2: a *different char* (★, a filled star — distinct from ☆ and also
+        // present in Noto Sans Symbols 2) → new cache entry.
+        let filled = AnimateOptions {
+            shape: OrbShape::Glyph {
+                ch: '★',
+                font: crate::glyph::GlyphFontId::NotoSymbols2,
+            },
+            ..star.clone()
+        };
+        let filled_img = renderer.render_frame_glyph(&clusters, &filled, 0.0);
+        assert_eq!(
+            renderer.glyph_sdf_cache_len(),
+            2,
+            "a different char must add a glyph SDF cache entry"
+        );
+        assert!(
+            lit_vs_bg(&filled_img, filled.background, 8) > 0,
+            "★ frame must light pixels"
+        );
+
+        // Frame 3: same ☆ but a *different SDF size*. The SDF size is
+        // `next_power_of_two(max(radius * 2.25, 256))`, so the 80x64 frames above
+        // both clamp to the 256 floor; to bump the chosen size the frame radius must
+        // exceed ~114 px. A large canvas + large orb_size pushes the frame radius
+        // there, selecting a larger power-of-two SDF and thus a new `(char, size)`
+        // cache entry for the *same* char.
+        let big_star = glyph_opts(
+            400,
+            320,
+            MotionDirection::LeftToRight,
+            MotionSpeed::Slow,
+            true,
+        );
+        let big_star = AnimateOptions {
+            orb_size: 4.0,
+            ..big_star
+        };
+        let big_img = renderer.render_frame_glyph(&clusters, &big_star, 0.0);
+        assert_eq!(
+            renderer.glyph_sdf_cache_len(),
+            3,
+            "a different SDF size for the same char must add a glyph SDF cache entry"
+        );
+        assert!(
+            lit_vs_bg(&big_img, big_star.background, 8) > 0,
+            "larger ☆ frame must light pixels"
+        );
+    }
+
+    /// #212 (#10): concurrent glyph renders on the shared renderer must each match
+    /// their solo oracle — no panic / poison, no cross-thread aliasing of the shared
+    /// orb texture / per-size resources. Several threads render glyph frames with
+    /// mixed char / t on the *same* renderer; each thread's output must equal that
+    /// same input rendered alone (a fresh renderer). Mirrors the Circle concurrent
+    /// test (`shared_gpu_concurrent_high_count_render`) for the glyph path.
+    #[test]
+    fn shared_gpu_concurrent_glyph_render() {
+        let Some(renderer) = require_or_skip_renderer("shared_gpu_concurrent_glyph_render") else {
+            return;
+        };
+        // (char, t) cases — mixed glyph + time so threads exercise different SDF
+        // uploads and rotation angles at once. Both ☆ and ★ are in the bundled
+        // Noto Sans Symbols 2 subset, so each produces a real (distinct) fill.
+        let cases: [(char, f32); 4] = [('☆', 0.0), ('★', 0.25), ('☆', 0.5), ('★', 0.75)];
+
+        // Per-case oracle: render each alone on a fresh renderer first.
+        let mut oracles = Vec::new();
+        for &(ch, t) in &cases {
+            let mut opts = glyph_opts(
+                72,
+                56,
+                MotionDirection::LeftToRight,
+                MotionSpeed::Slow,
+                true,
+            );
+            opts.shape = OrbShape::Glyph {
+                ch,
+                font: crate::glyph::GlyphFontId::NotoSymbols2,
+            };
+            let clusters = sample_clusters();
+            let Some(fresh) =
+                require_or_skip_fresh_renderer("shared_gpu_concurrent_glyph_render (oracle leg)")
+            else {
+                return;
+            };
+            oracles.push(fresh.render_frame_glyph(&clusters, &opts, t));
+        }
+
+        std::thread::scope(|scope| {
+            let mut handles = Vec::new();
+            for (idx, &(ch, t)) in cases.iter().enumerate() {
+                let oracle = &oracles[idx];
+                handles.push(scope.spawn(move || {
+                    let clusters = sample_clusters();
+                    let mut opts = glyph_opts(
+                        72,
+                        56,
+                        MotionDirection::LeftToRight,
+                        MotionSpeed::Slow,
+                        true,
+                    );
+                    opts.shape = OrbShape::Glyph {
+                        ch,
+                        font: crate::glyph::GlyphFontId::NotoSymbols2,
+                    };
+                    // A few iterations per thread to maximize overlap on the shared
+                    // orb texture / per-size resources.
+                    for _ in 0..3 {
+                        let img = renderer.render_frame_glyph(&clusters, &opts, t);
+                        assert_within_tolerance(
+                            oracle,
+                            &img,
+                            &format!("concurrent glyph ch={ch} t={t} vs solo render"),
+                        );
+                    }
+                }));
+            }
+            for h in handles {
+                h.join().expect("concurrent glyph render thread panicked");
+            }
+        });
+        eprintln!("concurrent glyph render: all threads matched their solo oracle");
+    }
+
+    /// #212 (#12): the glyph path is deterministic — same opts / seed / t rendered
+    /// twice must be byte-identical, with rotation ON (so the rotation arithmetic is
+    /// part of what must be reproducible). Guards against any nondeterminism creeping
+    /// into the glyph dispatch (e.g. uninitialized padding, cache state leaking).
+    #[test]
+    fn gpu_glyph_determinism_same_seed_same_output() {
+        let Some(renderer) =
+            require_or_skip_renderer("gpu_glyph_determinism_same_seed_same_output")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let opts = glyph_opts(88, 66, MotionDirection::LeftToRight, MotionSpeed::Mid, true);
+        let a = renderer.render_frame_glyph(&clusters, &opts, 0.37);
+        let b = renderer.render_frame_glyph(&clusters, &opts, 0.37);
+        assert_eq!(
+            a, b,
+            "same opts/seed/t must render byte-identical glyph frames (rotation ON)"
+        );
+        eprintln!("glyph determinism: two renders byte-identical");
     }
 }

--- a/crates/core/src/orb_circle.wgsl
+++ b/crates/core/src/orb_circle.wgsl
@@ -61,15 +61,16 @@ struct Params {
     _pad2: f32,
 };
 
-// per-orb のパック（data-texture, #210）。pack_render_data_for_webgl の per-orb
-// 16 words のうち Circle 経路が使う分を 3 つの vec4 にほどき、gpu.rs が
-// **幅3 texel × 高さ N** の Rgba32Float テクスチャへ詰める。texel レイアウトは
+// per-orb のパック（data-texture, #210 / #212 Phase 1b で 4 texel 化）。
+// pack_render_data_for_webgl の per-orb 16 words を gpu.rs が
+// **幅4 texel × 高さ N** の Rgba32Float テクスチャへ詰める。texel レイアウトは
 //   x=0: color = (r, g, b, weight)
 //   x=1: phase = (phase, phi_radius, phi_blur, phi_opacity)
 //   x=2: misc  = (cross_axis, style_bit, speed_mult, _)
+//   x=3: rot   = (base_angle, rot_speed_signed, _, _)  ← Glyph 専用、Circle は無視
 //   y  : orb index
-// 並びは orberGl.ts の u_orb_color / u_orb_phase / u_orb_misc と同じ。回転
-// (base_angle / rot_speed) は Circle では未使用なので持ち込まない。
+// 並びは orberGl.ts の u_orb_color / u_orb_phase / u_orb_misc と同じ。Circle 経路は
+// x=0..2 の 3 つの vec4 だけを読み、回転 (x=3) は未使用なので持ち込まない。
 //
 // sampler は持たず textureLoad（texelFetch 相当）のみで読むので linear filtering に
 // 依存しない（gpu.rs の sample_type は Float{ filterable: false }）。これにより

--- a/crates/core/src/orb_glyph.wgsl
+++ b/crates/core/src/orb_glyph.wgsl
@@ -1,0 +1,293 @@
+// orber #212 Phase 1b — Glyph orb の production WGSL（native CLI / wgpu）。
+//
+// CPU 経路 `crate::glyph::render_glyph_orb`（= bleed pass 前の塗り）を WGSL に
+// 1:1 で写したもの。各 orb は埋め込みフォント 1 文字の SDF を bilinear sampling し、
+//   signed_unit = sdf01 * 2 - 1
+//   r = 1 - signed_unit
+//   alpha = falloff_curve(profile, r, blur, opacity)   ← Circle と同じ Rim/Soft profile
+// で塗り、straight-alpha の source-over で合成する。回転(#136)は per-orb の
+// (base_angle, rot_speed_signed) を data-texture の x=3 texel から読み、CPU の
+// glyph_rotation_angle と同式で角度を出して SDF サンプル座標を回す。
+//
+// パリティ範囲（過大主張しない）:
+//   - bit-exact は課さない。CPU 経路は全 orb 描画後に aquarelle bleed pass を 1 回
+//     かける（#195）が、この WGSL は **bleed 前の塗り** だけを描く。よって lit 被覆 /
+//     エッジ位置 / softness 連動 / 回転角は CPU と緩い許容で一致するが、bleed 由来の
+//     滲み差は期待値として許容する（別 slice 2.5 で実装予定）。
+//   - falloff_curve は style.rs の raw-float 版（u8 量子化なし）を写す。Circle の
+//     orb_circle.wgsl の falloff（tiny-skia lowp の u8 量子化版）とは別物なので
+//     共有しない。
+//   - blend は CPU の blend_source_over（straight rgba を per-orb で u8 量子化しながら
+//     source-over）を写し、finalize（a<255 で rgb を a で割って straight 化）まで
+//     再現する。背景塗りは不透明前提で premul==straight。
+//
+// 座標系:
+//   @builtin(position) は top-left のピクセル座標（中心 +0.5）。CPU も px = x+0.5 /
+//   py = y+0.5 で評価するので flip 不要。SDF テクスチャは R8Unorm、filterable な
+//   bilinear sampler で読む（WebGL2 portable、Phase 2）。
+
+const TAU: f32 = 6.28318530718;
+const BREATH_RADIUS_MAX_FACTOR: f32 = 1.10;
+// 1/√2。crate::glyph::GLYPH_SDF_CONTENT_SPAN と同期。Rust 側から override せず
+// ここに定数で持つ（CPU と同値であることをテストで担保する）。
+const GLYPH_SDF_CONTENT_SPAN: f32 = 0.70710678;
+
+struct Params {
+    resolution: vec2<f32>, // (width, height) px
+    t: f32,                // [0, 1)
+    base_radius: f32,      // px = min(w,h) * 0.25 * orb_size
+    bg: vec4<f32>,         // straight rgba (0..1)
+    base_blur: f32,        // 0..1
+    direction: f32,        // 0=LR, 1=RL, 2=TB, 3=BT
+    cycle: f32,            // 1=VerySlow, 2=Slow, 3=Mid, 4=Fast
+    n_orbs: f32,           // 整数を f32 で
+    alpha_mul: f32,        // softness.alpha_mul
+    glyph_rotate: f32,     // #136: 1.0=ON / 0.0=OFF
+    edge_softness: f32,    // #205: 現 fill では未使用（予約）
+    sdf_size: f32,         // glyph SDF の一辺（texel 数）。CPU の bilinear 規約を写すため
+};
+
+// per-orb のパック（data-texture, 幅 4 texel × 高さ N の Rgba32Float）。
+//   x=0: color = (r, g, b, weight)
+//   x=1: phase = (phase, phi_radius, phi_blur, phi_opacity)
+//   x=2: misc  = (cross_axis, style_bit, speed_mult, _)
+//   x=3: rot   = (base_angle, rot_speed_signed, _, _)   ← #136、Glyph だけが読む
+// textureLoad（point fetch）で読むので orb_tex は filterable:false で良い。
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var orb_tex: texture_2d<f32>;
+// glyph SDF（R8Unorm, 単一文字 / 単一サイズ）と bilinear sampler。
+@group(0) @binding(2) var glyph_sdf: texture_2d<f32>;
+@group(0) @binding(3) var glyph_samp: sampler;
+
+struct Orb {
+    color: vec4<f32>, // (r, g, b, weight)
+    phase: vec4<f32>, // (phase, phi_radius, phi_blur, phi_opacity)
+    misc: vec4<f32>,  // (cross_axis, style_bit, speed_mult, _)
+    rot: vec4<f32>,   // (base_angle, rot_speed_signed, _, _)
+};
+
+fn load_orb(i: u32) -> Orb {
+    let row = i32(i);
+    var o: Orb;
+    o.color = textureLoad(orb_tex, vec2<i32>(0, row), 0);
+    o.phase = textureLoad(orb_tex, vec2<i32>(1, row), 0);
+    o.misc = textureLoad(orb_tex, vec2<i32>(2, row), 0);
+    o.rot = textureLoad(orb_tex, vec2<i32>(3, row), 0);
+    return o;
+}
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VsOut {
+    var xy = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>(3.0, -1.0),
+        vec2<f32>(-1.0, 3.0),
+    );
+    var out: VsOut;
+    out.pos = vec4<f32>(xy[vi], 0.0, 1.0);
+    return out;
+}
+
+fn clampf(x: f32, a: f32, b: f32) -> f32 {
+    return min(max(x, a), b);
+}
+
+// style.rs::falloff_curve を raw-float のまま写す（u8 量子化なし）。
+//   r: 0=中心/深部、1=edge、>1=外側。返り値は straight alpha (0..1)。
+//   style_bit < 0.5 が Rim、それ以外が Soft。
+fn falloff_curve(style_bit: f32, r_in: f32, blur: f32, opacity_in: f32) -> f32 {
+    let opacity = clampf(opacity_in, 0.0, 1.0);
+    if (opacity <= 0.0) {
+        return 0.0;
+    }
+    let r = max(r_in, 0.0);
+    if (r >= 1.0) {
+        return 0.0;
+    }
+    let b = clampf(blur, 0.0, 1.0);
+    if (style_bit < 0.5) {
+        // Rim: mid_a = opacity * 80/255、mid_stop = clamp(1 - blur*0.8, .05, .95)。
+        let mid_a = opacity * (80.0 / 255.0);
+        let mid_stop = clampf(1.0 - b * 0.8, 0.05, 0.95);
+        if (r <= mid_stop) {
+            var u = 1.0;
+            if (mid_stop > 0.0) {
+                u = r / mid_stop;
+            }
+            return opacity + (mid_a - opacity) * u;
+        }
+        let denom = max(1.0 - mid_stop, 1e-6);
+        let u = (r - mid_stop) / denom;
+        return mid_a * (1.0 - u);
+    }
+    // Soft: hold_stop = clamp(1 - blur, .05, .95)。
+    let hold_stop = clampf(1.0 - b, 0.05, 0.95);
+    if (r <= hold_stop) {
+        return opacity;
+    }
+    let denom = max(1.0 - hold_stop, 1e-6);
+    let u = (r - hold_stop) / denom;
+    return opacity * (1.0 - u);
+}
+
+// CPU の glyph_rotation_angle(cycle, t, base_angle, rot_speed_signed, glyph_rotate)。
+//   glyph_rotate=false → base_angle 静止。
+//   それ以外 → base_angle + rem_euclid(cycle * rot_speed_signed * t, 1.0) * TAU。
+// loop closure: cycle * rot_speed_signed が整数なので t=1 で turns=0 に閉じる。
+fn glyph_rotation_angle(base_angle: f32, rot_speed_signed: f32) -> f32 {
+    if (params.glyph_rotate < 0.5) {
+        return base_angle;
+    }
+    let x = params.cycle * rot_speed_signed * params.t;
+    // rem_euclid(x, 1.0) = x - floor(x)（1.0 は正なので floor 版で一致、負も非負を返す）。
+    let turns = x - floor(x);
+    return base_angle + turns * TAU;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    let px = in.pos.x;
+    let py = in.pos.y;
+
+    var progress_axis = params.resolution.y;
+    if (params.direction < 1.5) {
+        progress_axis = params.resolution.x;
+    }
+
+    // CPU 経路は Pixmap を背景色で fill してから blend_source_over を重ねる。
+    // 背景は不透明前提（premul==straight）。アキュムレータは straight rgba を u8
+    // (0..255 float) で持ち、各 orb で round して量子化する（blend_source_over と同じ）。
+    var acc = vec4<f32>(
+        floor(clampf(params.bg.r, 0.0, 1.0) * 255.0 + 0.5),
+        floor(clampf(params.bg.g, 0.0, 1.0) * 255.0 + 0.5),
+        floor(clampf(params.bg.b, 0.0, 1.0) * 255.0 + 0.5),
+        floor(clampf(params.bg.a, 0.0, 1.0) * 255.0 + 0.5),
+    );
+
+    let count = u32(params.n_orbs + 0.5);
+    let t_frac = fract(params.t);
+
+    for (var i: u32 = 0u; i < count; i = i + 1u) {
+        let o = load_orb(i);
+        let weight = o.color.w;
+        let phase = o.phase.x;
+        let phi_radius = o.phase.y;
+        let phi_blur = o.phase.z;
+        let phi_opacity = o.phase.w;
+        let cross_axis = o.misc.x;
+        let style_bit = o.misc.y; // 0=rim, 1=soft
+        let speed_mult = o.misc.z;
+        let base_angle = o.rot.x;
+        let rot_speed_signed = o.rot.y;
+
+        let r_pixels_max = params.base_radius * sqrt(max(weight, 0.0)) * BREATH_RADIUS_MAX_FACTOR;
+        var r_normalized = 0.0;
+        if (progress_axis > 0.0) {
+            r_normalized = r_pixels_max / progress_axis;
+        }
+        let extent = 1.0 + 2.0 * r_normalized;
+
+        let advance_steps = fract(params.cycle * speed_mult * params.t);
+        let raw = phase * extent + advance_steps * extent;
+        let pos = (raw - extent * floor(raw / extent)) - r_normalized;
+
+        var nx: f32;
+        var ny: f32;
+        if (params.direction < 0.5) {        // LR
+            nx = pos;
+            ny = cross_axis;
+        } else if (params.direction < 1.5) { // RL
+            nx = 1.0 - pos;
+            ny = cross_axis;
+        } else if (params.direction < 2.5) { // TB
+            nx = cross_axis;
+            ny = pos;
+        } else {                             // BT
+            nx = cross_axis;
+            ny = 1.0 - pos;
+        }
+
+        let radius_factor = 1.0 + 0.10 * sin(TAU * t_frac + phi_radius);
+        let blur_delta = 0.15 * sin(TAU * t_frac + phi_blur);
+        let opacity_factor = 1.0 + 0.05 * sin(TAU * t_frac + phi_opacity);
+
+        let radius = params.base_radius * sqrt(max(weight, 0.0)) * radius_factor;
+        if (radius <= 0.0) {
+            continue;
+        }
+
+        let blur = clampf(params.base_blur + blur_delta, 0.0, 1.0);
+        let opacity = clampf(opacity_factor * params.alpha_mul, 0.0, 1.0);
+
+        let cx = nx * params.resolution.x;
+        let cy = ny * params.resolution.y;
+
+        // CPU render_glyph_orb と同じ座標変換: orb 中心からの差分を +angle で回し、
+        // (2*radius) で割って CONTENT_SPAN を掛けて 0.5 中心の UV にする。
+        let angle = glyph_rotation_angle(base_angle, rot_speed_signed);
+        let cos_a = cos(angle);
+        let sin_a = sin(angle);
+        let dx = px - cx;
+        let dy = py - cy;
+        let rx = cos_a * dx - sin_a * dy;
+        let ry = sin_a * dx + cos_a * dy;
+        let u = rx / (2.0 * radius) * GLYPH_SDF_CONTENT_SPAN + 0.5;
+        let v = ry / (2.0 * radius) * GLYPH_SDF_CONTENT_SPAN + 0.5;
+        if (u < 0.0 || u > 1.0 || v < 0.0 || v > 1.0) {
+            continue;
+        }
+
+        // CPU sample_sdf_bilinear の規約に合わせる: CPU は coord = clamp(u,0,1)*(size-1)
+        // の格子点を線形補間する。GPU sampler は uv*size-0.5 の texel 空間で補間するので、
+        //   uv_gpu = (u*(size-1) + 0.5) / size
+        // と remap すると両者が同じ格子点・同じ重みで補間し、半 texel ずれを消せる。
+        let s = params.sdf_size;
+        let uu = (clampf(u, 0.0, 1.0) * (s - 1.0) + 0.5) / s;
+        let vv = (clampf(v, 0.0, 1.0) * (s - 1.0) + 0.5) / s;
+        // bilinear sample（sampler が線形補間）。R8Unorm なので .r に SDF が入る。
+        let sdf01 = textureSampleLevel(glyph_sdf, glyph_samp, vec2<f32>(uu, vv), 0.0).r;
+        let signed_unit = sdf01 * 2.0 - 1.0;
+        let r = 1.0 - signed_unit;
+        let alpha = falloff_curve(style_bit, r, blur, opacity);
+        if (alpha <= 0.0) {
+            continue;
+        }
+
+        // blend_source_over: dst を straight として扱い、src_rgb = orb_rgb * alpha、
+        // out = src + dst*(1-alpha)、out_a = alpha + dst_a*(1-alpha)。各成分を
+        // *255 round clamp で u8 量子化してアキュムレータに書き戻す（per-orb）。
+        let one_minus_a = 1.0 - alpha;
+        let dst_r = acc.r / 255.0;
+        let dst_g = acc.g / 255.0;
+        let dst_b = acc.b / 255.0;
+        let dst_a = acc.a / 255.0;
+        let src_r = o.color.r * alpha;
+        let src_g = o.color.g * alpha;
+        let src_b = o.color.b * alpha;
+        acc = vec4<f32>(
+            floor(clampf(src_r + dst_r * one_minus_a, 0.0, 1.0) * 255.0 + 0.5),
+            floor(clampf(src_g + dst_g * one_minus_a, 0.0, 1.0) * 255.0 + 0.5),
+            floor(clampf(src_b + dst_b * one_minus_a, 0.0, 1.0) * 255.0 + 0.5),
+            floor(clampf(alpha + dst_a * one_minus_a, 0.0, 1.0) * 255.0 + 0.5),
+        );
+    }
+
+    // finalize_pixmap 相当: a==0 → rgb=0、a<255 → straight = round(rgb_u8 * 255 / a_u8)、
+    // a>=255 → そのまま。出力は straight rgba（read-back は Rgba8Unorm）。
+    let a8 = acc.a;
+    if (a8 <= 0.0) {
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    }
+    if (a8 >= 255.0) {
+        return vec4<f32>(acc.r / 255.0, acc.g / 255.0, acc.b / 255.0, 1.0);
+    }
+    let inv = 255.0 / a8;
+    let sr = floor(clampf(acc.r * inv, 0.0, 255.0) + 0.5);
+    let sg = floor(clampf(acc.g * inv, 0.0, 255.0) + 0.5);
+    let sb = floor(clampf(acc.b * inv, 0.0, 255.0) + 0.5);
+    return vec4<f32>(sr / 255.0, sg / 255.0, sb / 255.0, a8 / 255.0);
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -458,6 +458,12 @@ color. The pipeline:
 The on-disk font asset is the only payload added by Phase A; the `ttf-parser`
 dependency itself is small and pure-Rust (no shaping, no FreeType).
 
+Native `--renderer gpu` also draws Glyph orbs on the GPU (#212 Phase 1b): a WGSL
+shader fills each glyph from its SDF and applies the per-orb rotation, reproducing
+the CPU **pre-bleed** fill. The aquarelle bleed/halo pass (step 5 above) is **not
+yet implemented on the GPU path** — it lands in a separate slice — so a GPU Glyph
+render is the SDF fill only, without the paper-bleed softening.
+
 ## Softness axis
 
 `--softness {low, mid, high}` is a **single user-facing axis** that bundles


### PR DESCRIPTION
## 関連 Issue
closes #212
Refs #207（umbrella: wgpu 一重化 / Phase 1b スライス2）

## 概要
GPU(wgpu) に **Glyph shape の SDF fill + orb 回転(#136)** を WGSL 化。新 `orb_glyph.wgsl` ＋専用 pipeline を追加し、`--renderer gpu --shape glyph` が CPU 落ちせず GPU 描画する。glyph bleed/halo は別スライス(2.5)に分離（pre-bleed の塗りまで）。

## 範囲・parity 方針（合意 Option A）
- **やる**: SDF fill（R8Unorm SDF + bilinear、CPU `render_glyph_orb` の bleed 前の塗りに一致）+ 回転(#136)。
- **やらない**: glyph bleed/halo パス（slice 2.5）、image mask/aquarelle（slice 3）。
- **parity**: Glyph は bit-exact を課さず**構造＋緩い許容**（lit 被覆・回転角・softness 応答）。bleed 由来差は期待値。**Circle は bit-exact 維持（must）**。

## 変更
- **data-texture 4 texel 化**（`gpu.rs`）: x=3 = `rot=(base_angle, rot_speed_signed)`。Circle は x=3 を無視＝bit-exact 維持。`Params` の旧 padding スロットを `glyph_rotate/edge_softness/sdf_size` に改名（64byte レイアウト不変、`orb_circle.wgsl` は logic 不変）。
- **glyph シェーダ/pipeline**（新 `orb_glyph.wgsl`）: bilinear SDF サンプル→falloff_curve→source-over。回転は `glyph_rotation_angle` 相当（WGSL `x-floor(x)` ≡ Rust `rem_euclid`、負速度・loop closure 検証）。
- **SDF 供給**（`glyph.rs` ヘルパ + `gpu.rs`）: CPU の u8 SDF を R8Unorm で upload、per-(char,size) immutable キャッシュ（共有 renderer 並行安全、Phase 1a の競合は再導入なし）。
- **CLI**（`main.rs`）: Circle/Glyph→GPU、Aquarelle→CPU フォールバック。

## テスト・検証
- 新規 12 テスト（Circle 非回帰 bit-exact / short-pack 境界 / 回転数値一致(負速度) / 並行 glyph / dispatch / count 境界 / SDF キャッシュ grow・再利用 / 決定性 / softness）。実 GPU(GTX 1050 Ti) で **183 passed**、既定マルチスレッド・`ORBER_REQUIRE_GPU=1` で skip なし。Circle diff 0 維持。
- 実機 CLI スモーク: `--renderer gpu --shape glyph --glyph-char ☆` が GPU 描画、per-orb 回転した星を確認。
- 独立レビュー2巡 Approve。clippy/fmt/default/wasm 緑。CI gpu-parity(lavapipe 22.04 マルチスレッド) ハードゲート。