### PR TITLE
feat(gpu): glyph bleed/halo パスを WGSL 化（2nd pass） (Phase 1b.5)

### DIFF
--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -111,6 +111,33 @@ fn orb_glyph_wgsl() -> &'static str {
     include_str!("orb_glyph.wgsl")
 }
 
+/// The Glyph **bleed/halo** WGSL (#214 Phase 1b.5). The 2nd-pass group that writes
+/// the aquarelle paper-bleed over the glyph fill: premultiply + separable box-blur
+/// (H/V), halo saturation boost, and the intensity compose + finalize. Translated
+/// from `aquarelle::render_aquarelle_bleed_pass` (default params, seed=0); see the
+/// shader header and [`BLEED_BOX_RADIUS`] / [`BLEED_HALO_FACTOR`] /
+/// [`BLEED_INTENSITY`] for the constant provenance. The paper-grain noise (step 4)
+/// is **omitted** on the GPU (loose-parity decision documented there).
+fn orb_glyph_bleed_wgsl() -> &'static str {
+    include_str!("orb_glyph_bleed.wgsl")
+}
+
+/// Aquarelle bleed constants, fixed to `AquarelleBleedParams::default()` (the
+/// values the CPU `render_frame` passes: `radius = 3.0, intensity = 0.5,
+/// halo = 0.3`) so the GPU 2nd pass matches the CPU paper-bleed.
+///
+/// `BLEED_BOX_RADIUS` is `round(radius * 1.15).max(1)` = `round(3.45)` = `3`, the
+/// box-blur half-window the crate derives from `radius` (see
+/// `aquarelle::render_aquarelle_bleed_pass`). `BLEED_HALO_FACTOR` is
+/// `1.0 + 0.6 * halo` = `1.18` (the saturation multiplier
+/// `boost_saturation_buffer` applies). `BLEED_INTENSITY` is the compose mix
+/// (`dst = original * (1 - t) + blurred * t`). `BLEED_BLUR_ITERATIONS` is the
+/// crate's 3-pass (H→V) box-blur loop.
+const BLEED_BOX_RADIUS: f32 = 3.0;
+const BLEED_HALO_FACTOR: f32 = 1.18;
+const BLEED_INTENSITY: f32 = 0.5;
+const BLEED_BLUR_ITERATIONS: usize = 3;
+
 /// Header uniform block handed to the Circle shader. Mirrors `struct Params` in
 /// `orb_circle.wgsl`. `#[repr(C)]` + explicit padding to satisfy WGSL std140-ish
 /// uniform layout (vec2 then scalars packed into 16-byte rows).
@@ -165,12 +192,62 @@ struct GpuOrb {
     rot: [f32; 4],   // base_angle, rot_speed_signed, _, _
 }
 
+/// Uniform block for the Glyph bleed pass shader (`orb_glyph_bleed.wgsl`).
+/// Mirrors `struct BleedParams` there. `#[repr(C)]` + padding to a 32-byte (two
+/// 16-byte rows) uniform layout. One of these is built per bleed sub-pass with the
+/// per-pass `radius` / `premultiply` set; `halo_factor` / `intensity` are constant
+/// across passes but live here so every pass shares one uniform/bind-group layout.
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct BleedParams {
+    // row 0: resolution.xy, radius, premultiply
+    resolution: [f32; 2],
+    radius: f32,
+    premultiply: f32,
+    // row 1: halo_factor, intensity, pad, pad
+    halo_factor: f32,
+    intensity: f32,
+    _pad0: f32,
+    _pad1: f32,
+}
+
 /// A render pipeline plus its bind-group layout, compiled once per distinct
 /// shader source. Caching keeps shader compilation / pipeline creation off the
 /// per-frame path: a long video renders the same shader for every frame.
 struct CachedPipeline {
     pipeline: wgpu::RenderPipeline,
     bind_group_layout: wgpu::BindGroupLayout,
+}
+
+/// The four bleed-pass pipelines (one per `orb_glyph_bleed.wgsl` fragment entry
+/// point), plus the shared bind-group layout. Built once per renderer; the
+/// vertex-only-varying pipelines differ solely in their fragment entry point, so
+/// they all reuse the same layout (uniform 0 + `src` 1 + `blurred` 2). Cached so a
+/// long glyph clip compiles the bleed shader and its pipelines only once.
+struct BleedPipelines {
+    bind_group_layout: wgpu::BindGroupLayout,
+    /// Horizontal box-blur (`fs_blur_h`); the `premultiply` uniform flag turns the
+    /// straight-RGBA glyph fill into premultiplied on the first iteration only.
+    blur_h: wgpu::RenderPipeline,
+    /// Vertical box-blur (`fs_blur_v`).
+    blur_v: wgpu::RenderPipeline,
+    /// Halo saturation boost (`fs_halo`).
+    halo: wgpu::RenderPipeline,
+    /// Intensity compose + finalize to straight RGBA (`fs_compose`).
+    compose: wgpu::RenderPipeline,
+}
+
+/// Per-size intermediate textures for the Glyph bleed pass, reused across
+/// same-sized frames (mirrors [`SizedResources`]). The glyph fill renders into
+/// `fill` (straight RGBA, as the glyph shader emits); the box-blur ping-pongs
+/// between `ping` / `pong` (premultiplied); the compose pass reads `fill` +
+/// the final blurred texture and writes straight RGBA to the `SizedResources`
+/// `target`. All three are `Rgba8Unorm` so each box-blur pass quantizes to u8 the
+/// way the CPU crate does between its H/V passes.
+struct BleedTextures {
+    fill_view: wgpu::TextureView,
+    ping_view: wgpu::TextureView,
+    pong_view: wgpu::TextureView,
 }
 
 /// Per-dimension GPU resources reused across same-sized frames: the render
@@ -245,6 +322,14 @@ pub struct GpuRenderer {
     /// The bilinear (linear/linear, clamp-to-edge) sampler the Glyph shader uses
     /// to read the `R8Unorm` SDF. Built once; reused for every glyph frame.
     glyph_sampler: wgpu::Sampler,
+    /// The four Glyph bleed-pass pipelines (#214), compiled lazily once. `None`
+    /// until the first glyph frame (Circle never touches the bleed path, so a
+    /// Circle-only run never compiles the bleed shader).
+    bleed_pipelines: std::sync::Mutex<Option<BleedPipelines>>,
+    /// Per-size bleed intermediate textures (`fill` + blur ping-pong), keyed by
+    /// `(width, height)`. Grow-only / never-evicts like `sized_cache`: a glyph clip
+    /// at one size keeps a single entry.
+    bleed_textures: std::sync::Mutex<HashMap<(u32, u32), BleedTextures>>,
     /// Serializes the whole GPU side of [`Self::render_packed`] (orb/params
     /// upload → pass record → `queue.submit` → map/readback) so concurrent
     /// `render_frame` calls on one shared renderer cannot alias the shared cached
@@ -304,6 +389,8 @@ impl GpuRenderer {
             orb_texture: std::sync::Mutex::new(None),
             glyph_sdf_cache: std::sync::Mutex::new(HashMap::new()),
             glyph_sampler,
+            bleed_pipelines: std::sync::Mutex::new(None),
+            bleed_textures: std::sync::Mutex::new(HashMap::new()),
             render_guard: std::sync::Mutex::new(()),
         })
     }
@@ -715,13 +802,20 @@ impl GpuRenderer {
     /// texture, and the Glyph shader bilinear-samples it and fills with
     /// `falloff_curve(1 - signed_unit)`.
     ///
-    /// # Parity scope (loose — bleed is excluded)
+    /// # Parity scope (loose — structural + tolerant)
     ///
     /// The CPU `render_frame` applies a per-frame aquarelle **bleed pass** after
-    /// the glyph fill (#195); this GPU path renders only the **pre-bleed** fill.
-    /// So lit coverage / edge position / softness response / rotation match the CPU
-    /// within a loose tolerance, but bleed-derived halo differences are expected and
-    /// allowed (a separate slice will add the bleed pass).
+    /// the glyph fill (#195). This GPU path now reproduces it as a 2nd pass group
+    /// (#214): the glyph fill renders into an intermediate texture, then a WGSL
+    /// premultiply → separable box-blur ×3 → halo saturation → intensity compose +
+    /// finalize writes the backbuffer (see [`Self::run_glyph_fill_bleed_readback`]
+    /// / `orb_glyph_bleed.wgsl`). Parity is **loose, not bit-exact**: the box-blur
+    /// structure / halo / intensity match the crate, but the aquarelle paper-grain
+    /// noise (a faint ±0.05 seed-derived jitter) is **omitted** on the GPU because
+    /// its ChaCha8 per-pixel-order consumption cannot be bit-reproduced in parallel,
+    /// and the GPU's HSL path differs from `palette`'s by sub-ULP rounding. Those
+    /// small per-pixel differences vs. the CPU are **expected and allowed** (a
+    /// future WGSL hash could approximate the noise).
     ///
     /// Returns a background-only frame (no glyph fill) when the glyph is unknown /
     /// empty in the bundled font, mirroring the CPU "draw nothing for tofu"
@@ -984,7 +1078,18 @@ impl GpuRenderer {
                     layout: &cached.bind_group_layout,
                     entries: &entries,
                 });
-                self.run_pass_and_readback(&cached.pipeline, &bind_group, res)
+                if glyph.is_some() {
+                    // Glyph (#214): render the fill into the bleed `fill` texture,
+                    // then run the aquarelle bleed pass group (premult → box-blur×3
+                    // → halo → compose) into `res.target`, then read `res.target`
+                    // back. The bleed pipelines / intermediate textures are taken
+                    // here, nested under the (already-held) render_guard → pipeline
+                    // → sized locks; this is the only path that touches them, so the
+                    // ordering stays consistent and cannot deadlock.
+                    self.run_glyph_fill_bleed_readback(&cached.pipeline, &bind_group, res)
+                } else {
+                    self.run_pass_and_readback(&cached.pipeline, &bind_group, res)
+                }
             })
         })
     }
@@ -1029,6 +1134,22 @@ impl GpuRenderer {
             pass.set_bind_group(0, bind_group, &[]);
             pass.draw(0..3, 0..1);
         }
+        self.copy_target_and_readback(encoder, extent, res)
+    }
+
+    /// Copy `res.target` into the padded read-back buffer, submit, map, and strip
+    /// wgpu's row padding into a tight `RgbaImage`. Shared by the Circle path
+    /// ([`run_pass_and_readback`](Self::run_pass_and_readback)) and the Glyph bleed
+    /// path ([`run_glyph_fill_bleed_readback`](Self::run_glyph_fill_bleed_readback)),
+    /// which both end by reading `res.target` back the same way; `encoder` already
+    /// holds the render pass(es) that wrote `res.target`.
+    fn copy_target_and_readback(
+        &self,
+        mut encoder: wgpu::CommandEncoder,
+        extent: wgpu::Extent3d,
+        res: &SizedResources,
+    ) -> RgbaImage {
+        let (width, height) = (res.width, res.height);
         encoder.copy_texture_to_buffer(
             wgpu::TexelCopyTextureInfo {
                 texture: &res.target,
@@ -1067,6 +1188,321 @@ impl GpuRenderer {
 
         RgbaImage::from_raw(width, height, pixels)
             .expect("read-back buffer matches image dimensions")
+    }
+
+    /// Get-or-build the four Glyph bleed-pass pipelines (#214), compiling the bleed
+    /// shader and its pipelines at most once for the renderer's life. Returns the
+    /// caller's `f` applied to the cached `BleedPipelines`. Lazy: a Circle-only run
+    /// never compiles the bleed shader.
+    fn bleed_pipelines<R>(&self, f: impl FnOnce(&BleedPipelines) -> R) -> R {
+        let mut guard = self
+            .bleed_pipelines
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let pipelines = guard.get_or_insert_with(|| self.build_bleed_pipelines());
+        f(pipelines)
+    }
+
+    /// Compile the bleed shader once and build its four fragment-entry pipelines,
+    /// all sharing one bind-group layout (uniform 0 + `src` texture 1 + `blurred`
+    /// texture 2; both textures `filterable: false` because the shader reads them
+    /// with `textureLoad`, keeping the box-blur on exact texel centers like the CPU
+    /// crate). All targets are `Rgba8Unorm`, `blend: None`.
+    fn build_bleed_pipelines(&self) -> BleedPipelines {
+        let format = wgpu::TextureFormat::Rgba8Unorm;
+        let bind_group_layout =
+            self.device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("orber-bleed-bgl"),
+                    entries: &[
+                        uniform_entry(0),
+                        // `src` / `blurred` read via textureLoad (no sampler).
+                        orb_texture_entry(1),
+                        orb_texture_entry(2),
+                    ],
+                });
+        let shader = self
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("orber-bleed-shader"),
+                source: wgpu::ShaderSource::Wgsl(orb_glyph_bleed_wgsl().into()),
+            });
+        let pipeline_layout = self
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("orber-bleed-pl"),
+                bind_group_layouts: &[Some(&bind_group_layout)],
+                immediate_size: 0,
+            });
+        let make = |fs_entry: &str| {
+            self.device
+                .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                    label: Some("orber-bleed-pipeline"),
+                    layout: Some(&pipeline_layout),
+                    vertex: wgpu::VertexState {
+                        module: &shader,
+                        entry_point: Some("vs_main"),
+                        compilation_options: Default::default(),
+                        buffers: &[],
+                    },
+                    fragment: Some(wgpu::FragmentState {
+                        module: &shader,
+                        entry_point: Some(fs_entry),
+                        compilation_options: Default::default(),
+                        targets: &[Some(wgpu::ColorTargetState {
+                            format,
+                            blend: None,
+                            write_mask: wgpu::ColorWrites::ALL,
+                        })],
+                    }),
+                    primitive: wgpu::PrimitiveState::default(),
+                    depth_stencil: None,
+                    multisample: wgpu::MultisampleState::default(),
+                    multiview_mask: None,
+                    cache: None,
+                })
+        };
+        BleedPipelines {
+            blur_h: make("fs_blur_h"),
+            blur_v: make("fs_blur_v"),
+            halo: make("fs_halo"),
+            compose: make("fs_compose"),
+            bind_group_layout,
+        }
+    }
+
+    /// Get-or-build the per-size bleed intermediate textures (`fill` + blur
+    /// ping-pong), allocating only on first use of a `(width, height)`. Grow-only
+    /// like `sized_cache`.
+    fn bleed_textures<R>(&self, width: u32, height: u32, f: impl FnOnce(&BleedTextures) -> R) -> R {
+        let mut map = self
+            .bleed_textures
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let entry = map
+            .entry((width, height))
+            .or_insert_with(|| Self::build_bleed_textures(&self.device, width, height));
+        f(entry)
+    }
+
+    /// Allocate the three `Rgba8Unorm` bleed intermediates for a size: `fill` (the
+    /// glyph fill target, sampled by the bleed passes) and the `ping` / `pong`
+    /// blur ping-pong. Each is `RENDER_ATTACHMENT | TEXTURE_BINDING` (written by one
+    /// pass, read by the next); none needs `COPY_SRC` (only `res.target` is read
+    /// back).
+    fn build_bleed_textures(device: &wgpu::Device, width: u32, height: u32) -> BleedTextures {
+        let format = wgpu::TextureFormat::Rgba8Unorm;
+        let usage = wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING;
+        let make = |label: &str| {
+            let tex = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some(label),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage,
+                view_formats: &[],
+            });
+            tex.create_view(&wgpu::TextureViewDescriptor::default())
+        };
+        BleedTextures {
+            fill_view: make("orber-bleed-fill"),
+            ping_view: make("orber-bleed-ping"),
+            pong_view: make("orber-bleed-pong"),
+        }
+    }
+
+    /// The Glyph (#214) render: draw the glyph fill into the `fill` intermediate,
+    /// run the aquarelle bleed pass group over it (premultiply → separable
+    /// box-blur ×[`BLEED_BLUR_ITERATIONS`] → halo saturation → intensity compose +
+    /// finalize) into `res.target`, then read `res.target` back. `fill_pipeline` /
+    /// `fill_bind_group` are the already-built Glyph fill pipeline + bind group.
+    ///
+    /// One command encoder records every pass in order; wgpu serializes passes that
+    /// read a texture a prior pass wrote, so the box-blur ping-pong is correct
+    /// without manual barriers. All work runs under the outer `render_guard`, so
+    /// concurrent `render_frame` calls cannot alias these shared intermediates.
+    fn run_glyph_fill_bleed_readback(
+        &self,
+        fill_pipeline: &wgpu::RenderPipeline,
+        fill_bind_group: &wgpu::BindGroup,
+        res: &SizedResources,
+    ) -> RgbaImage {
+        let (width, height) = (res.width, res.height);
+        let extent = wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        };
+
+        self.bleed_pipelines(|bp| {
+            self.bleed_textures(width, height, |bt| {
+                let mut encoder =
+                    self.device
+                        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                            label: Some("orber-glyph-bleed-encoder"),
+                        });
+
+                // 1) Glyph fill → `fill` (straight RGBA, as the glyph shader emits).
+                self.record_fullscreen_pass(
+                    &mut encoder,
+                    "orber-glyph-fill-pass",
+                    &bt.fill_view,
+                    fill_pipeline,
+                    fill_bind_group,
+                );
+
+                // 2) Bleed pass group. Two blur textures ping-pong: H always writes
+                // `ping` (reading the previous V output, or `fill` on iter 0), V
+                // always reads `ping` and writes `pong`. After every iteration the
+                // blurred layer is in `pong`; the next H reads `pong`. No pass ever
+                // reads and writes the same texture. The first H pass sets
+                // `premultiply = 1` to turn the straight fill into premultiplied;
+                // every later pass reads already-premultiplied data.
+                let base = |radius: f32, premultiply: f32| BleedParams {
+                    resolution: [width as f32, height as f32],
+                    radius,
+                    premultiply,
+                    halo_factor: BLEED_HALO_FACTOR,
+                    intensity: BLEED_INTENSITY,
+                    _pad0: 0.0,
+                    _pad1: 0.0,
+                };
+                for i in 0..BLEED_BLUR_ITERATIONS {
+                    // H: (fill | pong) → ping. premultiply only on the first pass.
+                    let h_src = if i == 0 { &bt.fill_view } else { &bt.pong_view };
+                    self.record_bleed_pass(
+                        &mut encoder,
+                        bp,
+                        &bp.blur_h,
+                        &bt.ping_view,
+                        h_src,
+                        None,
+                        base(BLEED_BOX_RADIUS, if i == 0 { 1.0 } else { 0.0 }),
+                    );
+                    // V: ping → pong.
+                    self.record_bleed_pass(
+                        &mut encoder,
+                        bp,
+                        &bp.blur_v,
+                        &bt.pong_view,
+                        &bt.ping_view,
+                        None,
+                        base(BLEED_BOX_RADIUS, 0.0),
+                    );
+                }
+                // The 3×(H,V) blurred premult layer is now in `pong`.
+
+                // 3) Halo saturation boost: pong → ping (ping is free again).
+                self.record_bleed_pass(
+                    &mut encoder,
+                    bp,
+                    &bp.halo,
+                    &bt.ping_view,
+                    &bt.pong_view,
+                    None,
+                    base(BLEED_BOX_RADIUS, 0.0),
+                );
+
+                // 4) Compose + finalize: original = `fill` (premultiplied inline),
+                // blurred = halo output (`ping`) → `res.target` (straight RGBA, read
+                // back).
+                self.record_bleed_pass(
+                    &mut encoder,
+                    bp,
+                    &bp.compose,
+                    &res.target_view,
+                    &bt.fill_view,
+                    Some(&bt.ping_view),
+                    base(BLEED_BOX_RADIUS, 0.0),
+                );
+
+                self.copy_target_and_readback(encoder, extent, res)
+            })
+        })
+    }
+
+    /// Record a single full-screen triangle pass into `target` with `pipeline` +
+    /// `bind_group` (clear-to-transparent load). Shared by the glyph fill pass and
+    /// indirectly by the bleed passes.
+    fn record_fullscreen_pass(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        label: &str,
+        target: &wgpu::TextureView,
+        pipeline: &wgpu::RenderPipeline,
+        bind_group: &wgpu::BindGroup,
+    ) {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some(label),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: wgpu::StoreOp::Store,
+                },
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, bind_group, &[]);
+        pass.draw(0..3, 0..1);
+    }
+
+    /// Record one bleed sub-pass: build the per-pass uniform + bind group (uniform
+    /// 0, `src` texture 1, `blurred` texture 2 — bound to `src` itself when the pass
+    /// does not use a second input), then draw the full-screen triangle into
+    /// `target`. `pipeline` selects which `orb_glyph_bleed.wgsl` fragment entry runs.
+    #[allow(clippy::too_many_arguments)]
+    fn record_bleed_pass(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        bp: &BleedPipelines,
+        pipeline: &wgpu::RenderPipeline,
+        target: &wgpu::TextureView,
+        src: &wgpu::TextureView,
+        blurred: Option<&wgpu::TextureView>,
+        params: BleedParams,
+    ) {
+        let params_buffer = self
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("orber-bleed-params"),
+                contents: bytemuck::bytes_of(&params),
+                usage: wgpu::BufferUsages::UNIFORM,
+            });
+        // Binding 2 (`blurred`) is only read by the compose pass; for the other
+        // passes bind `src` to it so the one bind-group layout is always satisfied.
+        let blurred_view = blurred.unwrap_or(src);
+        let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("orber-bleed-bg"),
+            layout: &bp.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: params_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(src),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::TextureView(blurred_view),
+                },
+            ],
+        });
+        self.record_fullscreen_pass(encoder, "orber-bleed-pass", target, pipeline, &bind_group);
     }
 }
 

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -445,6 +445,34 @@ impl GpuRenderer {
             .len()
     }
 
+    /// Number of live entries in the grow-only per-size bleed-texture cache (one
+    /// `BleedTextures` per distinct `(width, height)`). Exposed for the #214
+    /// bleed-cache tests (`gpu_glyph_bleed_textures_reuse_same_size` /
+    /// `gpu_glyph_bleed_textures_grow_on_new_size`): re-rendering a glyph at the
+    /// same size must keep this at 1, while a new size must add an entry. Mirrors
+    /// the `cache_sizes` / `glyph_sdf_cache_len` hooks (poison recovery via
+    /// `into_inner`, `#[cfg(test)]` so the production API stays clean).
+    #[cfg(test)]
+    fn bleed_textures_len(&self) -> usize {
+        self.bleed_textures
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+
+    /// Whether the lazy bleed pipelines have been compiled yet (`Some`). Exposed
+    /// for `gpu_bleed_pipelines_lazy_not_built_for_circle_only`: a Circle-only run
+    /// must leave this `false` (the bleed shader never compiles), and the first
+    /// glyph frame must flip it to `true`. Mirrors the `cache_sizes` /
+    /// `glyph_sdf_cache_len` hooks (poison recovery via `into_inner`).
+    #[cfg(test)]
+    fn bleed_pipelines_built(&self) -> bool {
+        self.bleed_pipelines
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_some()
+    }
+
     /// Get-or-build the Circle pipeline for `shader_wgsl`, compiling the shader and
     /// pipeline only on first use. The closure runs at most once per distinct
     /// shader source for the life of the renderer.
@@ -3200,5 +3228,490 @@ mod tests {
             "same opts/seed/t must render byte-identical glyph frames (rotation ON)"
         );
         eprintln!("glyph determinism: two renders byte-identical");
+    }
+
+    // ---- #214 Phase 1b.5: Glyph bleed/halo 2nd pass (WGSL) ----
+
+    /// A Glyph `AnimateOptions` matching the CPU bleed oracle's setup: a single
+    /// white centered cluster, `orb_size = 1.0`, `softness = Low` (the sharp
+    /// pre-#205 baseline the CPU bleed tests pin so the halo R survives the blur),
+    /// no flow advance / rotation so the glyph sits at the canvas center. Mirrors
+    /// the `orb.rs` `glyph_bleed_produces_halo_around_lit_pixel_cluster` opts.
+    fn glyph_bleed_opts(w: u32, h: u32) -> AnimateOptions {
+        AnimateOptions {
+            width: w,
+            height: h,
+            orb_size: 1.0,
+            blur: 0.5,
+            saturation: 1.0,
+            direction: MotionDirection::LeftToRight,
+            speed: MotionSpeed::Slow,
+            seed: 0,
+            count: Some(1),
+            background: [0, 0, 0, 255],
+            shape: OrbShape::Glyph {
+                ch: '☆',
+                font: crate::glyph::GlyphFontId::NotoSymbols2,
+            },
+            softness: SoftnessPreset::Low,
+            glyph_rotate: false,
+            color_tracks: None,
+            keyframe_tracks: None,
+        }
+    }
+
+    /// #214 (A): the GPU bleed pass must leak a **halo ring** outside the glyph
+    /// body — the direct evidence the box-blur/compose 2nd pass ran. Mirrors the
+    /// CPU oracle `glyph_bleed_produces_halo_around_lit_pixel_cluster`: a single
+    /// white ☆ at 64×64, `orb_size = 1.0` (radius ≈ 16 px, center (32,32)). The
+    /// star body is essentially complete by r ≈ 16; the ring 18..21 px from the
+    /// center is outside the body, so any lit (R>0) pixel there must come from the
+    /// bleed pass spreading the fill outward. Without the 2nd pass that ring would
+    /// be pure background black. Loose count (`>= 10`) like the CPU oracle (noise
+    /// is omitted on the GPU, so the absolute count differs from the CPU's).
+    #[test]
+    fn gpu_glyph_bleed_produces_halo_ring() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_bleed_produces_halo_ring") else {
+            return;
+        };
+        eprintln!(
+            "GPU Glyph bleed halo test running on adapter: {}",
+            renderer.adapter_name()
+        );
+        let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
+        let opts = glyph_bleed_opts(64, 64);
+        let img = renderer.render_frame_glyph(&[c], &opts, 0.0);
+        assert_eq!(img.dimensions(), (64, 64));
+        let (cx, cy) = (32.0f32, 32.0f32);
+        let mut halo_count = 0usize;
+        let mut halo_max_r = 0u8;
+        for y in 0..64u32 {
+            for x in 0..64u32 {
+                let dx = x as f32 - cx;
+                let dy = y as f32 - cy;
+                let d = (dx * dx + dy * dy).sqrt();
+                if (18.0..21.0).contains(&d) {
+                    let px = img.get_pixel(x, y);
+                    if px[0] > 0 {
+                        halo_count += 1;
+                        halo_max_r = halo_max_r.max(px[0]);
+                    }
+                }
+            }
+        }
+        assert!(
+            halo_count >= 10,
+            "GPU bleed pass must leak a halo (R>0) into the ring 18..21px from the \
+             glyph center; found {halo_count} halo pixels (max R = {halo_max_r}). \
+             A missing 2nd pass would leave this ring pure background black."
+        );
+        eprintln!("gpu bleed halo ring: {halo_count} lit pixels (max R = {halo_max_r})");
+    }
+
+    /// #214 (A): the bleed pass must not wash the glyph fill out — the lit body
+    /// pixels must survive the box-blur/compose. Mirrors the CPU oracle
+    /// `glyph_lit_pixels_remain_visible_after_bleed` (softness Low ☆, `lit > 32`
+    /// counted as R > 32). If the compose `intensity` over-weighted the (dimmer)
+    /// blurred layer the bright body would collapse below this threshold.
+    #[test]
+    fn gpu_glyph_lit_pixels_remain_visible_after_bleed() {
+        let Some(renderer) =
+            require_or_skip_renderer("gpu_glyph_lit_pixels_remain_visible_after_bleed")
+        else {
+            return;
+        };
+        let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
+        let opts = glyph_bleed_opts(100, 100);
+        let img = renderer.render_frame_glyph(&[c], &opts, 0.0);
+        let lit = img.pixels().filter(|p| p[0] > 32).count();
+        assert!(
+            lit > 32,
+            "glyph lit pixels must survive the GPU bleed pass (R>32), got lit={lit}"
+        );
+        eprintln!("gpu lit-after-bleed: lit={lit}");
+    }
+
+    /// #214 (A): empty clusters routed explicitly through `render_frame_glyph`
+    /// must stay background-only after the bleed contract — a blur of nothing is
+    /// still nothing. (The empty path early-outs before the fill, so this also
+    /// pins that the bleed orchestration is never asked to halo a blank canvas.)
+    /// Named for the bleed intent even though `gpu_glyph_empty_clusters_background_only`
+    /// covers the plain glyph dispatch.
+    #[test]
+    fn gpu_glyph_bleed_empty_clusters_stays_background() {
+        let Some(renderer) =
+            require_or_skip_renderer("gpu_glyph_bleed_empty_clusters_stays_background")
+        else {
+            return;
+        };
+        let opts = glyph_bleed_opts(48, 40);
+        let img = renderer.render_frame_glyph(&[], &opts, 0.3);
+        assert_eq!(img.dimensions(), (48, 40));
+        let lit = lit_vs_bg(&img, opts.background, 1);
+        assert_eq!(
+            lit, 0,
+            "empty clusters + glyph bleed path must stay background-only, got {lit} non-bg pixels"
+        );
+    }
+
+    /// #214 (A): a weight-0 cluster yields zero orbs (radius 0 → skipped), so the
+    /// glyph fill is empty and the bleed pass has nothing to spread. The frame
+    /// must stay background-only. Mirrors the CPU oracle
+    /// `glyph_zero_weight_cluster_stays_black_after_bleed`.
+    #[test]
+    fn gpu_glyph_bleed_weight_zero_stays_background() {
+        let Some(renderer) =
+            require_or_skip_renderer("gpu_glyph_bleed_weight_zero_stays_background")
+        else {
+            return;
+        };
+        let opts = glyph_bleed_opts(48, 40);
+        let img =
+            renderer.render_frame_glyph(&[cluster([255, 255, 255], 0.5, 0.5, 0.0)], &opts, 0.3);
+        let lit = lit_vs_bg(&img, opts.background, 1);
+        assert_eq!(
+            lit, 0,
+            "weight=0 cluster + glyph bleed path must stay background-only, got {lit} non-bg pixels"
+        );
+    }
+
+    /// #214 (A): an unknown glyph (pizza emoji, absent from the bundled Symbols 2
+    /// subset) produces no SDF, so the fill is empty and the bleed pass spreads
+    /// nothing — the frame must stay background-only. The "draw nothing for tofu"
+    /// contract must hold through the bleed path too.
+    #[test]
+    fn gpu_glyph_bleed_unknown_char_stays_background() {
+        let Some(renderer) =
+            require_or_skip_renderer("gpu_glyph_bleed_unknown_char_stays_background")
+        else {
+            return;
+        };
+        let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
+        let mut opts = glyph_bleed_opts(48, 40);
+        opts.shape = OrbShape::Glyph {
+            ch: '\u{1F355}', // pizza — not in Noto Sans Symbols 2
+            font: crate::glyph::GlyphFontId::NotoSymbols2,
+        };
+        let img = renderer.render_frame_glyph(&[c], &opts, 0.3);
+        let lit = lit_vs_bg(&img, opts.background, 1);
+        assert_eq!(
+            lit, 0,
+            "unknown glyph + bleed path must stay background-only, got {lit} non-bg pixels"
+        );
+    }
+
+    /// #214 (A): the whole glyph + bleed pipeline is fully deterministic. The
+    /// paper-grain noise (the one nondeterministic-looking step) is omitted on the
+    /// GPU, so the same opts/seed/t rendered twice must be **byte-identical** — no
+    /// jitter from the box-blur ping-pong, the halo HSL transform, or the compose.
+    /// Stronger than `gpu_glyph_determinism_same_seed_same_output` because it pins
+    /// determinism specifically over the bleed pass (single centered glyph, the
+    /// halo well clear of the body).
+    #[test]
+    fn gpu_glyph_bleed_determinism_byte_identical() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_bleed_determinism_byte_identical")
+        else {
+            return;
+        };
+        let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
+        let opts = glyph_bleed_opts(64, 64);
+        let a = renderer.render_frame_glyph(&[c], &opts, 0.42);
+        let b = renderer.render_frame_glyph(&[c], &opts, 0.42);
+        assert_eq!(
+            a, b,
+            "glyph bleed pass must be byte-identical on repeat (noise omitted → full determinism)"
+        );
+        eprintln!("gpu glyph bleed determinism: two renders byte-identical");
+    }
+
+    /// #214 (A / D1 pin): adding the bleed pass group must leave the **Circle**
+    /// path untouched. Circle never enters `run_glyph_fill_bleed_readback` (it goes
+    /// through `run_pass_and_readback` instead), so a Circle frame must still match
+    /// the CPU oracle within the ±2/channel contract every other Circle parity test
+    /// uses. This is the explicit non-regression pin that the #214 addition did not
+    /// leak into the Circle dispatch.
+    #[test]
+    fn gpu_circle_unaffected_by_bleed_addition() {
+        let Some(renderer) = require_or_skip_renderer("gpu_circle_unaffected_by_bleed_addition")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let mut overall_max = 0u8;
+        for &(dir, t) in &[
+            (MotionDirection::LeftToRight, 0.0_f32),
+            (MotionDirection::TopToBottom, 0.5),
+            (MotionDirection::BottomToTop, 1.0),
+        ] {
+            let opts = circle_opts(48, 32, dir, MotionSpeed::Mid);
+            let cpu = render_frame(&clusters, &opts, t);
+            let gpu = renderer.render_frame(&clusters, &opts, t);
+            let max_diff = assert_within_tolerance(
+                &cpu,
+                &gpu,
+                &format!("circle bleed-unaffected {dir:?} t={t}"),
+            );
+            overall_max = overall_max.max(max_diff);
+        }
+        eprintln!(
+            "circle unaffected by bleed addition: overall max per-channel diff = {overall_max}"
+        );
+    }
+
+    /// #214 (B): the box-blur radius clamp (`r = min(radius, w-1)` / `min(radius,
+    /// h-1)` in `orb_glyph_bleed.wgsl`) must keep tiny canvases from sampling out
+    /// of bounds. Several sub-`2r+1` sizes (1×1, 2×2, 5×4, where the box radius 3
+    /// exceeds the dimension) must render without panic / device loss and produce a
+    /// correctly-sized image. A missing clamp would read negative / past-edge
+    /// texels.
+    #[test]
+    fn gpu_glyph_bleed_tiny_canvas_no_panic() {
+        let Some(renderer) = require_or_skip_renderer("gpu_glyph_bleed_tiny_canvas_no_panic")
+        else {
+            return;
+        };
+        let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
+        for &(w, h) in &[(1u32, 1u32), (2, 2), (5, 4)] {
+            let opts = glyph_bleed_opts(w, h);
+            let img = renderer.render_frame_glyph(&[c], &opts, 0.0);
+            assert_eq!(
+                img.dimensions(),
+                (w, h),
+                "tiny {w}x{h} glyph bleed frame must have correct dims (radius clamp held)"
+            );
+        }
+        eprintln!("gpu glyph bleed tiny canvas: 1x1 / 2x2 / 5x4 rendered without panic");
+    }
+
+    /// #214 (B): re-rendering a glyph at the **same size** must reuse the cached
+    /// `BleedTextures` (fill + ping/pong), leaving the per-size bleed cache at
+    /// exactly one entry — mirrors `caches_resources_across_a_clip` for the bleed
+    /// intermediates. Uses a *fresh* renderer so the count is observable in
+    /// isolation (the shared renderer accumulates sizes from other tests).
+    #[test]
+    fn gpu_glyph_bleed_textures_reuse_same_size() {
+        let Some(renderer) =
+            require_or_skip_fresh_renderer("gpu_glyph_bleed_textures_reuse_same_size")
+        else {
+            return;
+        };
+        let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
+        let opts = glyph_bleed_opts(64, 48);
+        assert_eq!(
+            renderer.bleed_textures_len(),
+            0,
+            "no glyph frame yet → 0 bleed entries"
+        );
+        let _ = renderer.render_frame_glyph(&[c], &opts, 0.0);
+        assert_eq!(
+            renderer.bleed_textures_len(),
+            1,
+            "first glyph frame must allocate exactly one bleed-texture entry"
+        );
+        let _ = renderer.render_frame_glyph(&[c], &opts, 0.5);
+        assert_eq!(
+            renderer.bleed_textures_len(),
+            1,
+            "same-size second glyph frame must reuse the cached bleed textures (still 1)"
+        );
+    }
+
+    /// #214 (B): a glyph frame at a **new size** must add one bleed-texture entry
+    /// (grow-only, like `sized_cache`). Uses a *fresh* renderer so the exact entry
+    /// count is observable. Two distinct sizes → exactly two entries.
+    #[test]
+    fn gpu_glyph_bleed_textures_grow_on_new_size() {
+        let Some(renderer) =
+            require_or_skip_fresh_renderer("gpu_glyph_bleed_textures_grow_on_new_size")
+        else {
+            return;
+        };
+        let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
+        let _ = renderer.render_frame_glyph(&[c], &glyph_bleed_opts(64, 48), 0.0);
+        assert_eq!(
+            renderer.bleed_textures_len(),
+            1,
+            "first size → 1 bleed entry"
+        );
+        let _ = renderer.render_frame_glyph(&[c], &glyph_bleed_opts(40, 32), 0.0);
+        assert_eq!(
+            renderer.bleed_textures_len(),
+            2,
+            "a second distinct size must add one bleed-texture entry (grow-only)"
+        );
+    }
+
+    /// #214 (B): the bleed pipelines are **lazy** — a renderer that only ever drew
+    /// Circle frames must never compile the bleed shader (`bleed_pipelines_built()`
+    /// stays `false`), and the first glyph (lit) frame must compile them (flips to
+    /// `true`). A fresh renderer isolates the lazy state. Uses a real ☆ so the
+    /// glyph path actually enters `run_glyph_fill_bleed_readback` (an empty/unknown
+    /// glyph early-outs through the Circle pipeline and would *not* build them).
+    #[test]
+    fn gpu_bleed_pipelines_lazy_not_built_for_circle_only() {
+        let Some(renderer) =
+            require_or_skip_fresh_renderer("gpu_bleed_pipelines_lazy_not_built_for_circle_only")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        assert!(
+            !renderer.bleed_pipelines_built(),
+            "fresh renderer must not have compiled the bleed pipelines yet"
+        );
+        // Several Circle frames: still no bleed shader.
+        let circle = circle_opts(48, 32, MotionDirection::LeftToRight, MotionSpeed::Slow);
+        for k in 0..4 {
+            let _ = renderer.render_frame(&clusters, &circle, k as f32 / 4.0);
+        }
+        assert!(
+            !renderer.bleed_pipelines_built(),
+            "Circle-only rendering must never compile the bleed pipelines"
+        );
+        // First glyph frame with a real fill compiles them.
+        let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
+        let _ = renderer.render_frame_glyph(&[c], &glyph_bleed_opts(48, 32), 0.0);
+        assert!(
+            renderer.bleed_pipelines_built(),
+            "the first glyph (lit) frame must compile the bleed pipelines"
+        );
+    }
+
+    /// #214 (C): concurrent glyph+bleed renders on the shared renderer at the
+    /// **same size** must each match their solo oracle within ±2/channel — i.e. the
+    /// bleed intermediates (`fill` / `ping` / `pong`) are never aliased across
+    /// threads. The per-size bleed textures are shared mutable state behind the
+    /// `render_guard`; if a second thread's box-blur overwrote `ping` mid-pass for
+    /// the first thread the halo would corrupt. Several threads hammer the *same*
+    /// size + char + t (collision maximized), each output compared to a fresh solo
+    /// render. Strengthens `shared_gpu_concurrent_glyph_render` by explicitly
+    /// stressing the bleed mid-pass textures (Phase 1a's #210 aliasing class).
+    #[test]
+    fn shared_gpu_concurrent_glyph_bleed_no_aliasing() {
+        let Some(renderer) =
+            require_or_skip_renderer("shared_gpu_concurrent_glyph_bleed_no_aliasing")
+        else {
+            return;
+        };
+        // Same size for every thread so they all contend the one cached
+        // `(w,h)` BleedTextures entry — that is the aliasing surface under test.
+        let (w, h) = (72u32, 56u32);
+        let make_opts = || glyph_bleed_opts(w, h);
+
+        // Solo oracle on a fresh renderer (its own bleed textures, uncontended).
+        let Some(oracle_renderer) = require_or_skip_fresh_renderer(
+            "shared_gpu_concurrent_glyph_bleed_no_aliasing (oracle)",
+        ) else {
+            return;
+        };
+        let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
+        let oracle = oracle_renderer.render_frame_glyph(&[c], &make_opts(), 0.3);
+
+        std::thread::scope(|scope| {
+            let mut handles = Vec::new();
+            for _ in 0..4 {
+                let oracle = &oracle;
+                handles.push(scope.spawn(move || {
+                    let c = cluster([255, 255, 255], 0.5, 0.5, 1.0);
+                    let opts = make_opts();
+                    // Reuse the same char/size/t so all threads collide on the one
+                    // shared BleedTextures entry as hard as possible.
+                    for _ in 0..4 {
+                        let img = renderer.render_frame_glyph(&[c], &opts, 0.3);
+                        assert_within_tolerance(
+                            oracle,
+                            &img,
+                            "concurrent glyph bleed vs solo render (no intermediate aliasing)",
+                        );
+                    }
+                }));
+            }
+            for handle in handles {
+                handle
+                    .join()
+                    .expect("concurrent glyph bleed thread panicked");
+            }
+        });
+        eprintln!("concurrent glyph bleed: all threads matched solo oracle (no mid-pass aliasing)");
+    }
+
+    /// #214 (structural parity tighten): with the bleed pass now reproduced on the
+    /// GPU, the lit bbox and overlap should agree **more tightly** than the
+    /// pre-bleed `gpu_glyph_structural_parity_with_cpu` allowed — bbox within 3 px
+    /// (was 6) and overlap > 80% (was 60%). The **lit-count band [0.5, 2.0] is left
+    /// unchanged**: the GPU omits the paper-grain noise, so the CPU still scatters
+    /// extra faint soft pixels the GPU lacks, and pinning the count ratio tighter
+    /// would be a false positive. The existing looser test is intentionally left in
+    /// place; this one is the tightened companion.
+    #[test]
+    fn gpu_glyph_bleed_parity_tighter_bbox_overlap() {
+        let Some(renderer) =
+            require_or_skip_renderer("gpu_glyph_bleed_parity_tighter_bbox_overlap")
+        else {
+            return;
+        };
+        let clusters = sample_clusters();
+        let opts = glyph_opts(
+            120,
+            90,
+            MotionDirection::LeftToRight,
+            MotionSpeed::Slow,
+            true,
+        );
+        for &t in &[0.0_f32, 0.5] {
+            let cpu = render_frame(&clusters, &opts, t);
+            let gpu = renderer.render_frame_glyph(&clusters, &opts, t);
+            assert_eq!(cpu.dimensions(), gpu.dimensions());
+
+            let bg = opts.background;
+            let cpu_lit = lit_vs_bg(&cpu, bg, 8);
+            let gpu_lit = lit_vs_bg(&gpu, bg, 8);
+            assert!(cpu_lit > 0 && gpu_lit > 0, "both paths must light pixels");
+
+            // Lit-count band left at the looser [0.5, 2.0] (noise omitted on GPU).
+            let ratio = gpu_lit as f32 / cpu_lit as f32;
+            assert!(
+                (0.5..=2.0).contains(&ratio),
+                "t={t}: gpu_lit={gpu_lit}/cpu_lit={cpu_lit}={ratio:.2}, band [0.5,2.0] (unchanged)"
+            );
+
+            // Tighter bbox: 3 px slack on each edge (was 6).
+            let cb = lit_bbox(&cpu, bg, 8).expect("cpu has lit pixels");
+            let gb = lit_bbox(&gpu, bg, 8).expect("gpu has lit pixels");
+            let tol = 3i64;
+            for (label, a, b) in [
+                ("minx", cb.0 as i64, gb.0 as i64),
+                ("miny", cb.1 as i64, gb.1 as i64),
+                ("maxx", cb.2 as i64, gb.2 as i64),
+                ("maxy", cb.3 as i64, gb.3 as i64),
+            ] {
+                assert!(
+                    (a - b).abs() <= tol,
+                    "t={t}: lit bbox {label} differs by {} (cpu={a} gpu={b}), tightened tol={tol}",
+                    (a - b).abs()
+                );
+            }
+
+            // Tighter overlap: > 80% of the smaller lit set (was 60%).
+            let mut overlap = 0usize;
+            for (cp, gp) in cpu.pixels().zip(gpu.pixels()) {
+                let c_lit = (0..3).any(|c| cp.0[c].abs_diff(bg[c]) > 8);
+                let g_lit = (0..3).any(|c| gp.0[c].abs_diff(bg[c]) > 8);
+                if c_lit && g_lit {
+                    overlap += 1;
+                }
+            }
+            let overlap_frac = overlap as f32 / cpu_lit.min(gpu_lit) as f32;
+            assert!(
+                overlap_frac > 0.8,
+                "t={t}: lit overlap {:.1}% of the smaller set; tightened expectation >80%",
+                overlap_frac * 100.0
+            );
+            eprintln!(
+                "glyph bleed tighter parity t={t}: cpu_lit={cpu_lit} gpu_lit={gpu_lit} \
+                 ratio={ratio:.2} overlap={:.1}%",
+                overlap_frac * 100.0
+            );
+        }
     }
 }

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -892,7 +892,13 @@ impl GpuRenderer {
 
         // No glyph (radius 0 / unknown char / empty SDF) ⇒ background-only frame,
         // matching the CPU "draw nothing" contract. Build a glyph-shaped pack with
-        // zero orbs so only the background paints.
+        // zero orbs so only the background paints. This routes through `render_packed`
+        // (the Circle path), so the bleed 2nd pass is skipped — intentional: the CPU
+        // runs `render_aquarelle_bleed_pass` unconditionally for Glyph, but blurring
+        // orber's uniform opaque background is a no-op *up to the omitted paper-grain
+        // noise* (the CPU would jitter that flat background by ±0.05; the GPU leaves it
+        // flat). Both yield a background-only frame within the same noise-omitted
+        // loose-parity contract this pass already accepts.
         let Some((sdf, sdf_size)) =
             crate::glyph::cached_glyph_sdf_for_radius(font, ch, frame_radius)
         else {

--- a/crates/core/src/orb_glyph_bleed.wgsl
+++ b/crates/core/src/orb_glyph_bleed.wgsl
@@ -1,0 +1,245 @@
+// orber #214 Phase 1b.5 — Glyph orb の aquarelle bleed/halo パスを WGSL 化。
+//
+// CPU 経路（`crate::animate::render_frame` が全 orb 描画後に 1 回かける
+// `aquarelle::render_aquarelle_bleed_pass`、default params seed=0）を 2nd pass 群
+// として GPU に写したもの。glyph fill（#212、straight RGBA を中間テクスチャに描画）
+// を入力に、premultiply → 分離 box-blur×3 → halo saturation → compose → finalize
+// の順で backbuffer に straight RGBA を出力する。
+//
+// aquarelle 0.2 `render_aquarelle_bleed_pass`（default: radius=3.0, intensity=0.5,
+// halo=0.3）のアルゴリズム:
+//   1. premult RGBA スナップショット original → blurred = original.clone()
+//   2. box_radius = round(radius*1.15).max(1) = 3 の 分離 box-blur を ×3
+//      （各回 H→V）。box-blur は clamp-to-edge、window = 2r+1 の単純平均。
+//      crate は各 H/V パスごとに u8 へ量子化する（中間が Rgba8Unorm なので一致）。
+//   3. halo: boost_saturation_buffer(blurred, 1.0 + 0.6*halo) = ×1.18。
+//      un-premult → sRGB→HSL → saturation*factor を clamp(0,1) → HSL→sRGB → re-premult。
+//      a==0 は hue 未定義なのでスキップ。
+//   4. paper-grain noise（ChaCha8Rng(seed=0) をピクセル順消費、振幅 ±0.1*intensity）。
+//      **GPU では省略する。** ChaCha8 のピクセル順消費は並列 GPU で bit 一致再現が
+//      非現実的で、効果も faint（±0.05）。loose parity の確定方針。CPU との差は
+//      期待値（将来 WGSL hash で近似可）。
+//   5. compose: dst = original*(1-intensity) + blurred*intensity（全 channel・premult）。
+//      intensity = 0.5。
+//
+// すべて premult RGBA（0..1）で処理し、最後の compose で finalize（un-premult して
+// straight 化）する。box-blur は textureLoad（整数 texel fetch）で隣接 texel を読み、
+// CPU の格子点平均と一致させる（sampler 補間は使わない）。clamp-to-edge は
+// clamp(coord, 0, dim-1) で実装。
+//
+// パリティ範囲: bit-exact は課さない。構造 + 緩い許容（halo が lit cluster 周囲に出る /
+// lit pixel が bleed 後も visible / 空 clusters・weight0 は背景黒）。noise 省略ぶんと
+// HSL 実装差は CPU と差が出るが期待値。
+
+struct BleedParams {
+    resolution: vec2<f32>, // (width, height) px
+    radius: f32,           // box-blur 半径（texel）。default 3。
+    premultiply: f32,      // 1.0 = 入力を straight とみなし読み込み時に premult 化（iter0 H のみ）
+    halo_factor: f32,      // saturation 倍率（1.0 + 0.6*halo = 1.18）
+    intensity: f32,        // compose の混合率（0..1、default 0.5）
+    _pad0: f32,
+    _pad1: f32,
+};
+
+@group(0) @binding(0) var<uniform> params: BleedParams;
+@group(0) @binding(1) var src: texture_2d<f32>;
+// compose だけが 2 枚目（blurred）を読む。他パスは binding 2 を src と同じ view に
+// バインドして無視する（bind group layout を 1 つに統一するため）。
+@group(0) @binding(2) var blurred_tex: texture_2d<f32>;
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VsOut {
+    var xy = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>(3.0, -1.0),
+        vec2<f32>(-1.0, 3.0),
+    );
+    var out: VsOut;
+    out.pos = vec4<f32>(xy[vi], 0.0, 1.0);
+    return out;
+}
+
+fn clampi(x: i32, lo: i32, hi: i32) -> i32 {
+    return min(max(x, lo), hi);
+}
+
+// src texel を読む。premultiply=1.0 のときは straight とみなして rgb *= a する。
+fn load_premult(ix: i32, iy: i32) -> vec4<f32> {
+    let c = textureLoad(src, vec2<i32>(ix, iy), 0);
+    if (params.premultiply > 0.5) {
+        return vec4<f32>(c.rgb * c.a, c.a);
+    }
+    return c;
+}
+
+// 量子化（CPU の各 box-blur パス末尾 `(v).clamp(0,255).round() as u8` を写す）。
+// 中間ターゲットは Rgba8Unorm なので store で同じ丸めが起きるが、明示しておく。
+fn quantize8(v: vec4<f32>) -> vec4<f32> {
+    return floor(clamp(v, vec4<f32>(0.0), vec4<f32>(1.0)) * 255.0 + 0.5) / 255.0;
+}
+
+// 水平 box-blur（clamp-to-edge、window = 2r+1 の単純平均）。
+// CPU box_blur_horizontal: radius を width-1 で cap、左右端は端 texel にクランプ。
+@fragment
+fn fs_blur_h(in: VsOut) -> @location(0) vec4<f32> {
+    let w = i32(params.resolution.x);
+    let h = i32(params.resolution.y);
+    let x = clampi(i32(floor(in.pos.x)), 0, w - 1);
+    let y = clampi(i32(floor(in.pos.y)), 0, h - 1);
+    let r = min(i32(params.radius), w - 1);
+    let window = f32(2 * r + 1);
+    var sum = vec4<f32>(0.0);
+    for (var k: i32 = -r; k <= r; k = k + 1) {
+        let sx = clampi(x + k, 0, w - 1);
+        sum = sum + load_premult(sx, y);
+    }
+    return quantize8(sum / window);
+}
+
+// 垂直 box-blur。CPU box_blur_vertical の写し。premultiply は H パスだけが立てる
+// （V パスの入力は既に premult なので premultiply=0）。
+@fragment
+fn fs_blur_v(in: VsOut) -> @location(0) vec4<f32> {
+    let w = i32(params.resolution.x);
+    let h = i32(params.resolution.y);
+    let x = clampi(i32(floor(in.pos.x)), 0, w - 1);
+    let y = clampi(i32(floor(in.pos.y)), 0, h - 1);
+    let r = min(i32(params.radius), h - 1);
+    let window = f32(2 * r + 1);
+    var sum = vec4<f32>(0.0);
+    for (var k: i32 = -r; k <= r; k = k + 1) {
+        let sy = clampi(y + k, 0, h - 1);
+        sum = sum + load_premult(x, sy);
+    }
+    return quantize8(sum / window);
+}
+
+// sRGB（encoded、0..1）→ HSL。palette の Hsl::from_color(Srgb) は encoded 値を
+// 直接 HSL 化する（linearize しない）ので、標準 RGB→HSL をそのまま使う。
+// 返り値 = (h[0,1), s[0,1], l[0,1])。
+fn rgb_to_hsl(rgb: vec3<f32>) -> vec3<f32> {
+    let maxc = max(rgb.r, max(rgb.g, rgb.b));
+    let minc = min(rgb.r, min(rgb.g, rgb.b));
+    let l = (maxc + minc) * 0.5;
+    let delta = maxc - minc;
+    var h = 0.0;
+    var s = 0.0;
+    if (delta > 0.0) {
+        if (l < 0.5) {
+            s = delta / (maxc + minc);
+        } else {
+            s = delta / (2.0 - maxc - minc);
+        }
+        if (maxc == rgb.r) {
+            h = (rgb.g - rgb.b) / delta;
+            if (rgb.g < rgb.b) {
+                h = h + 6.0;
+            }
+        } else if (maxc == rgb.g) {
+            h = (rgb.b - rgb.r) / delta + 2.0;
+        } else {
+            h = (rgb.r - rgb.g) / delta + 4.0;
+        }
+        h = h / 6.0;
+    }
+    return vec3<f32>(h, s, l);
+}
+
+fn hue_channel(p: f32, q: f32, t_in: f32) -> f32 {
+    var t = t_in;
+    if (t < 0.0) {
+        t = t + 1.0;
+    }
+    if (t > 1.0) {
+        t = t - 1.0;
+    }
+    if (t < 1.0 / 6.0) {
+        return p + (q - p) * 6.0 * t;
+    }
+    if (t < 0.5) {
+        return q;
+    }
+    if (t < 2.0 / 3.0) {
+        return p + (q - p) * (2.0 / 3.0 - t) * 6.0;
+    }
+    return p;
+}
+
+// HSL → sRGB（encoded、0..1）。標準逆変換。
+fn hsl_to_rgb(hsl: vec3<f32>) -> vec3<f32> {
+    let h = hsl.x;
+    let s = hsl.y;
+    let l = hsl.z;
+    if (s <= 0.0) {
+        return vec3<f32>(l, l, l);
+    }
+    var q = 0.0;
+    if (l < 0.5) {
+        q = l * (1.0 + s);
+    } else {
+        q = l + s - l * s;
+    }
+    let p = 2.0 * l - q;
+    let r = hue_channel(p, q, h + 1.0 / 3.0);
+    let g = hue_channel(p, q, h);
+    let b = hue_channel(p, q, h - 1.0 / 3.0);
+    return vec3<f32>(r, g, b);
+}
+
+// halo: boost_saturation_buffer(blurred, halo_factor) を写す。premult を un-premult
+// してから HSL saturation を倍率し、re-premult する。a==0 は hue 未定義でスキップ。
+@fragment
+fn fs_halo(in: VsOut) -> @location(0) vec4<f32> {
+    let w = i32(params.resolution.x);
+    let h = i32(params.resolution.y);
+    let x = clampi(i32(floor(in.pos.x)), 0, w - 1);
+    let y = clampi(i32(floor(in.pos.y)), 0, h - 1);
+    let c = textureLoad(src, vec2<i32>(x, y), 0); // premult
+    let a = c.a;
+    if (a <= 0.0) {
+        return c;
+    }
+    // un-premult（CPU は u8/255 を a で割る。ここでは float のまま）。
+    let straight = clamp(c.rgb / a, vec3<f32>(0.0), vec3<f32>(1.0));
+    var hsl = rgb_to_hsl(straight);
+    hsl.y = clamp(hsl.y * params.halo_factor, 0.0, 1.0);
+    let out = clamp(hsl_to_rgb(hsl), vec3<f32>(0.0), vec3<f32>(1.0));
+    // re-premult。中間が Rgba8Unorm なので store で u8 量子化される。
+    return vec4<f32>(out * a, a);
+}
+
+// compose + finalize: dst_premult = original*(1-t) + blurred*t、その後 finalize で
+// straight 化して出力（backbuffer は Rgba8Unorm）。original は src（glyph fill の
+// straight）を premult 化して再現する（CPU の original premult スナップショット相当）。
+@fragment
+fn fs_compose(in: VsOut) -> @location(0) vec4<f32> {
+    let w = i32(params.resolution.x);
+    let h = i32(params.resolution.y);
+    let x = clampi(i32(floor(in.pos.x)), 0, w - 1);
+    let y = clampi(i32(floor(in.pos.y)), 0, h - 1);
+
+    // original = glyph fill（straight）を premult 化。
+    let fill = textureLoad(src, vec2<i32>(x, y), 0);
+    let orig = vec4<f32>(fill.rgb * fill.a, fill.a);
+    // blurred は既に premult。
+    let blur = textureLoad(blurred_tex, vec2<i32>(x, y), 0);
+
+    let t = params.intensity;
+    let inv = 1.0 - t;
+    // CPU は全 channel を *255 round してから premult のまま保持。ここでは float の
+    // premult で混合する（compose 後 finalize するので途中量子化は省く）。
+    var composed = orig * inv + blur * t;
+    composed = clamp(composed, vec4<f32>(0.0), vec4<f32>(1.0));
+
+    // finalize_pixmap 相当: a==0 → 0、それ以外は straight = premult_rgb / a。
+    let a = composed.a;
+    if (a <= 0.0) {
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    }
+    let straight = clamp(composed.rgb / a, vec3<f32>(0.0), vec3<f32>(1.0));
+    return vec4<f32>(straight, a);
+}


### PR DESCRIPTION
## 関連 Issue
closes #214
Refs #207（umbrella: wgpu 一重化 / Phase 1b.5 スライス2.5）

## 概要
#212 で繰り越した Glyph の **bleed/halo パス**（lit pixel 周りの滲み）を GPU の 2nd pass として WGSL 化。`--renderer gpu --shape glyph` が halo 込みで GPU 描画する。

## 実装
- 新 `orb_glyph_bleed.wgsl`: premult → 分離 box-blur H/V×3（clamp-to-edge, window=2r+1, textureLoad）→ halo saturation（un-premult→HSL→×1.18→re-premult）→ intensity compose 0.5。
- `gpu.rs`: render_packed_inner の Glyph 分岐が fill を中間テクスチャ(Rgba8Unorm)へ描く → bleed パス群（ping-pong fill→ping→pong, halo, compose→target）→ readback。`BleedPipelines`(lazy・Circle のみ run では未コンパイル)、`BleedTextures`(サイズ別 grow-only キャッシュ, Mutex/poison)。定数は aquarelle 0.2 `render_aquarelle_bleed_pass` default（radius3/intensity0.5/halo0.3）由来。
- **paper-grain noise は省略**: ChaCha8 のピクセル順消費は並列 GPU で bit 再現不可・振幅 ±0.05 と faint。loose parity の確定方針として省略し doc 明記（将来 WGSL hash で近似可）。

## parity・非回帰
- **Glyph(bleed込み) は構造＋緩い許容**: 実 GPU で GPU↔CPU エッジランプ ±2-4、mean|diff|=2.87、>10 ずれ 0%、bbox 3px/overlap 100%。
- **Circle は bleed 経路を通らず ±2/ch 維持**（実測 diff 1）。Glyph fill(#212) 構造 parity 維持。
- 共有 renderer の中間テクスチャ(fill/ping/pong)は render_guard 内で直列化＝Phase 1a 競合の再導入なし。

## テスト・検証
- 新規 13 テスト（halo リング / lit visible / 空・weight0・unknown→背景黒 / 決定論 byte 一致 / Circle 非回帰 / 極小キャンバス / BleedTextures キャッシュ再利用・grow / pipeline lazy / 並行 aliasing 無し / tighter bbox+overlap）＋ `#[cfg(test)]` アクセサ。実 GPU で **196 passed**、既定マルチスレッド・`ORBER_REQUIRE_GPU=1` で skip なし。
- 独立レビュー2巡 Approve。clippy/fmt/default/wasm 緑。CI gpu-parity(lavapipe 22.04 マルチスレッド) ハードゲート。