### PR TITLE
feat(gpu): Aquarelle shape を WGSL 化（Phase 1c・全 shape が WGSL に乗る）

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -146,15 +146,16 @@ impl From<CliVariationMode> for VariationMode {
 
 /// Which renderer backend to drive (`--renderer`).
 ///
-/// `gpu` is the wgpu (Rust + WGSL) production path (#207). It falls back to the
-/// CPU renderer when no GPU adapter is available, for non-Circle shapes (Phase 0
-/// covers Circle only), or when the binary was built without the `gpu` feature.
-/// Orb count no longer forces a fallback: per-orb data is a data-texture, so the
-/// GPU renders any count up to 1024 directly (#210 Phase 1a). On the path it
-/// covers — Circle, saturation reflected — the GPU output matches the CPU oracle
-/// within ±2/channel (bit-exact on real GPUs), so those flags give the same image
-/// either backend. Video frames are always rendered on the CPU; color/keyframe
-/// tracks are not yet folded into the GPU pack.
+/// `gpu` is the wgpu (Rust + WGSL) production path (#207). Circle, Glyph (#212)
+/// and Aquarelle (#216) all render on the GPU; the only fallback to the CPU
+/// renderer is when no GPU adapter is available, or when the binary was built
+/// without the `gpu` feature. The `image` shape is web-only. Orb count never
+/// forces a fallback: per-orb data is a data-texture, so the GPU renders any
+/// count up to 1024 directly (#210 Phase 1a). Circle matches the CPU oracle
+/// within ±2/channel (bit-exact on real GPUs); Glyph and Aquarelle match
+/// structurally (float SDF / AA differences only). Video frames are always
+/// rendered on the CPU; color/keyframe tracks are not yet folded into the GPU
+/// pack.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum Renderer {
     /// Reference CPU (tiny-skia) renderer.
@@ -320,12 +321,13 @@ struct Cli {
     shape: Shape,
 
     /// Renderer backend: production `gpu` (wgpu) or the `cpu` reference (#207).
-    /// `gpu` falls back to `cpu` when no GPU adapter is available, for non-Circle
-    /// shapes (Phase 0 covers Circle only), or when built without the `gpu`
-    /// feature. --count no longer triggers a fallback (the GPU renders up to 1024
-    /// orbs via a data-texture, #210). On the covered path (Circle, saturation
-    /// applied) the two match within +/-2/channel; video and color/keyframe tracks
-    /// are cpu-only.
+    /// Circle, Glyph (#212) and Aquarelle (#216) all render on the GPU; `gpu`
+    /// only falls back to `cpu` when no GPU adapter is available or when built
+    /// without the `gpu` feature. The `image` shape is web-only. --count never
+    /// triggers a fallback (the GPU renders up to 1024 orbs via a data-texture,
+    /// #210). Circle matches the CPU oracle within +/-2/channel (bit-exact on
+    /// real GPUs); Glyph and Aquarelle match structurally (float SDF / AA
+    /// differences). Video and color/keyframe tracks are cpu-only.
     /// Default depends on the build: the `gpu` feature builds default to `gpu`,
     /// plain (CPU-only) builds default to `cpu` — so a stock `cargo install orber`
     /// renders silently on the CPU instead of emitting a "no gpu feature, falling
@@ -496,10 +498,10 @@ fn resolve_motion(cli: &Cli) -> (MotionDirection, MotionSpeed) {
 /// #212 Phase 1b で WGSL 化（SDF fill + 回転）。Aquarelle は #216 Phase 1c で WGSL 化
 /// （4 層を解析 radial で評価、RNG/色は CPU pack で算出）。アダプタ無し・`gpu` feature
 /// 無しビルドは CPU にフォールバックする。Circle 経路は CPU オラクルと ±2/channel
-/// （実 GPU では bit-exact）一致。Glyph は CPU の bleed 前塗りと構造一致だが、per-frame の
-/// aquarelle bleed pass は当面 CPU 専用（既知の見た目差）。Aquarelle は 4 層が構造一致し
-/// RNG/色は bit-identical、残差は tiny-skia の AA 塗りとの差のみ。video や
-/// color/keyframe tracks も GPU pack 未対応で CPU 専用。
+/// （実 GPU では bit-exact）一致。Glyph は CPU の bleed 前塗りと構造一致だが、Glyph 専用の
+/// per-frame bleed pass は当面 CPU 専用（既知の見た目差）。Aquarelle は 4 層が構造一致し
+/// RNG/色は bit-identical、post-blur 無しで完全 parity（残差は tiny-skia の AA 塗りとの差
+/// のみ）。video や color/keyframe tracks も GPU pack 未対応で CPU 専用。
 enum FrameRenderer {
     Cpu,
     #[cfg(feature = "gpu")]
@@ -508,6 +510,8 @@ enum FrameRenderer {
 
 /// アダプタ取得前のルーティング判定（`FrameRenderer::route` の戻り値）。`Cpu` の
 /// `Option<String>` は「GPU を諦めた理由」の stderr 文言（CPU 明示指定なら `None`）。
+/// 現状は全 shape が GPU に乗るため `Cpu(Some(_))` は route から返らない（将来 GPU
+/// 非対応 shape を足したときの防御用に残す variant）。
 #[derive(Debug, PartialEq, Eq)]
 enum RenderRoute {
     Cpu(Option<String>),
@@ -515,8 +519,8 @@ enum RenderRoute {
 }
 
 impl FrameRenderer {
-    /// `--renderer` の選択と shape からバックエンドを決める。GPU 要求でも、非 Circle /
-    /// アダプタ取得失敗 / feature 無しなら CPU にフォールバックし、stderr に一言出す。
+    /// `--renderer` の選択と shape からバックエンドを決める。現状は全 shape が GPU に
+    /// 乗るため、GPU 要求が CPU に落ちるのはアダプタ取得失敗 / feature 無しのときだけ。
     ///
     /// orb 数による分岐は無い: GPU は per-orb データを data-texture に積んで
     /// fragment shader で `textureLoad` し、count を `MAX_ORB_COUNT` (1024) まで CPU と
@@ -525,6 +529,8 @@ impl FrameRenderer {
     /// で portable にしている（Phase 2 のブラウザ fallback を壊さない）。
     fn select(choice: Renderer, shape: OrbShape) -> Self {
         match Self::route(choice, shape) {
+            // 現状 route は全 shape を Gpu に振るため、この arm は到達しない。将来 GPU
+            // 非対応 shape を足したときに stderr 文言を出すための防御として残す。
             RenderRoute::Cpu(Some(reason)) => {
                 eprintln!("{reason}");
                 FrameRenderer::Cpu
@@ -535,17 +541,20 @@ impl FrameRenderer {
         }
     }
 
-    /// アダプタ取得より前の「どのバックエンドに振るか」だけを決める純関数。GPU を
-    /// 諦めるときは stderr 文言を `Cpu(Some(_))` に載せる。GPU を選んでも、最終的に
-    /// アダプタが取れなければ `select_gpu_circle` がさらに CPU に落とす。アダプタに
-    /// 依存しないので、ルーティング判定をそのままユニットテストできる。
+    /// アダプタ取得より前の「どのバックエンドに振るか」だけを決める純関数。現状は
+    /// 全 shape（Circle / Glyph / Aquarelle）を `Gpu` に振るため `Cpu(Some(_))` は
+    /// 発生しない。`Cpu(Some(_))` アームは将来 GPU 非対応 shape を足したときの防御
+    /// として残してあり、その場合だけ stderr 文言を載せる。`--renderer cpu` 明示は
+    /// `Cpu(None)`（文言なし）。GPU を選んでも、最終的にアダプタが取れなければ
+    /// `select_gpu` がさらに CPU に落とす。アダプタに依存しないので、ルーティング
+    /// 判定をそのままユニットテストできる。
     fn route(choice: Renderer, shape: OrbShape) -> RenderRoute {
         match choice {
             Renderer::Cpu => RenderRoute::Cpu(None),
             Renderer::Gpu => {
                 // Circle (#210), Glyph (#212 Phase 1b) and Aquarelle (#216 Phase 1c)
-                // render in WGSL. Glyph matches the CPU pre-bleed fill (the per-frame
-                // aquarelle bleed pass is CPU-only for now, a known visual difference).
+                // render in WGSL. Glyph matches the CPU pre-bleed fill (its own
+                // per-frame bleed pass is CPU-only for now, a known visual difference).
                 // Aquarelle reproduces the crate's four layers analytically (structural
                 // parity, AA-only residual). All three shapes route to the GPU.
                 match shape {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -491,12 +491,14 @@ fn resolve_motion(cli: &Cli) -> (MotionDirection, MotionSpeed) {
 
 /// 単一フレーム描画のバックエンド。`--renderer` を解決して GPU/CPU を選ぶ (#207)。
 ///
-/// GPU は Circle / Glyph shape かつ GPU アダプタが取れた場合に使う。count は 1024 まで
-/// GPU が data-texture 経路で直接描く（#210 Phase 1a で 64 制限を撤去）。Glyph は #212
-/// Phase 1b で WGSL 化（SDF fill + 回転）。aquarelle 等の他 shape、アダプタ無し、`gpu`
-/// feature 無しビルドは CPU にフォールバックする。Circle 経路は CPU オラクルと
-/// ±2/channel（実 GPU では bit-exact）一致。Glyph は CPU の bleed 前塗りと構造一致だが、
-/// per-frame の aquarelle bleed pass は当面 CPU 専用（既知の見た目差）。video や
+/// GPU は Circle / Glyph / Aquarelle shape かつ GPU アダプタが取れた場合に使う。count は
+/// 1024 まで GPU が data-texture 経路で直接描く（#210 Phase 1a で 64 制限を撤去）。Glyph は
+/// #212 Phase 1b で WGSL 化（SDF fill + 回転）。Aquarelle は #216 Phase 1c で WGSL 化
+/// （4 層を解析 radial で評価、RNG/色は CPU pack で算出）。アダプタ無し・`gpu` feature
+/// 無しビルドは CPU にフォールバックする。Circle 経路は CPU オラクルと ±2/channel
+/// （実 GPU では bit-exact）一致。Glyph は CPU の bleed 前塗りと構造一致だが、per-frame の
+/// aquarelle bleed pass は当面 CPU 専用（既知の見た目差）。Aquarelle は 4 層が構造一致し
+/// RNG/色は bit-identical、残差は tiny-skia の AA 塗りとの差のみ。video や
 /// color/keyframe tracks も GPU pack 未対応で CPU 専用。
 enum FrameRenderer {
     Cpu,
@@ -541,15 +543,15 @@ impl FrameRenderer {
         match choice {
             Renderer::Cpu => RenderRoute::Cpu(None),
             Renderer::Gpu => {
-                // Circle (#210) and Glyph (#212 Phase 1b) render in WGSL. Glyph
-                // matches the CPU pre-bleed fill (the per-frame aquarelle bleed
-                // pass is CPU-only for now, a known visual difference). Aquarelle
-                // and any other shape still fall back to the CPU renderer.
+                // Circle (#210), Glyph (#212 Phase 1b) and Aquarelle (#216 Phase 1c)
+                // render in WGSL. Glyph matches the CPU pre-bleed fill (the per-frame
+                // aquarelle bleed pass is CPU-only for now, a known visual difference).
+                // Aquarelle reproduces the crate's four layers analytically (structural
+                // parity, AA-only residual). All three shapes route to the GPU.
                 match shape {
-                    OrbShape::Circle | OrbShape::Glyph { .. } => RenderRoute::Gpu,
-                    _ => RenderRoute::Cpu(Some(
-                        "orber: --renderer gpu は Circle / Glyph のみ対応。aquarelle 等のため cpu にフォールバックします".to_string(),
-                    )),
+                    OrbShape::Circle | OrbShape::Glyph { .. } | OrbShape::Aquarelle(_) => {
+                        RenderRoute::Gpu
+                    }
                 }
             }
         }
@@ -591,10 +593,10 @@ impl FrameRenderer {
             FrameRenderer::Cpu => orber_core::animate::render_frame(clusters, opts, t),
             #[cfg(feature = "gpu")]
             FrameRenderer::Gpu(gpu) => match opts.shape {
-                // Glyph uses the dedicated WGSL glyph path (#212); Circle the
-                // default. (Aquarelle never reaches the GPU branch — `route`
-                // sends it to the CPU renderer.)
+                // Glyph uses the dedicated WGSL glyph path (#212); Aquarelle the
+                // dedicated WGSL four-layer path (#216); Circle the default.
                 OrbShape::Glyph { .. } => gpu.render_frame_glyph(clusters, opts, t),
+                OrbShape::Aquarelle(_) => gpu.render_frame_aquarelle(clusters, opts, t),
                 _ => gpu.render_frame(clusters, opts, t),
             },
         }
@@ -1355,30 +1357,25 @@ mod tests {
         );
     }
 
-    /// C2 (#210 → #212): Aquarelle（および将来の非 Circle/非 Glyph shape）は GPU 要求でも
-    /// 理由つき CPU フォールバックを温存する。#212 で Glyph が GPU 経路に乗ったので、
-    /// route(Gpu, Glyph) は `Gpu` になることもあわせて確認する。
-    /// --renderer cpu は理由なし `Cpu(None)` のまま。
+    /// C2 (#210 → #212 → #216): GPU 要求時、Circle / Glyph / Aquarelle の全 shape が
+    /// `Gpu` に乗る（#216 Phase 1c で aquarelle も WGSL 化され、理由つき CPU フォール
+    /// バックは無くなった）。--renderer cpu は理由なし `Cpu(None)` のまま。
     #[test]
-    fn gpu_route_falls_back_for_aquarelle_but_not_glyph() {
-        // Aquarelle は CPU フォールバック（理由つき）。
-        match FrameRenderer::route(
-            Renderer::Gpu,
-            OrbShape::Aquarelle(AquarelleParams {
-                bleed: 0.5,
-                bloom: 0.5,
-                offset: 0.5,
-                halo: 0.5,
-            }),
-        ) {
-            RenderRoute::Cpu(Some(msg)) => {
-                assert!(
-                    msg.contains("aquarelle") || msg.contains("Circle"),
-                    "aquarelle fallback message should explain the limitation, got: {msg}"
-                );
-            }
-            other => panic!("aquarelle + gpu must route to Cpu(Some(_)), got {other:?}"),
-        }
+    fn gpu_route_covers_circle_glyph_and_aquarelle() {
+        // Aquarelle (#216) は GPU 経路に乗る（フォールバック文言なし）。
+        assert_eq!(
+            FrameRenderer::route(
+                Renderer::Gpu,
+                OrbShape::Aquarelle(AquarelleParams {
+                    bleed: 0.5,
+                    bloom: 0.5,
+                    offset: 0.5,
+                    halo: 0.5,
+                }),
+            ),
+            RenderRoute::Gpu,
+            "aquarelle + gpu must route to the gpu path (#216)"
+        );
 
         // Glyph (#212) は GPU 経路に乗る（フォールバック文言なし）。
         assert_eq!(
@@ -1391,6 +1388,13 @@ mod tests {
             ),
             RenderRoute::Gpu,
             "glyph + gpu must route to the gpu path (#212)"
+        );
+
+        // Circle (#210) も GPU 経路。
+        assert_eq!(
+            FrameRenderer::route(Renderer::Gpu, OrbShape::Circle),
+            RenderRoute::Gpu,
+            "circle + gpu must route to the gpu path (#210)"
         );
 
         // --renderer cpu は理由なしで CPU（明示指定なので警告は出さない）。

--- a/crates/core/src/animate.rs
+++ b/crates/core/src/animate.rs
@@ -785,12 +785,39 @@ fn render_frame_aquarelle(
     params: &[OrbParams],
     t: f32,
 ) -> RgbaImage {
-    use crate::cluster::Centroid;
     use crate::orb::{render_static, RenderOptions};
+
+    let modulated = modulate_aquarelle_clusters(clusters, opts, params, t);
+
+    let render_opts = RenderOptions {
+        width: opts.width,
+        height: opts.height,
+        orb_size: opts.orb_size,
+        blur: opts.blur,
+        saturation: opts.saturation,
+        background: opts.background,
+        shape: opts.shape,
+        softness: opts.softness,
+    };
+    render_static(&modulated, &render_opts)
+}
+
+/// Aquarelle フレームの per-orb 変調（位置 wrap・半径呼吸・#33/#7 色補間）を 1 箇所に
+/// 集約したヘルパ。`render_frame_aquarelle`（CPU 経路）と GPU 経路
+/// （[`aquarelle_modulated_clusters`]）が同じ算術を共有し、片方だけ挙動が
+/// ずれるのを防ぐ。返す `Vec<Cluster>` の index は `render_static` での描画 index と
+/// 一致し、`render_aquarelle_orb` の `seed = i` に対応する。
+fn modulate_aquarelle_clusters(
+    clusters: &[Cluster],
+    opts: &AnimateOptions,
+    params: &[OrbParams],
+    t: f32,
+) -> Vec<Cluster> {
+    use crate::cluster::Centroid;
 
     let cycle = opts.speed.cycle_count();
 
-    let modulated: Vec<Cluster> = clusters
+    clusters
         .iter()
         .zip(params.iter())
         .enumerate()
@@ -824,19 +851,24 @@ fn render_frame_aquarelle(
                 weight: (weight_t33 * weight_scale).max(0.0),
             }
         })
-        .collect();
+        .collect()
+}
 
-    let render_opts = RenderOptions {
-        width: opts.width,
-        height: opts.height,
-        orb_size: opts.orb_size,
-        blur: opts.blur,
-        saturation: opts.saturation,
-        background: opts.background,
-        shape: opts.shape,
-        softness: opts.softness,
-    };
-    render_static(&modulated, &render_opts)
+/// GPU Aquarelle 経路（#216）が CPU `render_frame_aquarelle` と完全に同じ変調済み
+/// cluster 列を得るための `#[doc(hidden)]` シーム。`pack_render_data_for_webgl` と
+/// 同様、内部の `OrbParams` レイアウトや RNG 列は公開しない。
+///
+/// 返り値の index は `render_static`（= `render_aquarelle_orb` の `seed = i`）の
+/// 描画順に一致する。`gpu::GpuRenderer::render_frame_aquarelle` が各 cluster の
+/// 変調済み中心 / 重み / 色を読み、per-orb の 4 層を WGSL で描く。
+#[doc(hidden)]
+pub fn aquarelle_modulated_clusters(
+    clusters: &[Cluster],
+    opts: &AnimateOptions,
+    t: f32,
+) -> Vec<Cluster> {
+    let cache = precompute_orb_params(opts, clusters);
+    modulate_aquarelle_clusters(clusters, opts, &cache.params, t)
 }
 
 /// Pixmap → RgbaImage 変換（un-premultiply 込み）。

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -65,6 +65,10 @@ use crate::animate::{pack_render_data_for_webgl, AnimateOptions, MotionDirection
 use crate::cluster::Cluster;
 use crate::orb::adjust_saturation_pub;
 
+use palette::{FromColor, Hsl, IntoColor, Srgb};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
 /// Bytes per pixel for `Rgba8Unorm`.
 const BYTES_PER_PIXEL: u32 = 4;
 
@@ -89,6 +93,15 @@ const ORB_TEX_BYTES_PER_TEXEL: u32 = 16;
 /// Bytes per row of the orb data-texture (`4 × 16 = 64`). `write_texture` has no
 /// row-alignment requirement, so this tight value is used as-is.
 const ORB_TEX_BYTES_PER_ROW: u32 = ORB_TEX_WIDTH * ORB_TEX_BYTES_PER_TEXEL;
+
+/// Width, in texels, of the per-orb **aquarelle** data-texture (#216). Nine texels
+/// per orb hold the four `render_aquarelle_orb` layers' geometry + u8 colors; see
+/// `orb_aquarelle.wgsl`'s header for the slot map. Independent of the Circle/Glyph
+/// `ORB_TEX_WIDTH` (4) — aquarelle binds its own texture so the two never alias.
+const AQUARELLE_TEX_WIDTH: u32 = 9;
+/// Bytes per row of the aquarelle data-texture (`9 × 16 = 144`). `write_texture` is
+/// exempt from row-alignment, so this tight value is used directly.
+const AQUARELLE_TEX_BYTES_PER_ROW: u32 = AQUARELLE_TEX_WIDTH * ORB_TEX_BYTES_PER_TEXEL;
 
 /// Header words / per-orb words in the `pack_render_data_for_webgl` layout.
 /// Kept in sync with that function (header 16 words, per-orb 16 words).
@@ -120,6 +133,18 @@ fn orb_glyph_wgsl() -> &'static str {
 /// is **omitted** on the GPU (loose-parity decision documented there).
 fn orb_glyph_bleed_wgsl() -> &'static str {
     include_str!("orb_glyph_bleed.wgsl")
+}
+
+/// The Aquarelle orb WGSL (#216 Phase 1c). A dedicated pipeline + data-texture
+/// (separate from the Circle/Glyph orb texture) that evaluates the four
+/// `aquarelle::render_aquarelle_orb` layers analytically: offset main 3-stop
+/// radial, 0..3 bleed satellites, and the bloom core, composited SourceOver in
+/// the same u8-quantize → premultiply → source_over lowp流儀 as `orb_circle.wgsl`.
+/// The ChaCha8 RNG / HSL color math is **not** ported to WGSL; `pack_aquarelle_orbs`
+/// runs it on the CPU (bit-identical to the crate) and uploads the resulting
+/// centers / radii / u8 colors.
+fn orb_aquarelle_wgsl() -> &'static str {
+    include_str!("orb_aquarelle.wgsl")
 }
 
 /// Aquarelle bleed constants, fixed to `AquarelleBleedParams::default()` (the
@@ -190,6 +215,40 @@ struct GpuOrb {
     phase: [f32; 4], // phase, phi_radius, phi_blur, phi_opacity
     misc: [f32; 4],  // cross_axis, style_bit, speed_mult, _
     rot: [f32; 4],   // base_angle, rot_speed_signed, _, _
+}
+
+/// Header uniform block for the Aquarelle shader. Mirrors `struct Params` in
+/// `orb_aquarelle.wgsl` (resolution, orb count, background). `#[repr(C)]` + padding
+/// to 16-byte rows. Separate from the Circle [`Params`] because the aquarelle pack
+/// needs no motion scalars (positions are baked per orb on the CPU).
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct AquarelleHeader {
+    // row 0: resolution.xy, n_orbs, pad
+    resolution: [f32; 2],
+    n_orbs: f32,
+    _pad0: f32,
+    // row 1: bg.rgba (straight)
+    bg: [f32; 4],
+}
+
+/// One aquarelle orb as the shader sees it: nine `vec4`s mirroring `struct AquaOrb`
+/// in `orb_aquarelle.wgsl`. Filled by [`GpuRenderer::pack_aquarelle_orbs`] from the
+/// per-orb ChaCha8 + HSL math (run on the CPU, bit-identical to the crate). One
+/// `GpuAquaOrb` packs to one row of the `Rgba32Float` aquarelle data-texture
+/// (9 texels = 144 bytes).
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct GpuAquaOrb {
+    main: [f32; 4],       // main_cx, main_cy, main_radius, sat_count
+    inner: [f32; 4],      // inner_rgb (color@255), bloom_flag
+    halo: [f32; 4],       // halo_rgb (mid@128 / edge@0), _
+    bloom_geom: [f32; 4], // bloom_cx, bloom_cy, bloom_core_radius, _
+    bloom_col: [f32; 4],  // bloom_rgb (mix_with_white), _
+    bleed_col: [f32; 4],  // bleed_rgb (satellite color), _
+    sat0: [f32; 4],       // sat0_cx, sat0_cy, sat0_radius, _
+    sat1: [f32; 4],       // sat1_cx, sat1_cy, sat1_radius, _
+    sat2: [f32; 4],       // sat2_cx, sat2_cy, sat2_radius, _
 }
 
 /// Uniform block for the Glyph bleed pass shader (`orb_glyph_bleed.wgsl`).
@@ -330,6 +389,12 @@ pub struct GpuRenderer {
     /// `(width, height)`. Grow-only / never-evicts like `sized_cache`: a glyph clip
     /// at one size keeps a single entry.
     bleed_textures: std::sync::Mutex<HashMap<(u32, u32), BleedTextures>>,
+    /// The grow-only per-orb **aquarelle** data-texture (#216), reallocated only
+    /// when a frame needs more rows than the cached capacity. `None` until the first
+    /// aquarelle frame (Circle/Glyph-only runs never allocate it). Separate from
+    /// `orb_texture` so the 9-texel aquarelle layout never aliases the 4-texel
+    /// Circle/Glyph one, keeping Circle bit-exact.
+    aquarelle_texture: std::sync::Mutex<Option<OrbTexture>>,
     /// Serializes the whole GPU side of [`Self::render_packed`] (orb/params
     /// upload → pass record → `queue.submit` → map/readback) so concurrent
     /// `render_frame` calls on one shared renderer cannot alias the shared cached
@@ -391,6 +456,7 @@ impl GpuRenderer {
             glyph_sampler,
             bleed_pipelines: std::sync::Mutex::new(None),
             bleed_textures: std::sync::Mutex::new(HashMap::new()),
+            aquarelle_texture: std::sync::Mutex::new(None),
             render_guard: std::sync::Mutex::new(()),
         })
     }
@@ -954,6 +1020,315 @@ impl GpuRenderer {
                 size: sdf_size,
             }),
         )
+    }
+
+    /// Render one **Aquarelle** frame at time `t` from `clusters` + `opts`,
+    /// matching the CPU [`crate::animate::render_frame`] → `render_frame_aquarelle`
+    /// → `render_static` → `aquarelle::render_aquarelle_orb` path (#216 Phase 1c).
+    ///
+    /// `opts.shape` must be [`OrbShape::Aquarelle`]; its [`AquarelleParams`] drive
+    /// the four layers. Per-orb positions / radii / colors come from
+    /// [`crate::animate::aquarelle_modulated_clusters`] (the same modulation the CPU
+    /// path uses), then [`Self::pack_aquarelle_orbs`] runs the crate's ChaCha8 RNG
+    /// (`seed = orb index`) + `palette` HSL color math on the CPU to produce the
+    /// offset center, satellite placements, and boosted/mixed u8 colors. The
+    /// `orb_aquarelle.wgsl` shader evaluates the radials and composites SourceOver.
+    ///
+    /// # Parity scope (loose — structural + tolerant)
+    ///
+    /// Bit-exact in the RNG / color math (it reuses the crate's exact arithmetic),
+    /// but the radial fill is analytic where tiny-skia anti-aliases `fill_path`, so
+    /// the residual is the same AA-only difference Circle accepts (±2/channel on
+    /// most hardware, 0 on the real GPU for interior pixels). Non-Aquarelle shapes
+    /// fall back to the Circle path so the call is total.
+    pub fn render_frame_aquarelle(
+        &self,
+        clusters: &[Cluster],
+        opts: &AnimateOptions,
+        t: f32,
+    ) -> RgbaImage {
+        let width = opts.width.max(1);
+        let height = opts.height.max(1);
+        let t = t.clamp(0.0, 1.0);
+
+        let params = match opts.shape {
+            crate::orb::OrbShape::Aquarelle(p) => p,
+            // Not an aquarelle shape: fall back to the Circle path so the call is total.
+            _ => return self.render_frame(clusters, opts, t),
+        };
+
+        // Same per-orb modulation the CPU aquarelle path uses (position wrap, radius
+        // breath, #33/#7 color interpolation). Index order == `render_static` draw
+        // order == `render_aquarelle_orb` seed `i`.
+        let modulated = crate::animate::aquarelle_modulated_clusters(clusters, opts, t);
+
+        // `base_radius_unit` mirrors `render_static`: min(w,h) * 0.25 * orb_size.
+        let base_radius_unit = (width.min(height) as f32) * 0.25 * opts.orb_size.max(0.0);
+        let saturation = opts.saturation.max(0.0);
+
+        let orbs = self.pack_aquarelle_orbs(
+            &modulated,
+            width as f32,
+            height as f32,
+            base_radius_unit,
+            saturation,
+            params,
+        );
+
+        self.render_aquarelle_packed(&orbs, width, height, opts.background)
+    }
+
+    /// Run the crate's four-layer `render_aquarelle_orb` math on the CPU and pack
+    /// each orb into a [`GpuAquaOrb`] row. `seed = orb index` (matching `orb.rs:176`
+    /// `i as u64`); the ChaCha8 `gen_range` consumption order is **identical** to
+    /// `aquarelle::render_aquarelle_orb` (offset θ → per-satellite θ/dist/radius →
+    /// bloom with no RNG) so the satellite count / placement and offset direction
+    /// are bit-identical to the crate. Colors run through the same `boost_saturation`
+    /// (HSL via `palette`) / `mix_with_white` as the crate, quantized to u8.
+    ///
+    /// Orbs with radius `<= 0.0` (zero weight) pack a zero-radius row, which the
+    /// shader skips — matching the crate's early `return` for non-positive radius.
+    fn pack_aquarelle_orbs(
+        &self,
+        clusters: &[Cluster],
+        width: f32,
+        height: f32,
+        base_radius_unit: f32,
+        saturation: f32,
+        params: crate::aquarelle::AquarelleParams,
+    ) -> Vec<GpuAquaOrb> {
+        use std::f32::consts::TAU;
+
+        // `clamped()` mirrors the crate: out-of-range slider values are capped.
+        let p = params.clamped();
+        let n = clusters.len().min(MAX_ORB_COUNT);
+
+        let mut orbs = Vec::with_capacity(n.max(1));
+        for (i, cluster) in clusters.iter().take(n).enumerate() {
+            // `render_static`: radius = base_radius_unit * sqrt(weight),
+            // color = adjust_saturation(cluster.color, saturation),
+            // center = clamp(centroid, 0..1) * (width, height).
+            let radius = base_radius_unit * cluster.weight.max(0.0).sqrt();
+            let color = adjust_saturation_pub(cluster.color, saturation);
+            let center_x = cluster.centroid.x.clamp(0.0, 1.0) * width;
+            let center_y = cluster.centroid.y.clamp(0.0, 1.0) * height;
+
+            // Zero / negative radius ⇒ the crate returns early (draws nothing). Pack
+            // a zero-radius row; the shader's `main_radius <= 0.0` guard skips it.
+            if radius <= 0.0 {
+                orbs.push(GpuAquaOrb {
+                    main: [center_x, center_y, 0.0, 0.0],
+                    inner: [0.0; 4],
+                    halo: [0.0; 4],
+                    bloom_geom: [0.0; 4],
+                    bloom_col: [0.0; 4],
+                    bleed_col: [0.0; 4],
+                    sat0: [0.0; 4],
+                    sat1: [0.0; 4],
+                    sat2: [0.0; 4],
+                });
+                continue;
+            }
+
+            // RNG seeded per orb with `seed = i`, consumed in the *exact* order of
+            // `render_aquarelle_orb`. Any deviation here desyncs the satellite stream.
+            let mut rng = ChaCha8Rng::seed_from_u64(i as u64);
+
+            // 1. offset: shift the gradient center by up to 25 % of the radius.
+            let offset_dist = radius * 0.25 * p.offset;
+            let theta: f32 = rng.gen_range(0.0..TAU);
+            let cx = center_x + offset_dist * theta.cos();
+            let cy = center_y + offset_dist * theta.sin();
+
+            // 2. main color: halo color = boost_saturation(color, 1 + 0.6 * halo).
+            let halo_color = boost_saturation(color, 1.0 + 0.6 * p.halo);
+
+            // 3. bleed satellites: 0..3 small same-color gradients. The RNG draws
+            //    per satellite in order (θ, dist, radius-factor), matching the crate.
+            let bleed_count = (3.0 * p.bleed).round() as u32;
+            let bleed_color = boost_saturation(color, 1.0 + 0.4 * p.halo);
+            let mut sats = [[0.0f32; 4]; 3];
+            for sat in sats.iter_mut().take(bleed_count.min(3) as usize) {
+                let bleed_theta: f32 = rng.gen_range(0.0..TAU);
+                let bleed_dist = radius * rng.gen_range(0.4..0.9);
+                let bx = center_x + bleed_dist * bleed_theta.cos();
+                let by = center_y + bleed_dist * bleed_theta.sin();
+                let bleed_radius = radius * rng.gen_range(0.2..0.4) * (0.5 + 0.5 * p.bleed);
+                *sat = [bx, by, bleed_radius, 0.0];
+            }
+
+            // 4. bloom: near-white core inside the inner ~30 % when bloom > 0.
+            let (bloom_flag, bloom_core_radius, bloom_color) = if p.bloom > 0.0 {
+                let core_radius = radius * 0.3 * p.bloom;
+                if core_radius > 0.0 {
+                    let bloom_color = mix_with_white(color, 0.7);
+                    (1.0, core_radius, bloom_color)
+                } else {
+                    (0.0, 0.0, [0u8; 3])
+                }
+            } else {
+                (0.0, 0.0, [0u8; 3])
+            };
+
+            let to_unit = |c: [u8; 3]| {
+                [
+                    c[0] as f32 / 255.0,
+                    c[1] as f32 / 255.0,
+                    c[2] as f32 / 255.0,
+                ]
+            };
+            let inner_u = to_unit(color);
+            let halo_u = to_unit(halo_color);
+            let bleed_u = to_unit(bleed_color);
+            let bloom_u = to_unit(bloom_color);
+
+            orbs.push(GpuAquaOrb {
+                main: [cx, cy, radius, bleed_count.min(3) as f32],
+                inner: [inner_u[0], inner_u[1], inner_u[2], bloom_flag],
+                halo: [halo_u[0], halo_u[1], halo_u[2], 0.0],
+                // bloom center == main offset center (crate draws bloom at cx,cy).
+                bloom_geom: [cx, cy, bloom_core_radius, 0.0],
+                bloom_col: [bloom_u[0], bloom_u[1], bloom_u[2], 0.0],
+                bleed_col: [bleed_u[0], bleed_u[1], bleed_u[2], 0.0],
+                sat0: sats[0],
+                sat1: sats[1],
+                sat2: sats[2],
+            });
+        }
+        orbs
+    }
+
+    /// Upload the packed aquarelle orbs into the grow-only aquarelle data-texture,
+    /// build the header uniform, run the aquarelle pass, and read back. Serialized
+    /// under `render_guard` (like the Circle/Glyph path) so concurrent renders on a
+    /// shared renderer cannot alias the one shared aquarelle texture / per-size
+    /// target / read-back buffer (the #210 concurrency contract).
+    fn render_aquarelle_packed(
+        &self,
+        orbs: &[GpuAquaOrb],
+        width: u32,
+        height: u32,
+        background: [u8; 4],
+    ) -> RgbaImage {
+        let _render_guard = self
+            .render_guard
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let width = width.max(1);
+        let height = height.max(1);
+
+        let header = AquarelleHeader {
+            resolution: [width as f32, height as f32],
+            n_orbs: orbs.len() as f32,
+            _pad0: 0.0,
+            bg: [
+                background[0] as f32 / 255.0,
+                background[1] as f32 / 255.0,
+                background[2] as f32 / 255.0,
+                background[3] as f32 / 255.0,
+            ],
+        };
+        let header_buffer = self
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("orber-aquarelle-params"),
+                contents: bytemuck::bytes_of(&header),
+                usage: wgpu::BufferUsages::UNIFORM,
+            });
+
+        let orb_view = self.upload_aquarelle_texture(orbs);
+
+        self.pipeline(orb_aquarelle_wgsl(), false, |cached| {
+            self.sized_resources(width, height, |res| {
+                let entries = vec![
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: header_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::TextureView(&orb_view),
+                    },
+                ];
+                let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("orber-aquarelle-bg"),
+                    layout: &cached.bind_group_layout,
+                    entries: &entries,
+                });
+                self.run_pass_and_readback(&cached.pipeline, &bind_group, res)
+            })
+        })
+    }
+
+    /// Upload the packed aquarelle orbs into the grow-only `Rgba32Float` aquarelle
+    /// data-texture (9 texels wide × `orbs.len()` tall) and return a view to bind.
+    /// Mirrors [`Self::upload_orb_texture`] but for the separate aquarelle texture so
+    /// the Circle/Glyph orb texture is never resized to the wider aquarelle layout.
+    fn upload_aquarelle_texture(&self, orbs: &[GpuAquaOrb]) -> wgpu::TextureView {
+        let rows = orbs.len().max(1) as u32;
+        let mut guard = self
+            .aquarelle_texture
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let needs_realloc = match guard.as_ref() {
+            Some(tex) => tex.capacity < rows,
+            None => true,
+        };
+        if needs_realloc {
+            *guard = Some(self.build_aquarelle_texture(rows));
+        }
+        let tex = guard
+            .as_ref()
+            .expect("aquarelle texture just ensured present");
+
+        // One `GpuAquaOrb` is 9 × vec4<f32> = 144 bytes = one texel row.
+        self.queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &tex.texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            bytemuck::cast_slice(orbs),
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(AQUARELLE_TEX_BYTES_PER_ROW),
+                rows_per_image: Some(rows),
+            },
+            wgpu::Extent3d {
+                width: AQUARELLE_TEX_WIDTH,
+                height: rows,
+                depth_or_array_layers: 1,
+            },
+        );
+        tex.view.clone()
+    }
+
+    /// Allocate the aquarelle data-texture sized for `capacity` orbs (9 texels wide).
+    /// `usage = TEXTURE_BINDING | COPY_DST` (sampled via `textureLoad`, written via
+    /// `write_texture`) — input only, like [`Self::build_orb_texture`].
+    fn build_aquarelle_texture(&self, capacity: u32) -> OrbTexture {
+        let texture = self.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("orber-aquarelle-tex"),
+            size: wgpu::Extent3d {
+                width: AQUARELLE_TEX_WIDTH,
+                height: capacity,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba32Float,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        OrbTexture {
+            capacity,
+            texture,
+            view,
+        }
     }
 
     /// Render one **Circle** frame from a raw `pack_render_data_for_webgl` buffer.
@@ -1572,6 +1947,42 @@ fn apply_saturation_to_pack(pack: &mut [f32], saturation: f32, n_orbs: usize) {
         pack[off + 1] = out[1] as f32 / 255.0;
         pack[off + 2] = out[2] as f32 / 255.0;
     }
+}
+
+/// `boost_saturation` from `aquarelle::render_aquarelle_orb`, reproduced verbatim
+/// so the CPU pack produces the **same u8 color** the crate feeds tiny-skia. The
+/// HSL transform runs through `palette` at the exact version aquarelle pins
+/// (`palette 0.7`, the workspace dep), so the result is bit-identical and never
+/// reimplemented in WGSL. A factor within an ULP of 1.0 short-circuits like the
+/// crate.
+fn boost_saturation(rgb: [u8; 3], factor: f32) -> [u8; 3] {
+    if (factor - 1.0).abs() < f32::EPSILON {
+        return rgb;
+    }
+    let srgb = Srgb::new(
+        rgb[0] as f32 / 255.0,
+        rgb[1] as f32 / 255.0,
+        rgb[2] as f32 / 255.0,
+    );
+    let mut hsl: Hsl = Hsl::from_color(srgb);
+    hsl.saturation = (hsl.saturation * factor).clamp(0.0, 1.0);
+    let out: Srgb = hsl.into_color();
+    [
+        (out.red.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (out.green.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (out.blue.clamp(0.0, 1.0) * 255.0).round() as u8,
+    ]
+}
+
+/// `mix_with_white` from `aquarelle::render_aquarelle_orb`, reproduced verbatim so
+/// the bloom core color matches the crate's u8 output exactly.
+fn mix_with_white(rgb: [u8; 3], amount: f32) -> [u8; 3] {
+    let a = amount.clamp(0.0, 1.0);
+    [
+        (rgb[0] as f32 * (1.0 - a) + 255.0 * a).round() as u8,
+        (rgb[1] as f32 * (1.0 - a) + 255.0 * a).round() as u8,
+        (rgb[2] as f32 * (1.0 - a) + 255.0 * a).round() as u8,
+    ]
 }
 
 /// A fragment-visible uniform-buffer bind-group-layout entry.
@@ -3719,5 +4130,211 @@ mod tests {
                 overlap_frac * 100.0
             );
         }
+    }
+
+    // ===== #216: Aquarelle WGSL path — RNG/color parity + structural GPU↔CPU =====
+
+    use crate::aquarelle::AquarelleParams;
+
+    fn aquarelle_opts(w: u32, h: u32, params: AquarelleParams) -> AnimateOptions {
+        AnimateOptions {
+            width: w,
+            height: h,
+            orb_size: 1.0,
+            blur: 0.5,
+            saturation: 1.0,
+            direction: MotionDirection::LeftToRight,
+            speed: MotionSpeed::Mid,
+            seed: 12345,
+            // Aquarelle ignores --count (one orb per cluster), so count is irrelevant.
+            count: None,
+            background: [12, 18, 28, 255],
+            shape: OrbShape::Aquarelle(params),
+            softness: SoftnessPreset::Mid,
+            glyph_rotate: true,
+            color_tracks: None,
+            keyframe_tracks: None,
+        }
+    }
+
+    /// `boost_saturation` / `mix_with_white` are reproduced verbatim from the crate.
+    /// A factor of exactly 1.0 (halo=0 ⇒ 1+0.6*0) must be the identity fast-path,
+    /// and a boost must raise HSL saturation (here: pull a desaturated gray toward
+    /// its hue). `mix_with_white(c, 0.7)` must land 70 % of the way to white.
+    #[test]
+    fn aquarelle_color_helpers_match_crate_semantics() {
+        // Identity fast-path: factor 1.0 returns the input untouched.
+        assert_eq!(boost_saturation([200, 100, 50], 1.0), [200, 100, 50]);
+
+        // A boost on an already-colored pixel must not *lower* its max-min spread
+        // (saturation goes up, clamped at 1.0).
+        let base = [200u8, 120, 60];
+        let boosted = boost_saturation(base, 1.6);
+        let spread = |c: [u8; 3]| c.iter().max().unwrap() - c.iter().min().unwrap();
+        assert!(
+            spread(boosted) >= spread(base),
+            "boost_saturation must not reduce chroma: base={base:?} boosted={boosted:?}"
+        );
+
+        // mix_with_white(c, 0.7): each channel = round(c*0.3 + 255*0.7).
+        let mixed = mix_with_white([100, 0, 200], 0.7);
+        let expect = |c: u8| (c as f32 * 0.3 + 255.0 * 0.7).round() as u8;
+        assert_eq!(mixed, [expect(100), expect(0), expect(200)]);
+
+        // Full white mix => white; zero mix => unchanged.
+        assert_eq!(mix_with_white([10, 20, 30], 1.0), [255, 255, 255]);
+        assert_eq!(mix_with_white([10, 20, 30], 0.0), [10, 20, 30]);
+    }
+
+    /// `bleed_count = round(3 * bleed)` and the satellite stream is consumed in the
+    /// crate's order. Pack one orb and assert the satellite count for representative
+    /// `bleed` values, plus that bloom presence tracks `bloom > 0`.
+    #[test]
+    fn aquarelle_pack_satellite_count_and_bloom_flag() {
+        let Some(renderer) =
+            require_or_skip_renderer("aquarelle_pack_satellite_count_and_bloom_flag")
+        else {
+            return;
+        };
+        let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
+        // bleed → expected round(3*bleed): 0→0, 0.5→2 (1.5 rounds to 2), 1.0→3.
+        for (bleed, expected) in [(0.0_f32, 0u32), (0.5, 2), (1.0, 3)] {
+            let params = AquarelleParams {
+                bleed,
+                bloom: 0.5,
+                offset: 0.5,
+                halo: 0.5,
+            };
+            let orbs =
+                renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, params.clamped());
+            assert_eq!(orbs.len(), 1);
+            assert_eq!(
+                orbs[0].main[3] as u32, expected,
+                "bleed={bleed} must pack {expected} satellites"
+            );
+            // bloom=0.5 > 0 ⇒ bloom_flag set, core radius positive.
+            assert!(orbs[0].inner[3] > 0.5, "bloom>0 must set bloom_flag");
+            assert!(
+                orbs[0].bloom_geom[2] > 0.0,
+                "bloom core radius must be positive when bloom>0"
+            );
+        }
+        // bloom=0 ⇒ no bloom layer.
+        let no_bloom = AquarelleParams {
+            bleed: 0.0,
+            bloom: 0.0,
+            offset: 0.0,
+            halo: 0.0,
+        };
+        let orbs = renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, no_bloom);
+        assert!(orbs[0].inner[3] < 0.5, "bloom=0 must clear bloom_flag");
+    }
+
+    /// Aquarelle GPU↔CPU **structural** parity: the WGSL four-layer path matches the
+    /// CPU `render_frame_aquarelle` oracle within a loose tolerance (AA-only residual,
+    /// like Circle). Asserts the lit-pixel sets overlap heavily and the mean color is
+    /// close — not byte-exact, because tiny-skia anti-aliases its `fill_path` where
+    /// the shader evaluates the radial analytically.
+    #[test]
+    fn aquarelle_gpu_structural_parity_with_cpu() {
+        let Some(renderer) = require_or_skip_renderer("aquarelle_gpu_structural_parity_with_cpu")
+        else {
+            return;
+        };
+        let (w, h) = (96u32, 128u32);
+        let clusters = vec![
+            cluster([220, 60, 60], 0.3, 0.35, 0.8),
+            cluster([60, 120, 220], 0.7, 0.55, 0.5),
+            cluster([200, 200, 80], 0.5, 0.8, 0.4),
+        ];
+        let params = AquarelleParams::default();
+        let opts = aquarelle_opts(w, h, params);
+        let t = 0.0;
+
+        let cpu = render_frame(&clusters, &opts, t);
+        let gpu = renderer.render_frame_aquarelle(&clusters, &opts, t);
+        assert_eq!(cpu.dimensions(), gpu.dimensions());
+
+        let bg = opts.background;
+        let mut cpu_lit = 0usize;
+        let mut gpu_lit = 0usize;
+        let mut overlap = 0usize;
+        let mut sum_abs = 0u64;
+        for (cp, gp) in cpu.pixels().zip(gpu.pixels()) {
+            let c_lit = (0..3).any(|c| cp.0[c].abs_diff(bg[c]) > 8);
+            let g_lit = (0..3).any(|c| gp.0[c].abs_diff(bg[c]) > 8);
+            if c_lit {
+                cpu_lit += 1;
+            }
+            if g_lit {
+                gpu_lit += 1;
+            }
+            if c_lit && g_lit {
+                overlap += 1;
+            }
+            for c in 0..3 {
+                sum_abs += cp.0[c].abs_diff(gp.0[c]) as u64;
+            }
+        }
+        assert!(cpu_lit > 0 && gpu_lit > 0, "both renders must light pixels");
+        let overlap_frac = overlap as f32 / cpu_lit.min(gpu_lit) as f32;
+        assert!(
+            overlap_frac > 0.9,
+            "aquarelle lit overlap {:.1}% of smaller set; expected >90% (cpu_lit={cpu_lit} gpu_lit={gpu_lit})",
+            overlap_frac * 100.0
+        );
+        let mean_abs = sum_abs as f64 / (w as f64 * h as f64 * 3.0);
+        assert!(
+            mean_abs < 2.0,
+            "aquarelle mean per-channel |cpu-gpu| {mean_abs:.3} should be small (AA-only residual)"
+        );
+        eprintln!(
+            "aquarelle structural parity: cpu_lit={cpu_lit} gpu_lit={gpu_lit} \
+             overlap={:.1}% mean_abs={mean_abs:.3}",
+            overlap_frac * 100.0
+        );
+    }
+
+    /// Aquarelle GPU determinism: the same `(clusters, opts, t)` must render
+    /// byte-identical twice (the pack RNG is seeded per orb index, no thread_rng).
+    #[test]
+    fn aquarelle_gpu_determinism_byte_identical() {
+        let Some(renderer) = require_or_skip_renderer("aquarelle_gpu_determinism_byte_identical")
+        else {
+            return;
+        };
+        let clusters = vec![
+            cluster([200, 100, 50], 0.4, 0.4, 0.7),
+            cluster([50, 180, 120], 0.6, 0.6, 0.5),
+        ];
+        let opts = aquarelle_opts(80, 80, AquarelleParams::default());
+        let a = renderer.render_frame_aquarelle(&clusters, &opts, 0.0);
+        let b = renderer.render_frame_aquarelle(&clusters, &opts, 0.0);
+        assert_eq!(
+            a.as_raw(),
+            b.as_raw(),
+            "aquarelle GPU render must be byte-identical on repeated calls"
+        );
+    }
+
+    /// A non-Aquarelle shape passed to `render_frame_aquarelle` must fall back to the
+    /// Circle path (the call is total), matching the Glyph-entry fallback contract.
+    #[test]
+    fn aquarelle_entry_circle_shape_falls_back() {
+        let Some(renderer) = require_or_skip_renderer("aquarelle_entry_circle_shape_falls_back")
+        else {
+            return;
+        };
+        let clusters = vec![cluster([200, 100, 50], 0.5, 0.5, 1.0)];
+        let mut opts = aquarelle_opts(64, 64, AquarelleParams::default());
+        opts.shape = OrbShape::Circle;
+        // Should not panic and should produce the same image as the Circle path.
+        let via_aqua = renderer.render_frame_aquarelle(&clusters, &opts, 0.0);
+        let via_circle = renderer.render_frame(&clusters, &opts, 0.0);
+        assert_eq!(
+            via_aqua.as_raw(),
+            via_circle.as_raw(),
+            "non-aquarelle shape must fall back to the Circle path byte-for-byte"
+        );
     }
 }

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -17,7 +17,8 @@
 //!   differences), not bit-exact — see `render_frame_glyph` /
 //!   `render_frame_aquarelle`. The `image` shape is web-only and rides the Glyph
 //!   SDF path (core/wasm have no native `image` shape). The CPU renderer is now
-//!   only a no-GPU-adapter fallback (removed in Phase 1.5);
+//!   only a no-GPU-adapter fallback (it will be removed in Phase 1.5, but still
+//!   exists today);
 //! - **saturation reflected**: [`GpuRenderer::render_frame`] re-applies
 //!   [`adjust_saturation_pub`](crate::orb::adjust_saturation_pub) with
 //!   `opts.saturation` to each packed orb color after
@@ -62,9 +63,9 @@
 //! #216) all render on the GPU. The `image` shape is web-only and reuses the
 //! Glyph SDF path (core/wasm have no `image` shape — the browser hands an image
 //! silhouette in as a glyph SDF). The CPU (tiny-skia) renderer remains only as a
-//! no-GPU-adapter fallback and as the parity oracle; both are removed in
-//! Phase 1.5. Video and per-orb color/keyframe tracks (#7 / #33) are still
-//! CPU-only.
+//! no-GPU-adapter fallback and as the parity oracle; both will be removed in
+//! Phase 1.5 (they still exist today). Video and per-orb color/keyframe tracks
+//! (#7 / #33) are still CPU-only.
 
 use std::collections::HashMap;
 

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -4337,4 +4337,533 @@ mod tests {
             "non-aquarelle shape must fall back to the Circle path byte-for-byte"
         );
     }
+
+    // --- #216 new coverage: RNG reproduction / offset / round boundaries / clamp /
+    //     desaturation / count-ignore / GPU corner & branch parity ---
+
+    /// Oracle satellite placement for one orb, mirroring `render_aquarelle_orb`'s
+    /// **exact** ChaCha8 consumption order (offset θ → per satellite θ/dist/radius)
+    /// so the test owns an independent reference the pack must match bit-for-bit.
+    /// `seed` == orb index (the pack seeds `ChaCha8Rng::seed_from_u64(i)`).
+    fn oracle_aquarelle_sats(
+        seed: u64,
+        center: (f32, f32),
+        radius: f32,
+        bleed: f32,
+    ) -> (f32, Vec<(f32, f32, f32)>) {
+        use std::f32::consts::TAU;
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        // 1) offset angle is the first draw (consumed even when offset==0).
+        let theta: f32 = rng.gen_range(0.0..TAU);
+        // 2) satellites, in θ → dist → radius-factor order, `round(3*bleed)` of them.
+        let bleed_count = (3.0 * bleed).round() as u32;
+        let mut sats = Vec::new();
+        for _ in 0..bleed_count.min(3) {
+            let bleed_theta: f32 = rng.gen_range(0.0..TAU);
+            let bleed_dist = radius * rng.gen_range(0.4..0.9);
+            let bx = center.0 + bleed_dist * bleed_theta.cos();
+            let by = center.1 + bleed_dist * bleed_theta.sin();
+            let bleed_radius = radius * rng.gen_range(0.2..0.4) * (0.5 + 0.5 * bleed);
+            sats.push((bx, by, bleed_radius));
+        }
+        (theta, sats)
+    }
+
+    /// (#1, most important) The packed satellite centers/radii must be **bit-identical**
+    /// to an independent ChaCha8 oracle consuming the RNG in `render_aquarelle_orb`'s
+    /// exact order. Guards the RNG-reproduction contract the whole WGSL path rests on.
+    #[test]
+    fn aquarelle_pack_satellite_positions_match_crate() {
+        let Some(renderer) =
+            require_or_skip_renderer("aquarelle_pack_satellite_positions_match_crate")
+        else {
+            return;
+        };
+        let (w, h, base_radius_unit) = (200.0_f32, 200.0_f32, 40.0_f32);
+        // weight 1.0 ⇒ radius == base_radius_unit; center at (0.5,0.5) ⇒ (100,100).
+        let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
+        let radius = base_radius_unit * 1.0_f32.sqrt();
+        let center = (0.5_f32.clamp(0.0, 1.0) * w, 0.5_f32.clamp(0.0, 1.0) * h);
+
+        // bleed=1.0 ⇒ 3 satellites; saturation 1.0 keeps colors untouched.
+        let params = AquarelleParams {
+            bleed: 1.0,
+            bloom: 0.5,
+            offset: 0.5,
+            halo: 0.5,
+        };
+        let orbs =
+            renderer.pack_aquarelle_orbs(&single, w, h, base_radius_unit, 1.0, params.clamped());
+        assert_eq!(orbs.len(), 1);
+        assert_eq!(
+            orbs[0].main[3] as u32, 3,
+            "bleed=1.0 must pack 3 satellites"
+        );
+
+        let (_, sats) = oracle_aquarelle_sats(0, center, radius, 1.0);
+        assert_eq!(sats.len(), 3);
+        let packed = [orbs[0].sat0, orbs[0].sat1, orbs[0].sat2];
+        for (i, ((ox, oy, or), p)) in sats.iter().zip(packed.iter()).enumerate() {
+            assert_eq!(
+                p[0], *ox,
+                "sat{i} cx must bit-match oracle (packed={}, oracle={ox})",
+                p[0]
+            );
+            assert_eq!(
+                p[1], *oy,
+                "sat{i} cy must bit-match oracle (packed={}, oracle={oy})",
+                p[1]
+            );
+            assert_eq!(
+                p[2], *or,
+                "sat{i} radius must bit-match oracle (packed={}, oracle={or})",
+                p[2]
+            );
+        }
+    }
+
+    /// (#2) offset direction. With `offset=1.0` the packed main center must equal
+    /// `center + radius*0.25*(cosθ,sinθ)` for the seed's first `gen_range(0..TAU)`;
+    /// with `offset=0.0` the offset distance is 0 so the main center is the geometric
+    /// center *exactly* (the θ draw is still consumed but multiplied by 0).
+    #[test]
+    fn aquarelle_pack_offset_direction_matches_seed_angle() {
+        let Some(renderer) =
+            require_or_skip_renderer("aquarelle_pack_offset_direction_matches_seed_angle")
+        else {
+            return;
+        };
+        let (w, h, base_radius_unit) = (200.0_f32, 200.0_f32, 40.0_f32);
+        let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
+        let radius = base_radius_unit;
+        let center = (100.0_f32, 100.0_f32);
+        let (theta, _) = oracle_aquarelle_sats(0, center, radius, 0.0);
+
+        // offset == 1.0 ⇒ center shifted radius*0.25 along θ.
+        let p1 = AquarelleParams {
+            bleed: 0.0,
+            bloom: 0.0,
+            offset: 1.0,
+            halo: 0.0,
+        };
+        let orbs1 =
+            renderer.pack_aquarelle_orbs(&single, w, h, base_radius_unit, 1.0, p1.clamped());
+        let exp_cx = center.0 + radius * 0.25 * theta.cos();
+        let exp_cy = center.1 + radius * 0.25 * theta.sin();
+        assert_eq!(
+            orbs1[0].main[0], exp_cx,
+            "offset=1.0 main cx must follow seed θ"
+        );
+        assert_eq!(
+            orbs1[0].main[1], exp_cy,
+            "offset=1.0 main cy must follow seed θ"
+        );
+
+        // offset == 0.0 ⇒ exact geometric center (no shift).
+        let p0 = AquarelleParams {
+            bleed: 0.0,
+            bloom: 0.0,
+            offset: 0.0,
+            halo: 0.0,
+        };
+        let orbs0 =
+            renderer.pack_aquarelle_orbs(&single, w, h, base_radius_unit, 1.0, p0.clamped());
+        assert_eq!(
+            orbs0[0].main[0], center.0,
+            "offset=0.0 main cx must be exact center"
+        );
+        assert_eq!(
+            orbs0[0].main[1], center.1,
+            "offset=0.0 main cy must be exact center"
+        );
+    }
+
+    /// (#3) `round(3*bleed)` boundaries (round-half-away-from-zero). The existing test
+    /// only covers 0.0/0.5/1.0; this nails the three rounding edges so a `.round()` →
+    /// `.floor()`/`.trunc()` regression in the satellite count is caught.
+    #[test]
+    fn aquarelle_pack_bleed_count_round_boundaries() {
+        let Some(renderer) =
+            require_or_skip_renderer("aquarelle_pack_bleed_count_round_boundaries")
+        else {
+            return;
+        };
+        let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
+        // (bleed, expected sat_count): just below/above each .5 boundary.
+        for (bleed, expected) in [
+            (0.16_f32, 0u32), // 0.48 → 0
+            (0.17, 1),        // 0.51 → 1
+            (0.49, 1),        // 1.47 → 1
+            (0.50, 2),        // 1.50 → 2 (half away from zero)
+            (0.83, 2),        // 2.49 → 2
+            (0.84, 3),        // 2.52 → 3
+        ] {
+            let params = AquarelleParams {
+                bleed,
+                bloom: 0.0,
+                offset: 0.0,
+                halo: 0.0,
+            };
+            let orbs =
+                renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, params.clamped());
+            assert_eq!(
+                orbs[0].main[3] as u32, expected,
+                "bleed={bleed} ⇒ round(3*bleed) must be {expected}"
+            );
+        }
+    }
+
+    /// (#4) bloom guard. A tiny positive bloom (`1e-4`) must still set the bloom flag
+    /// and produce a positive core radius (the inner `core_radius > 0.0` guard must not
+    /// reject it); bloom `0.0` must clear the flag and pack a zero core radius.
+    #[test]
+    fn aquarelle_pack_bloom_tiny_positive_keeps_core_positive() {
+        let Some(renderer) =
+            require_or_skip_renderer("aquarelle_pack_bloom_tiny_positive_keeps_core_positive")
+        else {
+            return;
+        };
+        let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
+
+        let tiny = AquarelleParams {
+            bleed: 0.0,
+            bloom: 1e-4,
+            offset: 0.0,
+            halo: 0.0,
+        };
+        let orbs = renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, tiny.clamped());
+        assert!(
+            orbs[0].inner[3] > 0.5,
+            "bloom=1e-4 (>0) must set bloom_flag"
+        );
+        assert!(
+            orbs[0].bloom_geom[2] > 0.0,
+            "bloom=1e-4 must keep core radius positive (got {})",
+            orbs[0].bloom_geom[2]
+        );
+
+        let zero = AquarelleParams {
+            bleed: 0.0,
+            bloom: 0.0,
+            offset: 0.0,
+            halo: 0.0,
+        };
+        let orbs0 = renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, zero.clamped());
+        assert!(orbs0[0].inner[3] < 0.5, "bloom=0 must clear bloom_flag");
+        assert_eq!(
+            orbs0[0].bloom_geom[2], 0.0,
+            "bloom=0 must pack zero core radius"
+        );
+    }
+
+    /// (#5) A zero-weight orb packs a fully zeroed row (radius 0, every layer slot 0),
+    /// and a positive-weight orb mixed in the same call is unaffected — only the dead
+    /// row collapses. Guards the early `radius <= 0.0` skip path and row independence.
+    #[test]
+    fn aquarelle_pack_zero_weight_orb_packs_skip_row() {
+        let Some(renderer) =
+            require_or_skip_renderer("aquarelle_pack_zero_weight_orb_packs_skip_row")
+        else {
+            return;
+        };
+        // Orb 0: zero weight (dead). Orb 1: positive weight (real).
+        let clusters = vec![
+            cluster([200, 120, 60], 0.3, 0.3, 0.0),
+            cluster([60, 120, 220], 0.7, 0.7, 1.0),
+        ];
+        let params = AquarelleParams::default();
+        let orbs =
+            renderer.pack_aquarelle_orbs(&clusters, 200.0, 200.0, 40.0, 1.0, params.clamped());
+        assert_eq!(orbs.len(), 2);
+
+        // Dead row: radius 0, sat_count 0, all layer slots zero.
+        assert_eq!(orbs[0].main[2], 0.0, "zero-weight orb must pack radius 0");
+        assert_eq!(
+            orbs[0].main[3], 0.0,
+            "zero-weight orb must pack 0 satellites"
+        );
+        for slot in [
+            orbs[0].inner,
+            orbs[0].halo,
+            orbs[0].bloom_geom,
+            orbs[0].bloom_col,
+            orbs[0].bleed_col,
+            orbs[0].sat0,
+            orbs[0].sat1,
+            orbs[0].sat2,
+        ] {
+            assert_eq!(slot, [0.0; 4], "zero-weight orb layer slots must be zeroed");
+        }
+
+        // Live row: positive radius (the dead neighbor did not poison it).
+        assert!(
+            orbs[1].main[2] > 0.0,
+            "positive-weight orb must have radius > 0"
+        );
+    }
+
+    /// (#6) Out-of-range slider values are clamped (the pack calls `params.clamped()`):
+    /// `bleed=5.0` must still cap at 3 satellites, and a negative `bloom=-1.0` must
+    /// clear the bloom flag (clamped to 0) rather than wrapping to a huge core.
+    #[test]
+    fn aquarelle_pack_clamps_out_of_range_params() {
+        let Some(renderer) = require_or_skip_renderer("aquarelle_pack_clamps_out_of_range_params")
+        else {
+            return;
+        };
+        let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
+        let wild = AquarelleParams {
+            bleed: 5.0,
+            bloom: -1.0,
+            offset: 9.0,
+            halo: -3.0,
+        };
+        // The renderer clamps internally; pass the raw params (matching production:
+        // `pack_aquarelle_orbs` calls `params.clamped()`).
+        let orbs = renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, wild);
+        assert!(
+            (orbs[0].main[3] as u32) <= 3,
+            "bleed=5.0 must clamp to ≤3 satellites (got {})",
+            orbs[0].main[3]
+        );
+        assert!(
+            orbs[0].inner[3] < 0.5,
+            "negative bloom must clamp to 0 and clear the bloom flag"
+        );
+        assert_eq!(
+            orbs[0].bloom_geom[2], 0.0,
+            "negative bloom must pack a zero core radius (clamped)"
+        );
+    }
+
+    /// (#7) `saturation=0.0` desaturates every packed layer color: each must equal the
+    /// grayscale `adjust_saturation_pub(base, 0.0)` (boosting a gray stays gray, mixing
+    /// a gray toward white stays gray), so the GPU never sees a saturated color the CPU
+    /// oracle desaturated.
+    #[test]
+    fn aquarelle_pack_saturation_zero_desaturates_layer_colors() {
+        let Some(renderer) =
+            require_or_skip_renderer("aquarelle_pack_saturation_zero_desaturates_layer_colors")
+        else {
+            return;
+        };
+        let base = [200u8, 120, 60];
+        let single = vec![cluster(base, 0.5, 0.5, 1.0)];
+        // bleed=1.0 ⇒ satellites exist; bloom=0.5 ⇒ bloom color packed; halo=0.5.
+        let params = AquarelleParams {
+            bleed: 1.0,
+            bloom: 0.5,
+            offset: 0.5,
+            halo: 0.5,
+        };
+        let orbs = renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 0.0, params.clamped());
+
+        // The pack desaturates the source first (saturation 0.0 ⇒ grayscale), then
+        // boost_saturation/mix_with_white operate on that gray. A boost of an
+        // already-gray color stays gray; a white-mix of gray stays gray. So every
+        // packed layer's three channels must be equal (chroma == 0).
+        let gray = adjust_saturation_pub(base, 0.0);
+        assert_eq!(gray[0], gray[1], "desaturated base must be gray");
+        assert_eq!(gray[1], gray[2], "desaturated base must be gray");
+
+        let is_gray = |rgb: [f32; 4]| -> bool {
+            let to8 = |c: f32| (c * 255.0).round() as i32;
+            (to8(rgb[0]) - to8(rgb[1])).abs() <= 1 && (to8(rgb[1]) - to8(rgb[2])).abs() <= 1
+        };
+        assert!(
+            is_gray(orbs[0].inner),
+            "inner color must be gray at saturation 0"
+        );
+        assert!(
+            is_gray(orbs[0].halo),
+            "halo color must be gray at saturation 0"
+        );
+        assert!(
+            is_gray(orbs[0].bleed_col),
+            "bleed color must be gray at saturation 0"
+        );
+        assert!(
+            is_gray(orbs[0].bloom_col),
+            "bloom color must be gray at saturation 0"
+        );
+        // And the inner color is exactly the desaturated base (round-trip via u8).
+        let inner8 = [
+            (orbs[0].inner[0] * 255.0).round() as u8,
+            (orbs[0].inner[1] * 255.0).round() as u8,
+            (orbs[0].inner[2] * 255.0).round() as u8,
+        ];
+        assert_eq!(
+            inner8, gray,
+            "inner layer must be the desaturated base color"
+        );
+    }
+
+    /// (#8, pure CPU — runs everywhere) Aquarelle ignores `--count`: one orb per
+    /// cluster. `count=Some(64)` with 3 clusters must render byte-identically to
+    /// `count=None`. Uses only the CPU `render_frame` oracle (no GPU needed).
+    #[test]
+    fn aquarelle_render_frame_ignores_count() {
+        let clusters = vec![
+            cluster([220, 60, 60], 0.3, 0.35, 0.8),
+            cluster([60, 120, 220], 0.7, 0.55, 0.5),
+            cluster([200, 200, 80], 0.5, 0.8, 0.4),
+        ];
+        let mut opts = aquarelle_opts(72, 56, AquarelleParams::default());
+        opts.count = None;
+        let none = render_frame(&clusters, &opts, 0.0);
+        opts.count = Some(64);
+        let with_count = render_frame(&clusters, &opts, 0.0);
+        assert_eq!(
+            none.as_raw(),
+            with_count.as_raw(),
+            "aquarelle must render one orb per cluster regardless of --count"
+        );
+    }
+
+    /// Shared structural-parity check: GPU↔CPU aquarelle must light overlapping pixel
+    /// sets and stay close in mean per-channel diff (AA-only residual, like Circle).
+    /// Returns nothing; panics on failure. Used by the corner / branch tests below.
+    fn assert_aquarelle_structural_parity(
+        renderer: &GpuRenderer,
+        clusters: &[Cluster],
+        opts: &AnimateOptions,
+        t: f32,
+        label: &str,
+    ) {
+        let cpu = render_frame(clusters, opts, t);
+        let gpu = renderer.render_frame_aquarelle(clusters, opts, t);
+        assert_eq!(cpu.dimensions(), gpu.dimensions(), "{label}: dim mismatch");
+        let bg = opts.background;
+        let (mut cpu_lit, mut gpu_lit, mut overlap, mut sum_abs) = (0usize, 0usize, 0usize, 0u64);
+        for (cp, gp) in cpu.pixels().zip(gpu.pixels()) {
+            let c_lit = (0..3).any(|c| cp.0[c].abs_diff(bg[c]) > 8);
+            let g_lit = (0..3).any(|c| gp.0[c].abs_diff(bg[c]) > 8);
+            if c_lit {
+                cpu_lit += 1;
+            }
+            if g_lit {
+                gpu_lit += 1;
+            }
+            if c_lit && g_lit {
+                overlap += 1;
+            }
+            for c in 0..3 {
+                sum_abs += cp.0[c].abs_diff(gp.0[c]) as u64;
+            }
+        }
+        assert!(
+            cpu_lit > 0 && gpu_lit > 0,
+            "{label}: both renders must light pixels"
+        );
+        let overlap_frac = overlap as f32 / cpu_lit.min(gpu_lit) as f32;
+        assert!(
+            overlap_frac > 0.85,
+            "{label}: lit overlap {:.1}% of smaller set; expected >85% (cpu_lit={cpu_lit} gpu_lit={gpu_lit})",
+            overlap_frac * 100.0
+        );
+        let (w, h) = cpu.dimensions();
+        let mean_abs = sum_abs as f64 / (w as f64 * h as f64 * 3.0);
+        assert!(
+            mean_abs < 3.0,
+            "{label}: mean per-channel |cpu-gpu| {mean_abs:.3} should be small (AA-only residual)"
+        );
+    }
+
+    /// (#9) A large orb near a corner pushes its satellites' `radius*1.5` cutoff past
+    /// the frame edge. The shader clips at the cutoff (outside ⇒ background); the GPU
+    /// must still match the CPU within the structural-parity band, proving the
+    /// edge-clipped arc is composited correctly rather than smeared or wrapped.
+    #[test]
+    fn aquarelle_gpu_satellite_cutoff_clipped_at_edge() {
+        let Some(renderer) =
+            require_or_skip_renderer("aquarelle_gpu_satellite_cutoff_clipped_at_edge")
+        else {
+            return;
+        };
+        // Big orb (weight 1.0 ⇒ radius == base_radius_unit, large for 64x64) tucked in
+        // the top-left corner so the main + satellites overhang the edge.
+        let clusters = vec![cluster([220, 80, 80], 0.08, 0.08, 1.0)];
+        let params = AquarelleParams {
+            bleed: 1.0,
+            bloom: 0.5,
+            offset: 0.5,
+            halo: 0.5,
+        };
+        let opts = aquarelle_opts(64, 64, params);
+        assert_aquarelle_structural_parity(
+            renderer,
+            &clusters,
+            &opts,
+            0.0,
+            "aquarelle edge-clipped satellites",
+        );
+    }
+
+    /// (#10) Transparent background (`bg.a < 255`, here fully transparent). The shader's
+    /// `0 < acc_a8 < 255` un-premultiply branch in `fs_main` must round-trip premultiplied
+    /// → straight the same way the CPU `finalize_pixmap` does, so GPU↔CPU stay within the
+    /// structural-parity band over a transparent canvas.
+    #[test]
+    fn aquarelle_gpu_transparent_background_premul_roundtrip() {
+        let Some(renderer) =
+            require_or_skip_renderer("aquarelle_gpu_transparent_background_premul_roundtrip")
+        else {
+            return;
+        };
+        let clusters = vec![
+            cluster([220, 60, 60], 0.35, 0.4, 0.6),
+            cluster([60, 140, 220], 0.65, 0.6, 0.5),
+        ];
+        let mut opts = aquarelle_opts(80, 80, AquarelleParams::default());
+        opts.background = [0, 0, 0, 0]; // fully transparent canvas
+        assert_aquarelle_structural_parity(
+            renderer,
+            &clusters,
+            &opts,
+            0.0,
+            "aquarelle transparent bg premul round-trip",
+        );
+    }
+
+    /// (#11) Param-corner parity. The existing structural test only exercises the
+    /// default mid (0.5) params; this sweeps representative `{bleed,bloom,halo,offset}`
+    /// corners in `{0,1}` so an extreme-param divergence (e.g. bloom-off vs bloom-max,
+    /// no-bleed vs full-bleed) is caught by the GPU↔CPU structural band.
+    #[test]
+    fn aquarelle_gpu_parity_across_param_corners() {
+        let Some(renderer) = require_or_skip_renderer("aquarelle_gpu_parity_across_param_corners")
+        else {
+            return;
+        };
+        let clusters = vec![
+            cluster([220, 60, 60], 0.3, 0.35, 0.7),
+            cluster([60, 120, 220], 0.7, 0.6, 0.5),
+        ];
+        // Representative corners (not the full 16 — keep GPU work bounded).
+        let corners = [
+            (0.0_f32, 0.0_f32, 0.0_f32, 0.0_f32),
+            (1.0, 0.0, 0.0, 1.0),
+            (0.0, 1.0, 1.0, 0.0),
+            (1.0, 1.0, 1.0, 1.0),
+            (1.0, 0.0, 1.0, 0.0),
+        ];
+        for (bleed, bloom, halo, offset) in corners {
+            let params = AquarelleParams {
+                bleed,
+                bloom,
+                offset,
+                halo,
+            };
+            let opts = aquarelle_opts(72, 72, params);
+            assert_aquarelle_structural_parity(
+                renderer,
+                &clusters,
+                &opts,
+                0.0,
+                &format!(
+                    "aquarelle corner bleed={bleed} bloom={bloom} halo={halo} offset={offset}"
+                ),
+            );
+        }
+    }
 }

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -1,4 +1,4 @@
-//! wgpu (Rust + WGSL) production render path — orber #207 Phase 0.
+//! wgpu (Rust + WGSL) production render path — orber #207 Phase 0–1c.
 //!
 //! [`GpuRenderer`] is the headless, native side of the renderer. It runs the
 //! **Circle** orb WGSL ([`orb_circle.wgsl`](../src/orb_circle.wgsl)) that is a
@@ -11,8 +11,13 @@
 //!
 //! Parity with the CPU oracle holds **only** on this exact path:
 //!
-//! - **shape = Circle** (Glyph / image / aquarelle are Phase 1; the CLI routes
-//!   those to the CPU renderer);
+//! - **shape = Circle** for the strict ±2/channel bit-exact parity described
+//!   here. Glyph (#212/#214) and Aquarelle (#216) also render on the GPU, but
+//!   match the CPU oracle only **structurally** (float SDF / analytic-vs-AA
+//!   differences), not bit-exact — see `render_frame_glyph` /
+//!   `render_frame_aquarelle`. The `image` shape is web-only and rides the Glyph
+//!   SDF path (core/wasm have no native `image` shape). The CPU renderer is now
+//!   only a no-GPU-adapter fallback (removed in Phase 1.5);
 //! - **saturation reflected**: [`GpuRenderer::render_frame`] re-applies
 //!   [`adjust_saturation_pub`](crate::orb::adjust_saturation_pub) with
 //!   `opts.saturation` to each packed orb color after
@@ -53,8 +58,13 @@
 //!
 //! ## Scope
 //!
-//! Phase 0 covers **Circle orbs only**. Glyph / image shapes / aquarelle are
-//! Phase 1; the CLI falls back to the CPU renderer for non-Circle shapes.
+//! Circle (Phase 0, #209), Glyph (Phase 1b, #212/#214) and Aquarelle (Phase 1c,
+//! #216) all render on the GPU. The `image` shape is web-only and reuses the
+//! Glyph SDF path (core/wasm have no `image` shape — the browser hands an image
+//! silhouette in as a glyph SDF). The CPU (tiny-skia) renderer remains only as a
+//! no-GPU-adapter fallback and as the parity oracle; both are removed in
+//! Phase 1.5. Video and per-orb color/keyframe tracks (#7 / #33) are still
+//! CPU-only.
 
 use std::collections::HashMap;
 
@@ -828,8 +838,9 @@ impl GpuRenderer {
     /// # Panics / scope
     ///
     /// This is the **Circle** path only. The shape in `opts.shape` is ignored
-    /// here (the caller is responsible for routing non-Circle shapes to the CPU
-    /// renderer); see the module docs.
+    /// here; the caller routes `Glyph` to `render_frame_glyph` and `Aquarelle`
+    /// to `render_frame_aquarelle` (both GPU), and only falls back to the CPU
+    /// renderer when no GPU adapter is available. See the module docs.
     pub fn render_frame(&self, clusters: &[Cluster], opts: &AnimateOptions, t: f32) -> RgbaImage {
         let width = opts.width.max(1);
         let height = opts.height.max(1);

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -4334,6 +4334,100 @@ mod tests {
         );
     }
 
+    /// #216: concurrent aquarelle renders on the shared renderer must each match
+    /// their solo oracle — no panic / poison, no cross-thread aliasing of the shared
+    /// aquarelle data-texture / per-size target / read-back buffer (the #210
+    /// serialization contract). Several threads render different aquarelle frames
+    /// (mixed params + t) on the *same* renderer; each thread's output must equal
+    /// that same input rendered alone (a fresh renderer). Mirrors the Circle
+    /// (`shared_gpu_concurrent_high_count_render`) and Glyph
+    /// (`shared_gpu_concurrent_glyph_render`) concurrent tests for the aquarelle
+    /// path. Aquarelle is deterministic (per-orb-index ChaCha8 seed, no thread_rng),
+    /// so the match is byte-identical, not just within tolerance.
+    #[test]
+    fn aquarelle_shared_gpu_concurrent_render() {
+        let Some(renderer) = require_or_skip_renderer("aquarelle_shared_gpu_concurrent_render")
+        else {
+            return;
+        };
+        // (params, t) cases — mixed layer params + time so threads exercise different
+        // packs (satellite counts, bloom, offset) and per-orb modulation at once.
+        let cases: [(AquarelleParams, f32); 4] = [
+            (
+                AquarelleParams {
+                    bleed: 1.0,
+                    bloom: 0.8,
+                    offset: 0.6,
+                    halo: 0.4,
+                },
+                0.0,
+            ),
+            (
+                AquarelleParams {
+                    bleed: 0.5,
+                    bloom: 0.0,
+                    offset: 0.3,
+                    halo: 0.7,
+                },
+                0.25,
+            ),
+            (
+                AquarelleParams {
+                    bleed: 0.0,
+                    bloom: 0.5,
+                    offset: 0.9,
+                    halo: 0.2,
+                },
+                0.5,
+            ),
+            (AquarelleParams::default(), 0.75),
+        ];
+
+        let clusters = vec![
+            cluster([220, 60, 60], 0.3, 0.35, 0.8),
+            cluster([60, 120, 220], 0.7, 0.55, 0.5),
+            cluster([200, 200, 80], 0.5, 0.8, 0.4),
+        ];
+
+        // Per-case oracle: render each alone on a fresh renderer first.
+        let mut oracles = Vec::new();
+        for &(params, t) in &cases {
+            let opts = aquarelle_opts(96, 72, params);
+            let Some(fresh) = require_or_skip_fresh_renderer(
+                "aquarelle_shared_gpu_concurrent_render (oracle leg)",
+            ) else {
+                return;
+            };
+            oracles.push(fresh.render_frame_aquarelle(&clusters, &opts, t));
+        }
+
+        std::thread::scope(|scope| {
+            let mut handles = Vec::new();
+            for (idx, &(params, t)) in cases.iter().enumerate() {
+                let oracle = &oracles[idx];
+                let clusters = &clusters;
+                handles.push(scope.spawn(move || {
+                    let opts = aquarelle_opts(96, 72, params);
+                    // A few iterations per thread to maximize overlap on the shared
+                    // aquarelle texture / per-size resources.
+                    for _ in 0..3 {
+                        let img = renderer.render_frame_aquarelle(clusters, &opts, t);
+                        assert_eq!(
+                            oracle.as_raw(),
+                            img.as_raw(),
+                            "concurrent aquarelle (case {idx}, t={t}) must be byte-identical to its solo render"
+                        );
+                    }
+                }));
+            }
+            for h in handles {
+                h.join()
+                    .expect("concurrent aquarelle render thread panicked");
+            }
+        });
+        eprintln!("concurrent aquarelle render: all threads matched their solo oracle");
+    }
+
     /// A non-Aquarelle shape passed to `render_frame_aquarelle` must fall back to the
     /// Circle path (the call is total), matching the Glyph-entry fallback contract.
     #[test]

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -1077,7 +1077,7 @@ impl GpuRenderer {
         let base_radius_unit = (width.min(height) as f32) * 0.25 * opts.orb_size.max(0.0);
         let saturation = opts.saturation.max(0.0);
 
-        let orbs = self.pack_aquarelle_orbs(
+        let orbs = Self::pack_aquarelle_orbs(
             &modulated,
             width as f32,
             height as f32,
@@ -1099,8 +1099,11 @@ impl GpuRenderer {
     ///
     /// Orbs with radius `<= 0.0` (zero weight) pack a zero-radius row, which the
     /// shader skips — matching the crate's early `return` for non-positive radius.
+    ///
+    /// Pure data transform (no `self`): an associated function so pack-only tests
+    /// can call it without a live GPU adapter (RNG/layout reproduction is verified
+    /// on every host, not just GPU CI).
     fn pack_aquarelle_orbs(
-        &self,
         clusters: &[Cluster],
         width: f32,
         height: f32,
@@ -4202,11 +4205,8 @@ mod tests {
     /// `bleed` values, plus that bloom presence tracks `bloom > 0`.
     #[test]
     fn aquarelle_pack_satellite_count_and_bloom_flag() {
-        let Some(renderer) =
-            require_or_skip_renderer("aquarelle_pack_satellite_count_and_bloom_flag")
-        else {
-            return;
-        };
+        // Pack-only: `pack_aquarelle_orbs` is an associated fn (no GPU adapter
+        // needed), so this RNG/layout test runs on every host, not just GPU CI.
         let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
         // bleed → expected round(3*bleed): 0→0, 0.5→2 (1.5 rounds to 2), 1.0→3.
         for (bleed, expected) in [(0.0_f32, 0u32), (0.5, 2), (1.0, 3)] {
@@ -4216,8 +4216,14 @@ mod tests {
                 offset: 0.5,
                 halo: 0.5,
             };
-            let orbs =
-                renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, params.clamped());
+            let orbs = GpuRenderer::pack_aquarelle_orbs(
+                &single,
+                200.0,
+                200.0,
+                40.0,
+                1.0,
+                params.clamped(),
+            );
             assert_eq!(orbs.len(), 1);
             assert_eq!(
                 orbs[0].main[3] as u32, expected,
@@ -4237,7 +4243,7 @@ mod tests {
             offset: 0.0,
             halo: 0.0,
         };
-        let orbs = renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, no_bloom);
+        let orbs = GpuRenderer::pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, no_bloom);
         assert!(orbs[0].inner[3] < 0.5, "bloom=0 must clear bloom_flag");
     }
 
@@ -4385,11 +4391,8 @@ mod tests {
     /// exact order. Guards the RNG-reproduction contract the whole WGSL path rests on.
     #[test]
     fn aquarelle_pack_satellite_positions_match_crate() {
-        let Some(renderer) =
-            require_or_skip_renderer("aquarelle_pack_satellite_positions_match_crate")
-        else {
-            return;
-        };
+        // Pack-only: `pack_aquarelle_orbs` is an associated fn (no GPU adapter
+        // needed), so this RNG-reproduction test runs on every host, not just GPU CI.
         let (w, h, base_radius_unit) = (200.0_f32, 200.0_f32, 40.0_f32);
         // weight 1.0 ⇒ radius == base_radius_unit; center at (0.5,0.5) ⇒ (100,100).
         let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
@@ -4403,8 +4406,14 @@ mod tests {
             offset: 0.5,
             halo: 0.5,
         };
-        let orbs =
-            renderer.pack_aquarelle_orbs(&single, w, h, base_radius_unit, 1.0, params.clamped());
+        let orbs = GpuRenderer::pack_aquarelle_orbs(
+            &single,
+            w,
+            h,
+            base_radius_unit,
+            1.0,
+            params.clamped(),
+        );
         assert_eq!(orbs.len(), 1);
         assert_eq!(
             orbs[0].main[3] as u32, 3,
@@ -4439,11 +4448,8 @@ mod tests {
     /// center *exactly* (the θ draw is still consumed but multiplied by 0).
     #[test]
     fn aquarelle_pack_offset_direction_matches_seed_angle() {
-        let Some(renderer) =
-            require_or_skip_renderer("aquarelle_pack_offset_direction_matches_seed_angle")
-        else {
-            return;
-        };
+        // Pack-only: `pack_aquarelle_orbs` is an associated fn (no GPU adapter
+        // needed), so this RNG-reproduction test runs on every host, not just GPU CI.
         let (w, h, base_radius_unit) = (200.0_f32, 200.0_f32, 40.0_f32);
         let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
         let radius = base_radius_unit;
@@ -4458,7 +4464,7 @@ mod tests {
             halo: 0.0,
         };
         let orbs1 =
-            renderer.pack_aquarelle_orbs(&single, w, h, base_radius_unit, 1.0, p1.clamped());
+            GpuRenderer::pack_aquarelle_orbs(&single, w, h, base_radius_unit, 1.0, p1.clamped());
         let exp_cx = center.0 + radius * 0.25 * theta.cos();
         let exp_cy = center.1 + radius * 0.25 * theta.sin();
         assert_eq!(
@@ -4478,7 +4484,7 @@ mod tests {
             halo: 0.0,
         };
         let orbs0 =
-            renderer.pack_aquarelle_orbs(&single, w, h, base_radius_unit, 1.0, p0.clamped());
+            GpuRenderer::pack_aquarelle_orbs(&single, w, h, base_radius_unit, 1.0, p0.clamped());
         assert_eq!(
             orbs0[0].main[0], center.0,
             "offset=0.0 main cx must be exact center"
@@ -4494,11 +4500,8 @@ mod tests {
     /// `.floor()`/`.trunc()` regression in the satellite count is caught.
     #[test]
     fn aquarelle_pack_bleed_count_round_boundaries() {
-        let Some(renderer) =
-            require_or_skip_renderer("aquarelle_pack_bleed_count_round_boundaries")
-        else {
-            return;
-        };
+        // Pack-only: `pack_aquarelle_orbs` is an associated fn (no GPU adapter
+        // needed), so this rounding-edge test runs on every host, not just GPU CI.
         let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
         // (bleed, expected sat_count): just below/above each .5 boundary.
         for (bleed, expected) in [
@@ -4515,8 +4518,14 @@ mod tests {
                 offset: 0.0,
                 halo: 0.0,
             };
-            let orbs =
-                renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, params.clamped());
+            let orbs = GpuRenderer::pack_aquarelle_orbs(
+                &single,
+                200.0,
+                200.0,
+                40.0,
+                1.0,
+                params.clamped(),
+            );
             assert_eq!(
                 orbs[0].main[3] as u32, expected,
                 "bleed={bleed} ⇒ round(3*bleed) must be {expected}"
@@ -4529,11 +4538,8 @@ mod tests {
     /// reject it); bloom `0.0` must clear the flag and pack a zero core radius.
     #[test]
     fn aquarelle_pack_bloom_tiny_positive_keeps_core_positive() {
-        let Some(renderer) =
-            require_or_skip_renderer("aquarelle_pack_bloom_tiny_positive_keeps_core_positive")
-        else {
-            return;
-        };
+        // Pack-only: `pack_aquarelle_orbs` is an associated fn (no GPU adapter
+        // needed), so this bloom-guard test runs on every host, not just GPU CI.
         let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
 
         let tiny = AquarelleParams {
@@ -4542,7 +4548,8 @@ mod tests {
             offset: 0.0,
             halo: 0.0,
         };
-        let orbs = renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, tiny.clamped());
+        let orbs =
+            GpuRenderer::pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, tiny.clamped());
         assert!(
             orbs[0].inner[3] > 0.5,
             "bloom=1e-4 (>0) must set bloom_flag"
@@ -4559,7 +4566,8 @@ mod tests {
             offset: 0.0,
             halo: 0.0,
         };
-        let orbs0 = renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, zero.clamped());
+        let orbs0 =
+            GpuRenderer::pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, zero.clamped());
         assert!(orbs0[0].inner[3] < 0.5, "bloom=0 must clear bloom_flag");
         assert_eq!(
             orbs0[0].bloom_geom[2], 0.0,
@@ -4572,11 +4580,8 @@ mod tests {
     /// row collapses. Guards the early `radius <= 0.0` skip path and row independence.
     #[test]
     fn aquarelle_pack_zero_weight_orb_packs_skip_row() {
-        let Some(renderer) =
-            require_or_skip_renderer("aquarelle_pack_zero_weight_orb_packs_skip_row")
-        else {
-            return;
-        };
+        // Pack-only: `pack_aquarelle_orbs` is an associated fn (no GPU adapter
+        // needed), so this skip-row test runs on every host, not just GPU CI.
         // Orb 0: zero weight (dead). Orb 1: positive weight (real).
         let clusters = vec![
             cluster([200, 120, 60], 0.3, 0.3, 0.0),
@@ -4584,7 +4589,7 @@ mod tests {
         ];
         let params = AquarelleParams::default();
         let orbs =
-            renderer.pack_aquarelle_orbs(&clusters, 200.0, 200.0, 40.0, 1.0, params.clamped());
+            GpuRenderer::pack_aquarelle_orbs(&clusters, 200.0, 200.0, 40.0, 1.0, params.clamped());
         assert_eq!(orbs.len(), 2);
 
         // Dead row: radius 0, sat_count 0, all layer slots zero.
@@ -4618,10 +4623,8 @@ mod tests {
     /// clear the bloom flag (clamped to 0) rather than wrapping to a huge core.
     #[test]
     fn aquarelle_pack_clamps_out_of_range_params() {
-        let Some(renderer) = require_or_skip_renderer("aquarelle_pack_clamps_out_of_range_params")
-        else {
-            return;
-        };
+        // Pack-only: `pack_aquarelle_orbs` is an associated fn (no GPU adapter
+        // needed), so this clamp test runs on every host, not just GPU CI.
         let single = vec![cluster([200, 120, 60], 0.5, 0.5, 1.0)];
         let wild = AquarelleParams {
             bleed: 5.0,
@@ -4631,7 +4634,7 @@ mod tests {
         };
         // The renderer clamps internally; pass the raw params (matching production:
         // `pack_aquarelle_orbs` calls `params.clamped()`).
-        let orbs = renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, wild);
+        let orbs = GpuRenderer::pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 1.0, wild);
         assert!(
             (orbs[0].main[3] as u32) <= 3,
             "bleed=5.0 must clamp to ≤3 satellites (got {})",
@@ -4653,11 +4656,8 @@ mod tests {
     /// oracle desaturated.
     #[test]
     fn aquarelle_pack_saturation_zero_desaturates_layer_colors() {
-        let Some(renderer) =
-            require_or_skip_renderer("aquarelle_pack_saturation_zero_desaturates_layer_colors")
-        else {
-            return;
-        };
+        // Pack-only: `pack_aquarelle_orbs` is an associated fn (no GPU adapter
+        // needed), so this saturation test runs on every host, not just GPU CI.
         let base = [200u8, 120, 60];
         let single = vec![cluster(base, 0.5, 0.5, 1.0)];
         // bleed=1.0 ⇒ satellites exist; bloom=0.5 ⇒ bloom color packed; halo=0.5.
@@ -4667,7 +4667,8 @@ mod tests {
             offset: 0.5,
             halo: 0.5,
         };
-        let orbs = renderer.pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 0.0, params.clamped());
+        let orbs =
+            GpuRenderer::pack_aquarelle_orbs(&single, 200.0, 200.0, 40.0, 0.0, params.clamped());
 
         // The pack desaturates the source first (saturation 0.0 ⇒ grayscale), then
         // boost_saturation/mix_with_white operate on that gray. A boost of an

--- a/crates/core/src/orb_aquarelle.wgsl
+++ b/crates/core/src/orb_aquarelle.wgsl
@@ -102,11 +102,14 @@ fn div255(v: f32) -> f32 {
 }
 
 // straight float (0..1) を tiny-skia の lowp 量子化で u8 (0..255 float) にする。
+// rgb は normalize(clamp 0..1) 後に *255+0.5 を floor。alpha は clamp 無し。
+// orb_circle.wgsl の to_u8_rgb / to_u8_a と完全に同一（aquarelle の alpha は
+// すべて N/255 の定数を mix した [0,1] 値なので clamp は元から no-op）。
 fn to_u8_rgb(c: f32) -> f32 {
     return floor(clampf(c, 0.0, 1.0) * 255.0 + 0.5);
 }
 fn to_u8_a(c: f32) -> f32 {
-    return floor(clampf(c, 0.0, 1.0) * 255.0 + 0.5);
+    return floor(c * 255.0 + 0.5);
 }
 
 // 1 つの 3-stop radial（aquarelle::draw_radial 相当）を評価し、straight rgba (0..1)

--- a/crates/core/src/orb_aquarelle.wgsl
+++ b/crates/core/src/orb_aquarelle.wgsl
@@ -1,0 +1,301 @@
+// orber #216 Phase 1c — Aquarelle orb の production WGSL（native CLI / wgpu）。
+//
+// `aquarelle::render_aquarelle_orb`（per-orb・seed = orb index で決定論的）の 4 層
+// （offset / main 3-stop radial / 0..3 bleed satellites / bloom core）を WGSL で評価し、
+// tiny-skia と同じ流儀（u8 量子化 → premultiply(div255) → source_over(div255)）で
+// SourceOver 合成する。描画順は main → satellites → bloom。
+//
+// ChaCha8 はシェーダに持ち込まない（#216 方針 Option A）:
+//   - offset 角・satellite の位置/半径・bloom 有無は seed=orb index から決定論的に
+//     決まるので、gpu.rs の pack 段で `ChaCha8Rng::seed_from_u64(i)` を
+//     render_aquarelle_orb と完全同順に回して算出し、専用 data-texture に積む。
+//   - boost_saturation(HSL)/mix_with_white の色も CPU で算出し u8 色として積む
+//     （HSL を WGSL 再実装して divergence を生むのを避ける）。
+//   - よってこのシェーダは「積まれた中心・半径・色で 3-stop radial を最大 5 回
+//     （main + ≤3 satellites + bloom）評価して SourceOver 合成する」だけ。
+//
+// CPU(tiny-skia) との対応（パリティ範囲は狭い。過大主張しない）:
+//   - 残差は tiny-skia の anti-alias 塗り(fill_path)と WGSL の解析的 radial の差のみ
+//     = 構造完全一致・AA だけ緩い許容（Circle と同じ性質。Circle は ±2/ch）。
+//   - 3-stop radial 各 stop の straight 色は tiny-skia `Color::from_rgba8` の u8
+//     量子化に合わせて pack 段で算出済み（このシェーダは 0..1 float をそのまま補間）。
+//
+// data-texture レイアウト（Rgba32Float, 幅 AQUARELLE_TEX_WIDTH=9 texel × 高さ N orbs、
+//   textureLoad で読む。gpu.rs::ORB の Circle 経路とは別テクスチャ・別 binding）:
+//   x=0: main = (main_cx, main_cy, main_radius, sat_count)         px 座標・px 半径
+//   x=1: inner = (inner_r, inner_g, inner_b, bloom_flag)           main の中心色 @255 / bloom 有無
+//   x=2: halo  = (halo_r, halo_g, halo_b, _)                       main の mid@128 / edge@0 色
+//   x=3: bloom_geom = (bloom_cx, bloom_cy, bloom_core_radius, _)
+//   x=4: bloom_col  = (bloom_r, bloom_g, bloom_b, _)               mix_with_white 済み色
+//   x=5: bleed_col   = (bleed_r, bleed_g, bleed_b, _)              satellite 共通色
+//   x=6: sat0 = (sat0_cx, sat0_cy, sat0_radius, _)
+//   x=7: sat1 = (sat1_cx, sat1_cy, sat1_radius, _)
+//   x=8: sat2 = (sat2_cx, sat2_cy, sat2_radius, _)
+//   y  : orb index
+//
+// sampler は持たず textureLoad（texelFetch 相当）のみで読むので filtering 非依存
+// （gpu.rs の sample_type は Float{ filterable: false }）。Rgba32Float が filtering
+// 非対応な環境でも動き、storage buffer 不使用なので WebGL2 backend でも可搬。
+
+struct Params {
+    resolution: vec2<f32>, // (width, height) px
+    n_orbs: f32,           // 整数を f32 で（uniform alignment 簡略化のため）
+    _pad0: f32,
+    bg: vec4<f32>,         // straight rgba (0..1)
+};
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var orb_tex: texture_2d<f32>;
+
+struct AquaOrb {
+    main: vec4<f32>,       // (main_cx, main_cy, main_radius, sat_count)
+    inner: vec4<f32>,      // (inner_rgb, bloom_flag)
+    halo: vec4<f32>,       // (halo_rgb, _)
+    bloom_geom: vec4<f32>, // (bloom_cx, bloom_cy, bloom_core_radius, _)
+    bloom_col: vec4<f32>,  // (bloom_rgb, _)
+    bleed_col: vec4<f32>,  // (bleed_rgb, _)
+    sat0: vec4<f32>,       // (sat0_cx, sat0_cy, sat0_radius, _)
+    sat1: vec4<f32>,       // (sat1_cx, sat1_cy, sat1_radius, _)
+    sat2: vec4<f32>,       // (sat2_cx, sat2_cy, sat2_radius, _)
+};
+
+fn load_orb(i: u32) -> AquaOrb {
+    let row = i32(i);
+    var o: AquaOrb;
+    o.main = textureLoad(orb_tex, vec2<i32>(0, row), 0);
+    o.inner = textureLoad(orb_tex, vec2<i32>(1, row), 0);
+    o.halo = textureLoad(orb_tex, vec2<i32>(2, row), 0);
+    o.bloom_geom = textureLoad(orb_tex, vec2<i32>(3, row), 0);
+    o.bloom_col = textureLoad(orb_tex, vec2<i32>(4, row), 0);
+    o.bleed_col = textureLoad(orb_tex, vec2<i32>(5, row), 0);
+    o.sat0 = textureLoad(orb_tex, vec2<i32>(6, row), 0);
+    o.sat1 = textureLoad(orb_tex, vec2<i32>(7, row), 0);
+    o.sat2 = textureLoad(orb_tex, vec2<i32>(8, row), 0);
+    return o;
+}
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>,
+};
+
+// フルスクリーン三角形（頂点バッファ無し）。orb_circle.wgsl と同形。
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VsOut {
+    var xy = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>(3.0, -1.0),
+        vec2<f32>(-1.0, 3.0),
+    );
+    var out: VsOut;
+    out.pos = vec4<f32>(xy[vi], 0.0, 1.0);
+    return out;
+}
+
+fn clampf(x: f32, a: f32, b: f32) -> f32 {
+    return min(max(x, a), b);
+}
+
+// tiny-skia lowp の div255: (v + 255) >> 8 == floor((v + 255) / 256)。
+// 入力 v は u8*u8 積（0..65025 程度）を float で持つ。orb_circle.wgsl と同一。
+fn div255(v: f32) -> f32 {
+    return floor((v + 255.0) / 256.0);
+}
+
+// straight float (0..1) を tiny-skia の lowp 量子化で u8 (0..255 float) にする。
+fn to_u8_rgb(c: f32) -> f32 {
+    return floor(clampf(c, 0.0, 1.0) * 255.0 + 0.5);
+}
+fn to_u8_a(c: f32) -> f32 {
+    return floor(clampf(c, 0.0, 1.0) * 255.0 + 0.5);
+}
+
+// 1 つの 3-stop radial（aquarelle::draw_radial 相当）を評価し、straight rgba (0..1)
+// を返す。pixel `px` が中心 (cx,cy)・半径 `radius` の円の **radius*1.5 の外** なら
+// 描かない（draw_radial は半径×1.5 の円を fill するため）。`.a == 0` で「無描画」。
+//
+// stop は [0→(inner_rgb, inner_a), mid_stop→(mid_rgb, mid_a), 1→(edge_rgb, edge_a)]。
+// tiny-skia (SpreadMode::Pad) は半径外（r>=1）では edge stop の色で clamp する。
+// straight 色 / alpha とも線形補間する（aquarelle は inner→mid→edge で rgb も変わる）。
+fn eval_radial(
+    px: vec2<f32>,
+    cx: f32,
+    cy: f32,
+    radius: f32,
+    inner_rgb: vec3<f32>,
+    inner_a: f32,
+    mid_rgb: vec3<f32>,
+    mid_a: f32,
+    edge_rgb: vec3<f32>,
+    edge_a: f32,
+    mid_stop_in: f32,
+) -> vec4<f32> {
+    if (radius <= 0.0) {
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    }
+    let dist = distance(px, vec2<f32>(cx, cy));
+    // draw_radial は半径 × 1.5 の円を fill する。その外は描画なし。
+    if (dist > radius * 1.5) {
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    }
+    let r = dist / radius;
+    // mid_stop は tiny-skia 同様 0.05..0.95 にクランプ（GradientStop の clamp）。
+    let mid_stop = clampf(mid_stop_in, 0.05, 0.95);
+
+    var rgb: vec3<f32>;
+    var a: f32;
+    if (r <= 0.0) {
+        rgb = inner_rgb;
+        a = inner_a;
+    } else if (r >= 1.0) {
+        // SpreadMode::Pad: 半径外は edge 色で clamp。
+        rgb = edge_rgb;
+        a = edge_a;
+    } else if (r <= mid_stop) {
+        var u = 1.0;
+        if (mid_stop > 0.0) {
+            u = r / mid_stop;
+        }
+        rgb = mix(inner_rgb, mid_rgb, u);
+        a = mix(inner_a, mid_a, u);
+    } else {
+        let denom = max(1.0 - mid_stop, 1e-6);
+        let u = (r - mid_stop) / denom;
+        rgb = mix(mid_rgb, edge_rgb, u);
+        a = mix(mid_a, edge_a, u);
+    }
+    return vec4<f32>(rgb, a);
+}
+
+// straight rgba (0..1) の src を premultiplied u8 アキュムレータ acc へ SourceOver 合成。
+// tiny-skia lowp パイプラインを bit-exact に再現:
+//   1. gradient straight color = (rgb, a) を u8 量子化
+//   2. premultiply: pr = div255(sr_u8 * sa_u8)
+//   3. source_over: out = src_premul + div255(dst_premul * (255 - sa_u8))
+// acc は (premul_r, premul_g, premul_b, a8) を 0..255 float で持つ。
+fn source_over(acc: vec4<f32>, src: vec4<f32>) -> vec4<f32> {
+    let sa8 = to_u8_a(src.a);
+    if (sa8 <= 0.0) {
+        return acc;
+    }
+    let sr8 = to_u8_rgb(src.r);
+    let sg8 = to_u8_rgb(src.g);
+    let sb8 = to_u8_rgb(src.b);
+    let pr = div255(sr8 * sa8);
+    let pg = div255(sg8 * sa8);
+    let pb = div255(sb8 * sa8);
+    let inv_sa = 255.0 - sa8;
+    return vec4<f32>(
+        pr + div255(acc.r * inv_sa),
+        pg + div255(acc.g * inv_sa),
+        pb + div255(acc.b * inv_sa),
+        sa8 + div255(acc.a * inv_sa),
+    );
+}
+
+// サブピクセル位置 `px` での 1 サンプルを premultiplied u8 (0..255 float) で合成する。
+// 背景 → 全 orb（各 orb は main → satellites → bloom）まで SourceOver。
+fn composite_premul(px: vec2<f32>) -> vec4<f32> {
+    // 背景塗り Pixmap::fill(Color::from_rgba8(...)) は straight 入力を
+    // premultiply(div255(c_u8 * a_u8)) で格納する。
+    let bg_a8 = to_u8_a(params.bg.a);
+    var acc = vec4<f32>(
+        div255(to_u8_rgb(params.bg.r) * bg_a8),
+        div255(to_u8_rgb(params.bg.g) * bg_a8),
+        div255(to_u8_rgb(params.bg.b) * bg_a8),
+        bg_a8,
+    );
+
+    let count = u32(params.n_orbs + 0.5);
+    for (var i: u32 = 0u; i < count; i = i + 1u) {
+        let o = load_orb(i);
+        let main_radius = o.main.z;
+        if (main_radius <= 0.0) {
+            continue;
+        }
+        let inner_rgb = o.inner.rgb;
+        let halo_rgb = o.halo.rgb;
+
+        // 1+2. main radial: inner=色@255 / mid=halo色@128 @0.55 / edge=halo色@0。
+        let main_col = eval_radial(
+            px, o.main.x, o.main.y, main_radius,
+            inner_rgb, 255.0 / 255.0,
+            halo_rgb, 128.0 / 255.0,
+            halo_rgb, 0.0,
+            0.55,
+        );
+        acc = source_over(acc, main_col);
+
+        // 3. bleed satellites: 0..3 個。各 alpha=(100,50,0)、mid_stop=0.5、色=bleed_col。
+        let sat_count = u32(o.main.w + 0.5);
+        let bleed_rgb = o.bleed_col.rgb;
+        if (sat_count >= 1u) {
+            let s = eval_radial(
+                px, o.sat0.x, o.sat0.y, o.sat0.z,
+                bleed_rgb, 100.0 / 255.0,
+                bleed_rgb, 50.0 / 255.0,
+                bleed_rgb, 0.0,
+                0.5,
+            );
+            acc = source_over(acc, s);
+        }
+        if (sat_count >= 2u) {
+            let s = eval_radial(
+                px, o.sat1.x, o.sat1.y, o.sat1.z,
+                bleed_rgb, 100.0 / 255.0,
+                bleed_rgb, 50.0 / 255.0,
+                bleed_rgb, 0.0,
+                0.5,
+            );
+            acc = source_over(acc, s);
+        }
+        if (sat_count >= 3u) {
+            let s = eval_radial(
+                px, o.sat2.x, o.sat2.y, o.sat2.z,
+                bleed_rgb, 100.0 / 255.0,
+                bleed_rgb, 50.0 / 255.0,
+                bleed_rgb, 0.0,
+                0.5,
+            );
+            acc = source_over(acc, s);
+        }
+
+        // 4. bloom: bloom_flag>0 のとき内側 30% に白寄りコア。
+        //    色=mix_with_white(color,0.7)、alpha=(255,128,0)、mid_stop=0.55。
+        if (o.inner.w > 0.5) {
+            let core_radius = o.bloom_geom.z;
+            if (core_radius > 0.0) {
+                let bloom_rgb = o.bloom_col.rgb;
+                let b = eval_radial(
+                    px, o.bloom_geom.x, o.bloom_geom.y, core_radius,
+                    bloom_rgb, 255.0 / 255.0,
+                    bloom_rgb, 128.0 / 255.0,
+                    bloom_rgb, 0.0,
+                    0.55,
+                );
+                acc = source_over(acc, b);
+            }
+        }
+    }
+
+    return acc / 255.0;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    // @builtin(position) は既に top-left のピクセル座標（中心 +0.5）。
+    // tiny-skia の radial gradient は pixel 中心で point sampling される。
+    let pm = composite_premul(in.pos.xy); // premultiplied 0..1
+    let acc_rgb8 = pm.rgb * 255.0;
+    let acc_a8 = pm.a * 255.0;
+
+    // finalize_pixmap 相当: premultiplied u8 → straight に戻す。
+    if (acc_a8 <= 0.0) {
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    }
+    if (acc_a8 >= 255.0) {
+        return vec4<f32>(pm.rgb, 1.0);
+    }
+    let inv = 255.0 / acc_a8;
+    let straight = floor(acc_rgb8 * inv + 0.5) / 255.0;
+    return vec4<f32>(clamp(straight, vec3<f32>(0.0), vec3<f32>(1.0)), acc_a8 / 255.0);
+}


### PR DESCRIPTION
## 関連 Issue
closes #216
Refs #207（wgpu 一重化 Phase 1 スライス 3/4 = 最後の shape）

## 概要
aquarelle shape を WGSL に移植し、**全 shape が WGSL レンダラ1本に乗った**。これで Phase 1.5（tiny-skia 撲滅）へ進める。CPU の `aquarelle::render_aquarelle_orb`（外部 crate aquarelle 0.2.0、per-orb・seed=orb index で ChaCha8 決定論）の4層を GPU で描画する。

## 方針（kako-jun 確定: Option A = 全4層を構造再現）
- **offset / main 3-stop radial+halo / 0..3 bleed satellites / bloom** の4層を SourceOver 合成（描画順 main→satellites→bloom）。
- **ChaCha8 はシェーダに持ち込まない**。`pack_aquarelle_orbs`（gpu.rs）が `seed=orb index` で crate と完全同順に RNG を消費し、satellite 位置・offset 角・各層の boost/mix 済み色（HSL の `boost_saturation` / `mix_with_white` を palette で再現）を CPU で算出して **専用 Rgba32Float data-texture（9 texel/orb）** に積む。WGSL は解析 radial を最大5回評価するだけ。
- 残差は **tiny-skia の AA と解析 radial の差のみ** = 構造完全一致・AA だけ緩い許容。

## 変更
- `crates/core/src/orb_aquarelle.wgsl`（新規）— 4層を解析 radial で評価、`orb_circle.wgsl` と同一の u8 量子化→premultiply→div255 source_over 流儀、`draw_radial` の半径×1.5 cutoff / mid_stop clamp / SpreadMode::Pad に忠実。
- `crates/core/src/gpu.rs` — `pack_aquarelle_orbs` / 専用 pipeline・data-texture / `render_aquarelle_packed`（`render_guard` 内で直列化）/ 公開エントリ `render_frame_aquarelle`。aquarelle 専用 texture は Circle/Glyph 用（別 texture/binding）と分離し **Circle bit-exact を物理的に保護**。
- `crates/core/src/animate.rs` — aquarelle 変調を `modulate_aquarelle_clusters` に集約し CPU/GPU 共有シーム化（ドリフトを構造的に排除）。
- `crates/cli/src/main.rs` — `--shape aquarelle` を GPU 経路へルーティング。
- テスト — RNG 再現の決定論（satellite 位置の crate 一致）・offset 方向・bleed round 境界・bloom 微小正値境界・zero-weight skip・clamp・saturation 連動・count 無視・edge cutoff・透過背景 premul・param コーナー parity（新規11件）。
- docs(gpu) — モジュールヘッダの shape scope を現状（Glyph/Aquarelle も GPU 化済み・image は web 専用で glyph SDF 経路）に更新。

## 検証
- `ORBER_REQUIRE_GPU=1 cargo test -p orber-core --features gpu` → **212 passed / 0 failed**（SKIP 0、Metal 実走）。`circle_bitexact_after_4texel_widening` ✅・`aquarelle_gpu_structural_parity_with_cpu`（mean_abs=0.000 / overlap=100%）✅・既定マルチスレッド10回連続緑（並行安全）。
- clippy `-D warnings` / `cargo fmt --check` clean。
- **CLI 実機目視**: `--features gpu` で `using gpu renderer (adapter: Apple A18 Pro)` を確認し、aquarelle GPU vs CPU = **0 AE**（fuzz 1%）、Circle GPU vs CPU = **0 AE**（bit-exact 維持）、bleed/bloom/halo/offset の連動も確認。

## 非対象（umbrella #207 で継続）
image 入力の CLI 対応（#217）、aquarelle→Web 公開（Phase 2）、tiny-skia 撲滅（Phase 1.5）。
