### PR TITLE
test(wasm): flaky な BorrowMutError を解消（source_cache を触る2テストを直列化）

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -782,6 +782,12 @@ pub fn generate_svg(params_js: JsValue) -> Result<String, JsError> {
 mod tests {
     use super::*;
 
+    /// `source_cache()` のグローバル `RefCell` を触るテストを直列化するためのガード。
+    /// native の `cargo test` は既定でテストを並列実行するため、複数テストが同時に
+    /// `get_or_build_clusters()` → `borrow_mut()` すると `BorrowMutError` になる
+    /// (#220)。production(wasm) は single-thread なのでこの直列化はテスト専用。
+    static CACHE_TEST_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn parse_direction_roundtrip() {
         assert!(matches!(
@@ -1121,6 +1127,7 @@ mod tests {
 
     #[test]
     fn pack_render_data_matches_core_pack_helper() {
+        let _guard = CACHE_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         let mut p = base_params();
         p.k = 2;
         p.source_width = 2;
@@ -1180,6 +1187,7 @@ mod tests {
     /// 入っていることを担保する。
     #[test]
     fn pack_render_data_header_includes_edge_softness() {
+        let _guard = CACHE_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         let mut p = base_params();
         p.k = 2;
         p.source_width = 2;


### PR DESCRIPTION
## 関連 Issue
closes #220

## 背景
`cargo test`（CI の `ci.yml:41` `cargo test --verbose` 含む）が約6〜17%の確率で断続的に失敗していた。main (d6e046c) でも再現（16回中1回）。native の既定マルチスレッド並列実行でのみ発生する **既存の flaky test**。

```
test tests::pack_render_data_header_includes_edge_softness ... FAILED
panicked at crates/wasm/src/lib.rs:263:16: already borrowed: BorrowMutError
```

## 原因
`source_cache()`（グローバル static の `RefCell`）を `get_or_build_clusters()` が `borrow_mut()` する。これを呼ぶテストは `pack_render_data_matches_core_pack_helper` と `pack_render_data_header_includes_edge_softness` の2つ。並列実行で同時に呼ぶと borrow が衝突して panic する。`WasmSingleThreadCell` の single-thread 前提は production(wasm) でのみ真で、native の並列テストランナーでは崩れる。**production の挙動はバグではない**（各 Web Worker は独立 wasm インスタンス）。テスト実行時だけのレース。

## 変更
- `#[cfg(test)] mod tests` に test 専用の `static CACHE_TEST_GUARD: Mutex<()>` を追加。
- グローバル cache を触る2テストの冒頭で `lock()`（poison は `into_inner()` で握り潰し）して直列化。
- **production コードは一切変更なし**（test スコープのみ、+8行）。

## 検証
- `for i in $(seq 1 30); do cargo test -p orber-wasm --lib; done` → **30/30 緑**（修正前は数回赤）。
- `cargo test`（全 workspace）/ `cargo clippy -- -D warnings` / `cargo fmt --check` 全緑。