### PR TITLE
refactor: aquarelle 再エクスポートを撤去し CLI/core を直接依存に

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 name = "orber"
 version = "0.3.0"
 dependencies = [
+ "aquarelle",
  "clap",
  "image",
  "orber-core",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -26,6 +26,7 @@ gpu = ["orber-core/gpu"]
 
 [dependencies]
 orber-core = { path = "../core", version = "0.3.0" }
+aquarelle = { workspace = true }
 clap = { workspace = true }
 image = { workspace = true, default-features = true }
 tempfile = { workspace = true }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,6 @@
+use aquarelle::AquarelleParams;
 use clap::{Parser, ValueEnum};
 use orber_core::animate::{MotionDirection, MotionSpeed};
-use orber_core::aquarelle::AquarelleParams;
 use orber_core::cluster::{derive_background_rgba, drop_dominant, extract_clusters, Cluster};
 use orber_core::glyph::{has_glyph, GlyphFontId};
 use orber_core::orb::{OrbShape, RenderOptions};

--- a/crates/core/src/animate.rs
+++ b/crates/core/src/animate.rs
@@ -1662,7 +1662,7 @@ mod tests {
         // 異なるはず（左上→右下の対角ドリフト）。
         let clusters = drift_static_clusters();
         let mut opts = opts_with(MotionDirection::LeftToRight, MotionSpeed::Slow);
-        opts.shape = OrbShape::Aquarelle(crate::aquarelle::AquarelleParams::default());
+        opts.shape = OrbShape::Aquarelle(aquarelle::AquarelleParams::default());
         opts.keyframe_tracks = Some(drift_keyframe_tracks());
 
         let a = render_frame(&clusters, &opts, 0.0);

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -1236,7 +1236,7 @@ impl GpuRenderer {
         height: f32,
         base_radius_unit: f32,
         saturation: f32,
-        params: crate::aquarelle::AquarelleParams,
+        params: aquarelle::AquarelleParams,
     ) -> Vec<GpuAquaOrb> {
         use std::f32::consts::TAU;
 
@@ -4499,7 +4499,7 @@ mod tests {
 
     // ===== #216: Aquarelle WGSL path — RNG/color parity + structural GPU↔CPU =====
 
-    use crate::aquarelle::AquarelleParams;
+    use aquarelle::AquarelleParams;
 
     fn aquarelle_opts(w: u32, h: u32, params: AquarelleParams) -> AnimateOptions {
         AnimateOptions {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,10 +1,6 @@
 //! orber-core — pure rendering core (wasm-buildable, no I/O, no subprocess).
 
 pub mod animate;
-/// Re-export of the standalone [`aquarelle`](https://crates.io/crates/aquarelle)
-/// crate so existing call sites can keep writing `orber_core::aquarelle::…`
-/// after the v0.4 extraction (closes orber Issue #10).
-pub use aquarelle;
 pub mod batch;
 pub mod cluster;
 pub mod color_track;


### PR DESCRIPTION
## 関連 Issue
closes #193

## 背景
`orber-core/src/lib.rs` が `pub use aquarelle;` で aquarelle crate 全体を public 再エクスポートしており、CLI が `orber_core::aquarelle::AquarelleParams` 経由で間接使用していた。これにより (1) aquarelle が破壊的変更すると orber-core も semver bump を強制される（`pub use` が public surface に乗る）、(2) aquarelle が orber-core の「半身」に見える誤解、があった。

## 変更
- `crates/core/src/lib.rs`: `pub use aquarelle;` とその doc コメントを削除（public 再エクスポート撤去）。
- core 内部の再エクスポート経由参照を直接参照へ（`pub use` 削除で `crate::aquarelle::` が壊れるため必須。aquarelle は core の直接依存なので bare `aquarelle::` で解決）:
  - `crates/core/src/animate.rs`: `crate::aquarelle::AquarelleParams` → `aquarelle::AquarelleParams`
  - `crates/core/src/gpu.rs`（2箇所）: 同上
- `crates/cli/src/main.rs`: `use orber_core::aquarelle::AquarelleParams` → `use aquarelle::AquarelleParams`
- `crates/cli/Cargo.toml`: `aquarelle = { workspace = true }` を直接追加（orber-core 依存はそのまま）
- wasm は `orber_core::aquarelle` を使っていないため無変更。

## テスト
新規テストなし。本変更は純粋な再エクスポート撤去で、正しさはコンパイラが強制する（`AquarelleParams` が aquarelle crate から解決できなければビルドが落ちる）。既存テスト（`aquarelle_params_out_of_range_rejected` / `gpu_route_covers_circle_glyph_and_aquarelle` 等）が aquarelle 経路を引き続きカバー。「import できること」を assert するテストはトートロジーになるため追加しない。

## semver メモ
`pub use aquarelle;` の削除は orber-core の public API 破壊変更。次回 orber-core publish 時に semver へ反映が必要（本 PR ではバージョン bump せず＝publish は別工程）。

## 検証
- `cargo build` / `cargo build --features gpu -p orber` 緑
- `cargo test`（全 workspace）緑
- `cargo clippy -- -D warnings` / `cargo clippy --features gpu -p orber -- -D warnings` 緑
- `cargo fmt --check` 緑