### PR TITLE
ci: wasm32 ビルドと web vitest を CI に追加（#194 / #165）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,3 +167,27 @@ jobs:
 
       - name: Build orber-wasm for wasm32
         run: cargo build --target wasm32-unknown-unknown -p orber-wasm
+
+  web-test:
+    name: Web test
+    # web に導入済みの vitest を CI で走らせる (#165)。strings / glyph SDF /
+    # encoder ロジック等の純粋 TS テストのみで、生成 wasm pkg はロードしない
+    # (worker は test 側で mock される) ため wasm ビルド step は前置しない。
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Run vitest
+        run: npm test
+        working-directory: web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,3 +133,37 @@ jobs:
         # (#210). Keeping the run parallel is deliberate: it lets CI detect any
         # regression of that data race (which `--test-threads=1` would have hidden).
         run: cargo test -p orber-core --features gpu -- --nocapture
+
+  wasm:
+    name: WASM build
+    # wgpu 一重化 (#207) で wasm の健全性が重要になったため、wasm32 ターゲットの
+    # orber-wasm が常時ビルド可能かを CI で検証する (#194)。
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build orber-wasm for wasm32
+        run: cargo build --target wasm32-unknown-unknown -p orber-wasm

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "stamp:sw": "node -e \"const f=require('fs'),p='dist/sw.js',d=new Date(Date.now()+9*36e5).toISOString().slice(0,10);f.writeFileSync(p,f.readFileSync(p,'utf-8').replaceAll('__BUILD_DATE__',d))\"",
     "dev": "npm run wasm:build && astro dev",
     "build": "npm run wasm:build && astro build && npm run stamp:sw",
-    "build:cf": "npm run wasm:ensure-rust && . $HOME/.cargo/env 2>/dev/null; npm run wasm:install && npm run wasm:build && astro build && npm run stamp:sw",
+    "build:cf": "npm run wasm:ensure-rust && . $HOME/.cargo/env 2>/dev/null; npm run wasm:install && npm run wasm:build && npm test && astro build && npm run stamp:sw",
     "preview": "astro preview",
     "deploy": "wrangler pages deploy dist",
     "test": "vitest run",

--- a/web/src/lib/strings.test.ts
+++ b/web/src/lib/strings.test.ts
@@ -142,16 +142,17 @@ describe('lang signal + t()', () => {
     expect('includeAlphaDisabledTitle' in STRINGS).toBe(false);
   });
 
-  test('viewsLabelPrefix / Suffix の語順が言語ごとに切り替わる (Footer counter)', async () => {
-    // ja は「閲覧数: {n}」(prefix のみ)、en は「{n} views」(suffix のみ) の
-    // 非対称構成。Footer の <nostalgic-counter> をこの 2 キーで挟む設計
-    // (#128 / #146) のため、語順切替を直接押さえる。
+  test('viewsLabelPrefix / Suffix は ja/en とも「{n} views」(suffix 統一) (Footer counter)', async () => {
+    // #128 の初期設計は ja「閲覧数: {n}」/ en「{n} views」の非対称構成だったが、
+    // 9e0306b「Counter ラベルを ja/en 両方 views で統一」で suffix の ' views' に
+    // 一本化された。Footer の <nostalgic-counter> をこの 2 キーで挟む設計
+    // (#128 / #146) のため、現行の統一仕様を直接押さえる。
     vi.stubGlobal('navigator', { language: 'en-US' });
     const { setLang, t } = await import('./strings');
     await Promise.resolve();
     setLang('ja');
-    expect(t('viewsLabelPrefix')).toBe('閲覧数: ');
-    expect(t('viewsLabelSuffix')).toBe('');
+    expect(t('viewsLabelPrefix')).toBe('');
+    expect(t('viewsLabelSuffix')).toBe(' views');
     setLang('en');
     expect(t('viewsLabelPrefix')).toBe('');
     expect(t('viewsLabelSuffix')).toBe(' views');

--- a/web/src/lib/strings.ts
+++ b/web/src/lib/strings.ts
@@ -184,8 +184,9 @@ export const STRINGS = {
     ja: '画像はブラウザ内で処理されます。サーバーへの送信はありません。',
     en: 'All processing happens in your browser — no images leave your device.',
   },
-  // #128 / #146: ja は「閲覧数: {n}」、en は「{n} views」で語順を言語ごとに分ける。
-  // {n} は <nostalgic-counter> がレンダリングする数値で置換する。
+  // #128 / #146: <nostalgic-counter> の数値 {n} を prefix/suffix で挟む設計。
+  // 当初は ja「閲覧数: {n}」/ en「{n} views」の非対称だったが、9e0306b で
+  // ja/en とも suffix の ' views' に統一した。
   viewsLabelPrefix: { ja: '', en: '' },
   viewsLabelSuffix: { ja: ' views', en: ' views' },
   // #146 review S2: Footer 全体の aria-label を i18n 化。


### PR DESCRIPTION
## 関連 Issue
closes #194
closes #165

## 変更
### #194: wasm32 ビルドジョブ
`.github/workflows/ci.yml` に `wasm`（"WASM build"）ジョブを追加。`dtolnay/rust-toolchain@stable`（`targets: wasm32-unknown-unknown`）＋ 既存と同じ cargo cache 3段 → `cargo build --target wasm32-unknown-unknown -p orber-wasm`。wgpu 一重化（#207）で wasm の健全性が重要になったため常時検証する。aquarelle 側 wasm CI は対象外（別 Issue）。

### #165: web vitest を CI / build:cf に
- `web/package.json` の `build:cf` に `npm test` を挿入（`wasm:build && npm test && astro build`）→ CF Pages ビルド時に vitest を走らせ、失敗ならデプロイを止める。
- `.github/workflows/ci.yml` に `web-test`（"Web test"）ジョブを追加（setup-node@v4 / npm ci / npm test、working-directory: web）。Rust 系と並列。
- web-test に wasm ビルド step は**前置しない**: テストは純粋 TS のみで生成 wasm pkg をロードしない（worker は test 側で mock）。
- ついでに stale だった `strings.test.ts`（旧 ja「閲覧数:」期待）と `strings.ts` のコメントを、現行の統一仕様（ja/en とも `viewsLabelSuffix: ' views'`、commit 9e0306b）に追従。テストを仕様に合わせた修正（バグ隠蔽ではない）。

## 検証
- `cargo build --target wasm32-unknown-unknown -p orber-wasm` 緑。
- `cd web && npm ci && npm test` → 84/84 緑。
- ci.yml は ruby YAML パーサで構文 OK。既存4ジョブ（Test/Format/Clippy/GPU parity (lavapipe)）は無改変。
- 独立レビュー Approve（must/should/nit ゼロ）。

## 残る手作業（kako-jun）
- 新ジョブ `WASM build` / `Web test` を branch protection の **required status check に登録**するのは GitHub 設定（コード外）。登録するまでは失敗してもマージをブロックしない。
- CF Pages は既定で devDependencies を入れるため `npm test` は通常デプロイで動作。将来 `NODE_ENV=production` 等で devDeps を省く運用にする場合のみ要再考。